### PR TITLE
Feature/native iptv

### DIFF
--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -29,6 +29,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('SHOW_ALERT_DIALOG', { message, title }),
     showSelectDialog: (message, title, options) =>
         ipcRenderer.invoke('SHOW_SELECT_DIALOG', { message, title, options }),
+    iptvFetchText: (url, options) =>
+        ipcRenderer.invoke('IPTV_FETCH_TEXT', { url, options }),
     fetchIntroDbSegments: (imdbId, season, episode) =>
         ipcRenderer.invoke('INTRODB_FETCH_SEGMENTS', { imdbId, season, episode }),
     localLibrary: {

--- a/apps/desktop/electron/services/mainIpc.cjs
+++ b/apps/desktop/electron/services/mainIpc.cjs
@@ -1,3 +1,147 @@
+const dns = require("dns").promises;
+const net = require("net");
+
+const IPTV_MAX_REDIRECTS = 5;
+const IPTV_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const IPTV_BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "ip6-localhost",
+  "ip6-loopback",
+  "loopback",
+  "broadcasthost",
+  "metadata",
+  "metadata.google.internal",
+  "instance-data",
+  "instance-data.ec2.internal",
+]);
+const IPTV_BLOCKED_HOSTNAME_SUFFIXES = [
+  ".localhost",
+  ".metadata.google.internal",
+];
+const iptvBlockedAddressList = new net.BlockList();
+iptvBlockedAddressList.addSubnet("0.0.0.0", 8, "ipv4");
+iptvBlockedAddressList.addSubnet("127.0.0.0", 8, "ipv4");
+iptvBlockedAddressList.addSubnet("169.254.0.0", 16, "ipv4");
+iptvBlockedAddressList.addSubnet("224.0.0.0", 4, "ipv4");
+iptvBlockedAddressList.addSubnet("240.0.0.0", 4, "ipv4");
+iptvBlockedAddressList.addSubnet("::", 96, "ipv6");
+iptvBlockedAddressList.addAddress("::", "ipv6");
+iptvBlockedAddressList.addAddress("::1", "ipv6");
+iptvBlockedAddressList.addSubnet("fe80::", 10, "ipv6");
+iptvBlockedAddressList.addSubnet("ff00::", 8, "ipv6");
+
+function normalizeIptvHostname(hostname) {
+  let normalized = String(hostname || "").trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    normalized = normalized.slice(1, -1);
+  }
+  return normalized.replace(/\.+$/, "");
+}
+
+function isBlockedIptvHostname(hostname) {
+  const normalized = normalizeIptvHostname(hostname);
+  return (
+    IPTV_BLOCKED_HOSTNAMES.has(normalized) ||
+    IPTV_BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+  );
+}
+
+function isBlockedIptvAddress(address) {
+  const normalized = normalizeIptvHostname(address);
+  const version = net.isIP(normalized);
+  if (!version) return true;
+  return iptvBlockedAddressList.check(normalized, version === 4 ? "ipv4" : "ipv6");
+}
+
+function parseIptvFetchUrl(target) {
+  let parsed;
+
+  try {
+    parsed = new URL(target);
+  } catch {
+    throw new Error("Enter a valid IPTV URL");
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http/https IPTV URLs are supported");
+  }
+
+  if (!normalizeIptvHostname(parsed.hostname)) {
+    throw new Error("Enter a valid IPTV URL");
+  }
+
+  return parsed;
+}
+
+async function assertSafeIptvFetchUrl(parsed) {
+  const hostname = normalizeIptvHostname(parsed.hostname);
+
+  if (isBlockedIptvHostname(hostname)) {
+    throw new Error("IPTV URL host is not allowed");
+  }
+
+  if (net.isIP(hostname)) {
+    if (isBlockedIptvAddress(hostname)) {
+      throw new Error("IPTV URL host is not allowed");
+    }
+    return;
+  }
+
+  let addresses;
+  try {
+    addresses = await dns.lookup(hostname, {
+      all: true,
+      verbatim: true,
+    });
+  } catch {
+    throw new Error("IPTV URL host could not be resolved");
+  }
+
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new Error("IPTV URL host could not be resolved");
+  }
+
+  for (const entry of addresses) {
+    if (isBlockedIptvAddress(entry.address)) {
+      throw new Error("IPTV URL host is not allowed");
+    }
+  }
+}
+
+async function getSafeIptvFetchResponse(initialUrl, signal) {
+  let currentUrl = initialUrl;
+
+  for (let redirectCount = 0; redirectCount <= IPTV_MAX_REDIRECTS; redirectCount += 1) {
+    await assertSafeIptvFetchUrl(currentUrl);
+
+    const response = await fetch(currentUrl.toString(), {
+      signal,
+      redirect: "manual",
+    });
+
+    if (!IPTV_REDIRECT_STATUSES.has(response.status)) {
+      return { response, url: currentUrl };
+    }
+
+    if (redirectCount >= IPTV_MAX_REDIRECTS) {
+      await response.body?.cancel?.().catch(() => {});
+      throw new Error("IPTV redirect limit exceeded");
+    }
+
+    const location = response.headers.get("location");
+    await response.body?.cancel?.().catch(() => {});
+
+    if (!location) {
+      throw new Error("IPTV redirect did not include a target");
+    }
+
+    currentUrl = parseIptvFetchUrl(new URL(location, currentUrl).toString());
+  }
+
+  throw new Error("IPTV redirect limit exceeded");
+}
+
 function registerMainIpcHandlers({
   ipcMain,
   dialog,
@@ -104,6 +248,89 @@ function registerMainIpcHandlers({
       status: response.status,
       data: await response.json(),
     };
+  });
+
+  ipcMain.handle("IPTV_FETCH_TEXT", async (_event, payload) => {
+    const target = typeof payload?.url === "string" ? payload.url.trim() : "";
+    const initialUrl = parseIptvFetchUrl(target);
+
+    const timeoutMs = Math.min(
+      Math.max(Number(payload?.options?.timeoutMs) || 30000, 1000),
+      120000,
+    );
+    const maxBytes = Math.min(
+      Math.max(Number(payload?.options?.maxBytes) || 64 * 1024 * 1024, 1024),
+      128 * 1024 * 1024,
+    );
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const { response, url: responseUrl } = await getSafeIptvFetchResponse(
+        initialUrl,
+        controller.signal,
+      );
+      const responseHost = normalizeIptvHostname(responseUrl.hostname);
+
+      if (!response.ok) {
+        logToFile("IPTV fetch failed", {
+          host: responseHost,
+          status: response.status,
+        });
+        throw new Error(`Fetch failed with HTTP ${response.status}`);
+      }
+
+      const reader = response.body?.getReader?.();
+      if (!reader) {
+        const arrayBuffer = await response.arrayBuffer();
+        if (arrayBuffer.byteLength > maxBytes) {
+          throw new Error("IPTV response exceeded maximum size");
+        }
+        logToFile("IPTV fetch completed", {
+          host: responseHost,
+          status: response.status,
+          bytes: arrayBuffer.byteLength,
+        });
+        return {
+          ok: true,
+          status: response.status,
+          text: Buffer.from(arrayBuffer).toString("utf8"),
+        };
+      }
+
+      const chunks = [];
+      let totalBytes = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+          throw new Error("IPTV response exceeded maximum size");
+        }
+        chunks.push(Buffer.from(value));
+      }
+
+      logToFile("IPTV fetch completed", {
+        host: responseHost,
+        status: response.status,
+        bytes: totalBytes,
+      });
+
+      return {
+        ok: true,
+        status: response.status,
+        text: Buffer.concat(chunks, totalBytes).toString("utf8"),
+      };
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new Error("IPTV fetch timed out");
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
   });
 
   ipcMain.handle("OPEN_EXTERNAL_URL", async (_event, targetUrl) => {

--- a/docs/plans/native-iptv-support.md
+++ b/docs/plans/native-iptv-support.md
@@ -1,0 +1,534 @@
+# Native IPTV Support Implementation Plan
+
+> **For Hermes:** Hand this plan to Codex on the Fedora desktop. Use strict TDD for parser/store code, keep Codex changes in `feature/native-iptv`, then Hermes must review diffs and run the verification commands before declaring success.
+
+**Goal:** Add first-class native IPTV support to Raffi desktop: users can add a Dispatcharr/M3U playlist URL plus optional XMLTV EPG URL, browse/search live channels by group, see now/next guide data, and play a channel in Raffi's existing player.
+
+**Architecture:** Add a small IPTV domain under `packages/app/src/lib/iptv/` for parsing, guide matching, source persistence, and fetch orchestration. Add a `live` route/page under `packages/app/src/pages/live/LiveTV.svelte` that uses the domain code and routes selected channels into the existing `Player.svelte` via `videoSrc`. Add a desktop Electron IPC fetch helper so M3U/XMLTV URLs work despite CORS; web builds can fall back to `fetch` and show a clear CORS error if blocked.
+
+**Tech Stack:** Svelte, TypeScript, Bun workspaces, Electron IPC, built-in `bun test` for pure parser/store tests, `svelte-check` via existing scripts.
+
+---
+
+## Current repo facts
+
+- Repo path on Fedora: `/home/mike/src/raffi`
+- Branch for this work: `feature/native-iptv`
+- Baseline check already passed on Fedora:
+  - `bun install --frozen-lockfile`
+  - `bun run check:app` → `0 errors, 0 warnings`
+- Fedora has `bun 1.3.14`, `node v24.16.0`, `codex-cli 0.141.0`.
+- Fedora does **not** currently have `go`; avoid Go/server changes unless absolutely necessary for playback.
+
+## Dispatcharr test endpoints
+
+Use these for live smoke testing. Do not commit downloaded playlist/EPG data. Do not print full M3U contents or stream URLs in logs.
+
+```text
+M3U:   http://192.168.10.3:9191/output/m3u/Live-TV
+XMLTV: http://192.168.10.3:9191/output/epg/Live-TV
+HDHR:  http://192.168.10.3:9191/hdhr/Live-TV/lineup.json
+```
+
+Verified from Fedora:
+
+```text
+/output/m3u/Live-TV  -> HTTP 200, ~144604 bytes, 586 #EXTINF channels
+/output/epg/Live-TV  -> HTTP 200, ~40936152 bytes, ~55508 <programme> entries
+/output/m3u          -> HTTP 200, 605 channels
+/output/epg          -> HTTP 200, ~55850 programmes
+```
+
+Old profile name `Test` is stale: `/output/m3u/Test` returned 404 and `/output/epg/Test` returned an empty response.
+
+Dispatcharr M3U stream URLs are local proxy URLs shaped like:
+
+```text
+http://192.168.10.3:9191/proxy/ts/...
+```
+
+These are MPEG-TS-style live streams, not simple static files. Route them to the existing Raffi player first; only touch lower-level playback if the player cannot handle them.
+
+---
+
+## Acceptance criteria
+
+1. `Live TV` is reachable from the home/search bar UI and via `router.navigate("live")`.
+2. User can add/edit/remove at least one IPTV source with:
+   - source name
+   - M3U URL
+   - optional XMLTV URL
+3. Source config is persisted locally, but raw playlist/EPG bodies are not persisted to `localStorage`.
+4. Refreshing the Dispatcharr `Live-TV` source loads ~586 channels without leaking full URLs to console.
+5. Channel list supports:
+   - group filter
+   - text search
+   - channel logo if present
+   - channel name
+   - now/next programme when XMLTV match exists
+6. XMLTV matching order:
+   - `tvg-id`
+   - `tvg-name`
+   - normalized display name fallback
+7. Clicking a channel opens the existing player with `videoSrc = channel.url` and a live-mode title/metadata.
+8. Player live mode avoids movie/series behaviors: no Trakt progress/scrobble, no next episode, no intro skip, no resume progress writes.
+9. Error states are human-readable: invalid URL, fetch/CORS failure, empty playlist, XMLTV parse failure, no source configured.
+10. Verification commands pass:
+    - `bun test packages/app/src/lib/iptv/*.test.ts`
+    - `bun run check:app`
+    - `bun run check:desktop`
+11. Dispatcharr smoke command succeeds without printing playlist secrets:
+    - fetch M3U and XMLTV through the implemented fetch path if possible, or via a small dev-only smoke script
+    - report counts only: channel count, group count, programme count, now/next match count sample
+
+---
+
+## Task 1: Add IPTV types and M3U parser tests
+
+**Objective:** Define the data model and lock parser behavior before implementation.
+
+**Files:**
+- Create: `packages/app/src/lib/iptv/types.ts`
+- Create: `packages/app/src/lib/iptv/m3u.test.ts`
+- Create: `packages/app/src/lib/iptv/m3u.ts`
+
+**Step 1: Write failing tests first**
+
+Create tests for at least:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { parseM3U } from "./m3u";
+
+describe("parseM3U", () => {
+  test("parses EXTINF attributes and following stream URL", () => {
+    const playlist = `#EXTM3U\n#EXTINF:-1 tvg-id="abc.us" tvg-name="ABC" tvg-logo="http://logo/abc.png" group-title="Local",ABC HD\nhttp://192.168.10.3:9191/proxy/ts/channel-1\n`;
+    const result = parseM3U(playlist, "source-1");
+    expect(result.channels).toHaveLength(1);
+    expect(result.channels[0]).toMatchObject({
+      sourceId: "source-1",
+      tvgId: "abc.us",
+      tvgName: "ABC",
+      logo: "http://logo/abc.png",
+      group: "Local",
+      name: "ABC HD",
+      url: "http://192.168.10.3:9191/proxy/ts/channel-1",
+    });
+  });
+
+  test("keeps provider order and handles missing attributes", () => {
+    const playlist = `#EXTM3U\n#EXTINF:-1,One\nhttp://one\n#EXTINF:-1 group-title="News",Two\nhttp://two\n`;
+    const result = parseM3U(playlist, "source-1");
+    expect(result.channels.map((c) => c.name)).toEqual(["One", "Two"]);
+    expect(result.channels[0].group).toBe("Ungrouped");
+    expect(result.groups.map((g) => g.name)).toEqual(["Ungrouped", "News"]);
+  });
+});
+```
+
+Run and verify RED:
+
+```bash
+bun test packages/app/src/lib/iptv/m3u.test.ts
+```
+
+Expected before implementation: fail because `parseM3U` does not exist.
+
+**Step 2: Implement minimal parser**
+
+Suggested types:
+
+```ts
+export type IptvSourceKind = "m3u";
+
+export interface IptvSource {
+  id: string;
+  name: string;
+  kind: IptvSourceKind;
+  m3uUrl: string;
+  epgUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IptvChannel {
+  id: string;
+  sourceId: string;
+  name: string;
+  url: string;
+  group: string;
+  tvgId?: string;
+  tvgName?: string;
+  logo?: string;
+  number?: string;
+  order: number;
+}
+
+export interface IptvGroup {
+  id: string;
+  sourceId: string;
+  name: string;
+  channelCount: number;
+  order: number;
+}
+```
+
+Implementation notes:
+- Parse `#EXTINF` attributes with a quote-aware regex: `/([\w-]+)="([^"]*)"/g`.
+- Channel display name is the text after the comma; fallback to `tvg-name`, then URL.
+- Default group: `Ungrouped`.
+- Stable channel id can be `${sourceId}:${order}:${normalizedName}` for now.
+- Skip entries with missing URL.
+
+**Step 3: Verify GREEN**
+
+```bash
+bun test packages/app/src/lib/iptv/m3u.test.ts
+```
+
+---
+
+## Task 2: Add XMLTV parser and guide matcher with tests
+
+**Objective:** Parse enough XMLTV to show now/next for large Dispatcharr EPG data without building a full guide grid yet.
+
+**Files:**
+- Create: `packages/app/src/lib/iptv/xmltv.test.ts`
+- Create: `packages/app/src/lib/iptv/xmltv.ts`
+
+**Step 1: Write failing tests**
+
+Test small XMLTV with two channels and multiple programmes. Include timezone-style XMLTV times like `20260622090000 -0400`.
+
+Required exported functions:
+
+```ts
+parseXmltv(xml: string): XmltvGuide
+getNowNext(channel: IptvChannel, guide: XmltvGuide, at?: Date): { now: XmltvProgramme | null; next: XmltvProgramme | null }
+```
+
+Test matching by:
+- exact `tvg-id` to XMLTV `channel id`
+- `tvg-name` to channel display-name fallback
+- normalized channel name fallback
+
+**Step 2: Implement minimal XMLTV support**
+
+Suggested types:
+
+```ts
+export interface XmltvProgramme {
+  channelId: string;
+  start: Date;
+  stop: Date;
+  title: string;
+  subTitle?: string;
+  description?: string;
+}
+
+export interface XmltvChannel {
+  id: string;
+  displayNames: string[];
+}
+
+export interface XmltvGuide {
+  channels: Map<string, XmltvChannel>;
+  programmesByChannel: Map<string, XmltvProgramme[]>;
+  displayNameToChannelId: Map<string, string>;
+}
+```
+
+Implementation notes:
+- For testability, pure functions only.
+- DOMParser is available in browser but not Bun. For tests, prefer a lightweight parser based on regex helpers or add a local `parseXmltvTime` plus extraction functions that work in Bun.
+- Decode common XML entities for titles/descriptions.
+- Sort programmes by start time per channel.
+- Keep MVP to current/next; do not build grid UI yet.
+
+**Step 3: Verify GREEN**
+
+```bash
+bun test packages/app/src/lib/iptv/xmltv.test.ts
+```
+
+---
+
+## Task 3: Add IPTV source store and fetch abstraction
+
+**Objective:** Persist source config and fetch M3U/XMLTV text through a CORS-safe desktop path.
+
+**Files:**
+- Create: `packages/app/src/lib/iptv/store.ts`
+- Create: `packages/app/src/lib/iptv/fetch.ts`
+- Modify: `apps/desktop/electron/preload.cjs`
+- Modify: `apps/desktop/electron/services/mainIpc.cjs`
+- Optionally modify: `packages/app/src/lib/platform.ts` types if needed.
+
+**Store requirements:**
+- localStorage key: `raffi_iptv_sources_v1`
+- exported Svelte store: `iptvSources`
+- helpers: `addIptvSource`, `updateIptvSource`, `removeIptvSource`, `getStoredIptvSources`
+- validate URL scheme: only `http:`/`https:` for URL sources
+- do not store fetched M3U/XMLTV bodies
+
+**Fetch requirements:**
+- In desktop, use `window.electronAPI.iptvFetchText(url, { timeoutMs, maxBytes })`.
+- In web fallback, use `fetch(url)` and surface a message if CORS blocks it.
+- Max bytes default: at least 64 MiB because Dispatcharr XMLTV is ~41 MiB.
+- Timeout default: 60 seconds for XMLTV, 20 seconds for M3U.
+- Never log response bodies.
+
+**Electron IPC sketch:**
+
+`preload.cjs`:
+
+```js
+iptvFetchText: (url, options) => ipcRenderer.invoke('IPTV_FETCH_TEXT', { url, options }),
+```
+
+`mainIpc.cjs` handler:
+
+```js
+ipcMain.handle("IPTV_FETCH_TEXT", async (_event, payload) => {
+  const target = String(payload?.url || "").trim();
+  const parsed = new URL(target);
+  if (!["http:", "https:"].includes(parsed.protocol)) throw new Error("Only http/https IPTV URLs are supported");
+  const timeoutMs = Math.min(Math.max(Number(payload?.options?.timeoutMs) || 30000, 1000), 120000);
+  const maxBytes = Math.min(Math.max(Number(payload?.options?.maxBytes) || 64 * 1024 * 1024, 1024), 128 * 1024 * 1024);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(target, { signal: controller.signal, redirect: "follow" });
+    if (!res.ok) throw new Error(`Fetch failed with HTTP ${res.status}`);
+    const arrayBuffer = await res.arrayBuffer();
+    if (arrayBuffer.byteLength > maxBytes) throw new Error("IPTV response exceeded maximum size");
+    return { ok: true, status: res.status, text: Buffer.from(arrayBuffer).toString("utf8") };
+  } finally {
+    clearTimeout(timer);
+  }
+});
+```
+
+Use `logToFile` only for metadata (`host`, `status`, byte count), never full URL query secrets or bodies.
+
+---
+
+## Task 4: Build refresh orchestration
+
+**Objective:** Given a source, fetch/parse M3U and optional XMLTV into page state.
+
+**Files:**
+- Create: `packages/app/src/lib/iptv/refresh.ts`
+- Create: `packages/app/src/lib/iptv/refresh.test.ts`
+
+**Behavior:**
+
+```ts
+refreshIptvSource(source: IptvSource): Promise<IptvRefreshResult>
+```
+
+Returns:
+- `channels`
+- `groups`
+- optional `guide`
+- `loadedAt`
+- `stats` with channel count, group count, programme count
+- friendly error messages
+
+Test by injecting fake fetchers so pure tests do not hit Dispatcharr.
+
+---
+
+## Task 5: Add Live TV route and UI shell
+
+**Objective:** Make a first-class Live TV page that can show source setup and loaded channel data.
+
+**Files:**
+- Modify: `packages/app/src/lib/stores/router.ts`
+- Modify: `packages/app/src/App.svelte`
+- Create: `packages/app/src/pages/live/LiveTV.svelte`
+- Create optional components under `packages/app/src/pages/live/components/`:
+  - `IptvSourceForm.svelte`
+  - `LiveChannelList.svelte`
+  - `LiveGroupFilter.svelte`
+  - `LiveProgramBadge.svelte`
+
+**Route changes:**
+
+```ts
+export type Route = "home" | "meta" | "player" | "lists" | "live";
+```
+
+`App.svelte` imports and maps `live: LiveTV`.
+
+**UI behavior:**
+- If no sources: show setup form.
+- If sources exist: show source selector, Refresh button, group filter, search input, channel list.
+- Add a `Use Dispatcharr example` helper only in development or as a subtle button that fills fields; do not hardcode it as the only source.
+- Display counts and refresh time.
+- Show errors inline.
+
+Default Dispatcharr helper values for this user's testing:
+
+```text
+name: Dispatcharr Live-TV
+m3uUrl: http://192.168.10.3:9191/output/m3u/Live-TV
+epgUrl: http://192.168.10.3:9191/output/epg/Live-TV
+```
+
+---
+
+## Task 6: Add navigation entry from home search bar
+
+**Objective:** User can open Live TV from the existing top-right button cluster.
+
+**Files:**
+- Modify: `packages/app/src/components/home/SearchBar.svelte`
+
+**Implementation:**
+- Import a suitable icon from `@lucide/svelte`, e.g. `Tv`.
+- Add `openLiveTv()`:
+
+```ts
+function openLiveTv() {
+  trackEvent("live_tv_opened", { source: "search_bar" });
+  router.navigate("live");
+}
+```
+
+- Add button near Lists:
+
+```svelte
+<button ... aria-label="live tv" onclick={openLiveTv}>
+  <Tv size={40} strokeWidth={2} color="#C3C3C3" />
+</button>
+```
+
+---
+
+## Task 7: Route channel playback into existing Player live mode
+
+**Objective:** Clicking a live channel starts playback without movie/series side effects.
+
+**Files:**
+- Modify: `packages/app/src/pages/live/LiveTV.svelte`
+- Modify: `packages/app/src/pages/player/Player.svelte`
+- Modify: `packages/app/src/pages/player/types.ts` if needed
+- Modify: `packages/app/src/pages/player/playerAnalytics.ts` if needed
+
+**Navigation from Live TV:**
+
+```ts
+router.navigate("player", {
+  videoSrc: channel.url,
+  startTime: 0,
+  metaData: null,
+  fileIdx: null,
+  season: null,
+  episode: null,
+  liveMode: true,
+  liveChannel: {
+    name: channel.name,
+    group: channel.group,
+    logo: channel.logo,
+    tvgId: channel.tvgId,
+    programmeTitle: nowNext.now?.title ?? null,
+  },
+});
+```
+
+**Player requirements:**
+- Add exported prop `liveMode = false` and optional `liveChannel`.
+- If `liveMode`, do not call progress persistence/scrobble paths.
+- If `liveMode`, suppress skip intro and next episode affordances.
+- Loading/error UI should identify the live channel name if available.
+- Do not break existing file/movie/series playback.
+
+---
+
+## Task 8: Add Dispatcharr smoke script or command
+
+**Objective:** Prove real user M3U/XMLTV can be parsed without committing private data.
+
+**Files:**
+- Create: `scripts/smoke-iptv-dispatcharr.mjs` or document command in `docs/plans/native-iptv-support.md`.
+
+**Command behavior:**
+- Fetch M3U URL and XMLTV URL from env vars:
+
+```bash
+IPTV_M3U_URL="http://192.168.10.3:9191/output/m3u/Live-TV" \
+IPTV_EPG_URL="http://192.168.10.3:9191/output/epg/Live-TV" \
+bun scripts/smoke-iptv-dispatcharr.mjs
+```
+
+- Import parser functions from built TS if easy; otherwise keep smoke logic minimal and only verify counts.
+- Output only counts, e.g.:
+
+```json
+{
+  "m3uStatus": 200,
+  "channelCount": 586,
+  "groupCount": 42,
+  "epgStatus": 200,
+  "programmeCount": 55508,
+  "nowNextMatchesInFirst50": 37
+}
+```
+
+Never print stream URLs or raw playlist lines.
+
+---
+
+## Task 9: Verification
+
+Run in this order from `/home/mike/src/raffi`:
+
+```bash
+bun test packages/app/src/lib/iptv/*.test.ts
+bun run check:app
+bun run check:desktop
+IPTV_M3U_URL="http://192.168.10.3:9191/output/m3u/Live-TV" \
+IPTV_EPG_URL="http://192.168.10.3:9191/output/epg/Live-TV" \
+bun scripts/smoke-iptv-dispatcharr.mjs
+```
+
+If `check:desktop` fails only because of pre-existing desktop issues, capture exact output and rerun `bun run check:app`; do not claim desktop verification passed.
+
+Optional manual run after automated checks:
+
+```bash
+bun run dev:desktop
+```
+
+Manual test steps:
+1. Open Live TV from the new TV button.
+2. Add source `Dispatcharr Live-TV` with the M3U/XMLTV URLs above.
+3. Refresh.
+4. Confirm channel count is around 586.
+5. Search for a known common channel.
+6. Click a channel.
+7. Confirm player opens and attempts playback.
+8. Confirm no raw playlist/EPG data is printed to console/logs.
+
+---
+
+## Commit guidance
+
+Make small commits if practical:
+
+```bash
+git add packages/app/src/lib/iptv
+ git commit -m "test: add IPTV parser coverage"
+
+git add packages/app/src/lib/iptv apps/desktop/electron
+ git commit -m "feat: add IPTV source fetch and parsing"
+
+git add packages/app/src/pages/live packages/app/src/lib/stores/router.ts packages/app/src/App.svelte packages/app/src/components/home/SearchBar.svelte packages/app/src/pages/player
+ git commit -m "feat: add native live TV page"
+
+git add scripts/smoke-iptv-dispatcharr.mjs docs/plans/native-iptv-support.md
+ git commit -m "test: add Dispatcharr IPTV smoke check"
+```
+
+Codex may combine commits if needed, but final tree must be clean except intended changes.

--- a/packages/app/src/App.svelte
+++ b/packages/app/src/App.svelte
@@ -2,6 +2,7 @@
     import Meta from "./pages/meta/Meta.svelte";
     import Home from "./pages/Home.svelte";
     import Player from "./pages/player/Player.svelte";
+    import LiveTV from "./pages/live/LiveTV.svelte";
     import { router } from "./lib/stores/router";
     import { onMount, tick } from "svelte";
     import { get } from "svelte/store";
@@ -28,6 +29,7 @@
         meta: Meta,
         player: Player,
         lists: Lists,
+        live: LiveTV,
     };
 
     type DecoderStatus = {

--- a/packages/app/src/components/home/SearchBar.svelte
+++ b/packages/app/src/components/home/SearchBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { Search, Link, Blocks, Library, Settings } from "@lucide/svelte";
+    import { Search, Link, Blocks, Library, Settings, Tv } from "@lucide/svelte";
     import {
         searchAddonTitlesSplit,
         searchTitlesSplit,
@@ -323,6 +323,11 @@
 	function openLists() {
 		trackEvent("lists_opened", { source: "search_bar" });
 		router.navigate("lists");
+	}
+
+	function openLiveTv() {
+		trackEvent("live_tv_opened", { source: "search_bar" });
+		router.navigate("live");
 	}
 
 	function openSettings() {
@@ -723,6 +728,14 @@
             onclick={openAddons}
         >
             <Blocks size={40} strokeWidth={2} color="#C3C3C3" />
+        </button>
+
+        <button
+            class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
+            aria-label="live tv"
+            onclick={openLiveTv}
+        >
+            <Tv size={40} strokeWidth={2} color="#C3C3C3" />
         </button>
 
         <button

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    clearStoredIptvRefreshResult,
+    getStoredIptvRefreshResult,
+    persistIptvRefreshResult,
+} from "./cache";
+import type { IptvRefreshResult, IptvSource } from "./types";
+
+class MemoryStorage {
+    private values = new Map<string, string>();
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    clear() {
+        this.values.clear();
+    }
+}
+
+const source: IptvSource = {
+    id: "source-1",
+    kind: "m3u",
+    name: "Dispatcharr",
+    m3uUrl: "https://dispatcharr.example.test/output/m3u",
+    epgUrl: "https://dispatcharr.example.test/output/epg",
+    createdAt: "2026-06-22T10:00:00.000Z",
+    updatedAt: "2026-06-22T10:00:00.000Z",
+};
+
+const result: IptvRefreshResult = {
+    loadedAt: "2026-06-22T14:00:00.000Z",
+    channels: [
+        {
+            id: "source-1:0:abc",
+            sourceId: "source-1",
+            name: "ABC",
+            url: "https://dispatcharr.example.test/proxy/ts/stream/abc",
+            group: "News",
+            tvgId: "abc.us",
+            tvgName: "ABC",
+            logo: "https://dispatcharr.example.test/logo/abc.png",
+            order: 0,
+        },
+    ],
+    groups: [
+        {
+            id: "source-1:group:news",
+            sourceId: "source-1",
+            name: "News",
+            channelCount: 1,
+            order: 0,
+        },
+    ],
+    guide: {
+        channels: new Map(),
+        programmesByChannel: new Map(),
+        displayNameToChannelId: new Map(),
+    },
+    stats: {
+        channelCount: 1,
+        groupCount: 1,
+        programmeCount: 42,
+    },
+};
+
+describe("IPTV refresh result cache", () => {
+    let storage: MemoryStorage;
+
+    beforeEach(() => {
+        storage = new MemoryStorage();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: storage,
+            configurable: true,
+        });
+    });
+
+    test("hydrates cached channels and groups for the same source without persisting guide maps", () => {
+        persistIptvRefreshResult(source, result);
+
+        const cached = getStoredIptvRefreshResult(source);
+
+        expect(cached?.channels.map((channel) => channel.name)).toEqual(["ABC"]);
+        expect(cached?.groups.map((group) => group.name)).toEqual(["News"]);
+        expect(cached?.loadedAt).toBe(result.loadedAt);
+        expect(cached?.stats).toEqual({
+            channelCount: 1,
+            groupCount: 1,
+            programmeCount: 42,
+        });
+        expect(cached?.guide).toBeUndefined();
+        expect(JSON.stringify(storage)).not.toContain("programmesByChannel");
+    });
+
+    test("ignores cached channels after the source URL changes", () => {
+        persistIptvRefreshResult(source, result);
+
+        expect(
+            getStoredIptvRefreshResult({
+                ...source,
+                m3uUrl: "https://dispatcharr.example.test/output/m3u/clean",
+            }),
+        ).toBeNull();
+    });
+
+    test("can clear cached channels for removed sources", () => {
+        persistIptvRefreshResult(source, result);
+        clearStoredIptvRefreshResult(source.id);
+
+        expect(getStoredIptvRefreshResult(source)).toBeNull();
+    });
+});

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -1,0 +1,219 @@
+import type {
+    IptvChannel,
+    IptvGroup,
+    IptvRefreshResult,
+    IptvRefreshStats,
+    IptvSource,
+} from "./types";
+
+const IPTV_REFRESH_CACHE_KEY_PREFIX = "raffi_iptv_refresh_result_v1";
+const CACHE_VERSION = 1;
+
+type StoredIptvRefreshResult = {
+    version: typeof CACHE_VERSION;
+    sourceId: string;
+    m3uUrl: string;
+    epgUrl: string | null;
+    channels: IptvChannel[];
+    groups: IptvGroup[];
+    loadedAt: string;
+    stats: IptvRefreshStats;
+};
+
+function getStorage(): Storage | null {
+    try {
+        return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch {
+        return null;
+    }
+}
+
+function cacheKeyForSourceId(sourceId: string): string {
+    return `${IPTV_REFRESH_CACHE_KEY_PREFIX}:${sourceId}`;
+}
+
+function normalizeOptionalUrl(url: string | undefined): string | null {
+    const trimmed = String(url ?? "").trim();
+    return trimmed || null;
+}
+
+function getSourceUrls(source: IptvSource) {
+    return {
+        m3uUrl: source.m3uUrl.trim(),
+        epgUrl: normalizeOptionalUrl(source.epgUrl),
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+    return typeof value === "string" && value ? value : undefined;
+}
+
+function sanitizeChannel(value: unknown): IptvChannel | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.id !== "string" ||
+        typeof value.sourceId !== "string" ||
+        typeof value.name !== "string" ||
+        typeof value.url !== "string" ||
+        typeof value.group !== "string" ||
+        typeof value.order !== "number" ||
+        !Number.isFinite(value.order)
+    ) {
+        return null;
+    }
+
+    return {
+        id: value.id,
+        sourceId: value.sourceId,
+        name: value.name,
+        url: value.url,
+        group: value.group,
+        tvgId: optionalString(value.tvgId),
+        tvgName: optionalString(value.tvgName),
+        logo: optionalString(value.logo),
+        number: optionalString(value.number),
+        order: value.order,
+    };
+}
+
+function sanitizeGroup(value: unknown): IptvGroup | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.id !== "string" ||
+        typeof value.sourceId !== "string" ||
+        typeof value.name !== "string" ||
+        typeof value.channelCount !== "number" ||
+        typeof value.order !== "number" ||
+        !Number.isFinite(value.channelCount) ||
+        !Number.isFinite(value.order)
+    ) {
+        return null;
+    }
+
+    return {
+        id: value.id,
+        sourceId: value.sourceId,
+        name: value.name,
+        channelCount: value.channelCount,
+        order: value.order,
+    };
+}
+
+function sanitizeStats(value: unknown): IptvRefreshStats | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.channelCount !== "number" ||
+        typeof value.groupCount !== "number" ||
+        typeof value.programmeCount !== "number" ||
+        !Number.isFinite(value.channelCount) ||
+        !Number.isFinite(value.groupCount) ||
+        !Number.isFinite(value.programmeCount)
+    ) {
+        return null;
+    }
+
+    return {
+        channelCount: value.channelCount,
+        groupCount: value.groupCount,
+        programmeCount: value.programmeCount,
+    };
+}
+
+function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
+    if (!isRecord(value)) return null;
+    if (
+        value.version !== CACHE_VERSION ||
+        typeof value.sourceId !== "string" ||
+        typeof value.m3uUrl !== "string" ||
+        (value.epgUrl !== null && typeof value.epgUrl !== "string") ||
+        typeof value.loadedAt !== "string" ||
+        !Array.isArray(value.channels) ||
+        !Array.isArray(value.groups)
+    ) {
+        return null;
+    }
+
+    const channels = value.channels.map(sanitizeChannel);
+    const groups = value.groups.map(sanitizeGroup);
+    const stats = sanitizeStats(value.stats);
+    if (!stats || channels.some((channel) => !channel) || groups.some((group) => !group)) {
+        return null;
+    }
+
+    return {
+        version: CACHE_VERSION,
+        sourceId: value.sourceId,
+        m3uUrl: value.m3uUrl,
+        epgUrl: value.epgUrl,
+        channels: channels as IptvChannel[],
+        groups: groups as IptvGroup[],
+        loadedAt: value.loadedAt,
+        stats,
+    };
+}
+
+function storedResultMatchesSource(source: IptvSource, stored: StoredIptvRefreshResult): boolean {
+    const urls = getSourceUrls(source);
+    return (
+        stored.sourceId === source.id &&
+        stored.m3uUrl === urls.m3uUrl &&
+        stored.epgUrl === urls.epgUrl
+    );
+}
+
+export function persistIptvRefreshResult(source: IptvSource, result: IptvRefreshResult): void {
+    const storage = getStorage();
+    if (!storage) return;
+
+    const urls = getSourceUrls(source);
+    const stored: StoredIptvRefreshResult = {
+        version: CACHE_VERSION,
+        sourceId: source.id,
+        m3uUrl: urls.m3uUrl,
+        epgUrl: urls.epgUrl,
+        channels: result.channels,
+        groups: result.groups,
+        loadedAt: result.loadedAt,
+        stats: result.stats,
+    };
+
+    try {
+        storage.setItem(cacheKeyForSourceId(source.id), JSON.stringify(stored));
+    } catch {
+        // Best-effort cache writes should not block Live TV refreshes.
+    }
+}
+
+export function getStoredIptvRefreshResult(source: IptvSource): IptvRefreshResult | null {
+    const storage = getStorage();
+    if (!storage) return null;
+
+    try {
+        const raw = storage.getItem(cacheKeyForSourceId(source.id));
+        if (!raw) return null;
+
+        const stored = sanitizeStoredResult(JSON.parse(raw));
+        if (!stored || !storedResultMatchesSource(source, stored)) {
+            return null;
+        }
+
+        return {
+            channels: stored.channels,
+            groups: stored.groups,
+            loadedAt: stored.loadedAt,
+            stats: stored.stats,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function clearStoredIptvRefreshResult(sourceId: string): void {
+    const storage = getStorage();
+    if (!storage) return;
+    storage.removeItem(cacheKeyForSourceId(sourceId));
+}

--- a/packages/app/src/lib/iptv/fetch.ts
+++ b/packages/app/src/lib/iptv/fetch.ts
@@ -1,0 +1,89 @@
+export type IptvFetchOptions = {
+    timeoutMs?: number;
+    maxBytes?: number;
+};
+
+export type IptvFetchText = (url: string, options?: IptvFetchOptions) => Promise<string>;
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+
+export function validateIptvUrl(url: string): string {
+    const trimmed = String(url ?? "").trim();
+    if (!trimmed) {
+        throw new Error("Enter an IPTV URL");
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(trimmed);
+    } catch {
+        throw new Error("Enter a valid IPTV URL");
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error("Only http and https IPTV URLs are supported");
+    }
+
+    return parsed.toString();
+}
+
+async function fetchTextWithBrowser(url: string, options: IptvFetchOptions): Promise<string> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            signal: controller.signal,
+            redirect: "follow",
+        });
+
+        if (!response.ok) {
+            throw new Error(`Fetch failed with HTTP ${response.status}`);
+        }
+
+        const contentLength = Number(response.headers.get("content-length"));
+        if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+            throw new Error("IPTV response exceeded maximum size");
+        }
+
+        const text = await response.text();
+        if (new TextEncoder().encode(text).byteLength > maxBytes) {
+            throw new Error("IPTV response exceeded maximum size");
+        }
+        return text;
+    } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+            throw new Error("IPTV fetch timed out");
+        }
+        if (error instanceof TypeError) {
+            throw new Error(
+                "IPTV fetch failed. If this is the web app, the provider may be blocking browser CORS requests.",
+            );
+        }
+        throw error;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+export const iptvFetchText: IptvFetchText = async (url, options = {}) => {
+    const target = validateIptvUrl(url);
+    const requestOptions = {
+        timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
+    };
+    const electronApi = typeof window !== "undefined" ? (window as any).electronAPI : null;
+
+    if (electronApi?.iptvFetchText) {
+        const result = await electronApi.iptvFetchText(target, requestOptions);
+        if (result?.ok && typeof result.text === "string") {
+            return result.text;
+        }
+        throw new Error(result?.error || "IPTV fetch failed");
+    }
+
+    return fetchTextWithBrowser(target, requestOptions);
+};

--- a/packages/app/src/lib/iptv/guideGrid.test.ts
+++ b/packages/app/src/lib/iptv/guideGrid.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { buildGuideRows, getNowLinePercent } from "./guideGrid";
+import { parseXmltv } from "./xmltv";
+import type { IptvChannel } from "./types";
+
+const channel = (overrides: Partial<IptvChannel>): IptvChannel => ({
+    id: "source-1:0:test",
+    sourceId: "source-1",
+    name: "Test Channel",
+    url: "stream-one",
+    group: "News",
+    order: 0,
+    ...overrides,
+});
+
+describe("guide grid layout", () => {
+    const viewportStart = new Date("2026-06-22T23:00:00.000Z");
+    const viewportEnd = new Date("2026-06-23T00:00:00.000Z");
+    const now = new Date("2026-06-22T23:15:00.000Z");
+
+    test("positions current and future programmes against a shared time viewport", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="abc.us"><display-name>ABC News</display-name></channel>
+  <programme channel="abc.us" start="20260622190000 -0400" stop="20260622193000 -0400"><title>ABCNL Prime</title></programme>
+  <programme channel="abc.us" start="20260622193000 -0400" stop="20260622200000 -0400"><title>All Good</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ tvgId: "abc.us", name: "ABC News" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.channel.name).toBe("ABC News");
+        expect(row.programmes.map((programme) => programme.title)).toEqual([
+            "ABCNL Prime",
+            "All Good",
+        ]);
+        expect(row.programmes[0]).toMatchObject({
+            leftPercent: 0,
+            widthPercent: 50,
+            state: "current",
+            timeRange: "7:00 PM-7:30 PM",
+        });
+        expect(row.programmes[1]).toMatchObject({
+            leftPercent: 50,
+            widthPercent: 50,
+            state: "future",
+            timeRange: "7:30 PM-8:00 PM",
+        });
+        expect(getNowLinePercent({ viewportStart, viewportEnd, now })).toBe(25);
+    });
+
+    test("clips long currently-airing programmes to the visible viewport", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="weather"><display-name>AccuWeather</display-name></channel>
+  <programme channel="weather" start="20260622160000 -0400" stop="20260622200000 -0400"><title>AccuWeather Ahead</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ tvgName: "AccuWeather", name: "AccuWeather" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.programmes).toHaveLength(1);
+        expect(row.programmes[0]).toMatchObject({
+            title: "AccuWeather Ahead",
+            leftPercent: 0,
+            widthPercent: 100,
+            startsBeforeViewport: true,
+            endsAfterViewport: false,
+            state: "current",
+        });
+    });
+
+    test("falls back to normalized channel display-name matching", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="cnn"><display-name>CNN International</display-name></channel>
+  <programme channel="cnn" start="20260622190000 -0400" stop="20260622200000 -0400"><title>Live: Erin Burnett OutFront</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ name: "cnn international" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.programmes.map((programme) => programme.title)).toEqual([
+            "Live: Erin Burnett OutFront",
+        ]);
+    });
+});

--- a/packages/app/src/lib/iptv/guideGrid.ts
+++ b/packages/app/src/lib/iptv/guideGrid.ts
@@ -1,0 +1,151 @@
+import type { IptvChannel, XmltvGuide, XmltvProgramme } from "./types";
+import { normalizeIptvText } from "./utils";
+
+export type GuideProgrammeState = "past" | "current" | "future";
+
+export interface GuideGridViewport {
+    viewportStart: Date;
+    viewportEnd: Date;
+    now: Date;
+}
+
+export interface GuideGridProgramme {
+    id: string;
+    title: string;
+    subTitle?: string;
+    description?: string;
+    start: Date;
+    stop: Date;
+    timeRange: string;
+    leftPercent: number;
+    widthPercent: number;
+    state: GuideProgrammeState;
+    startsBeforeViewport: boolean;
+    endsAfterViewport: boolean;
+}
+
+export interface GuideGridRow {
+    channel: IptvChannel;
+    programmes: GuideGridProgramme[];
+}
+
+function hasGuideChannelId(guide: XmltvGuide, channelId: string): boolean {
+    return guide.channels.has(channelId) || guide.programmesByChannel.has(channelId);
+}
+
+function resolveGuideChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
+    if (channel.tvgId && hasGuideChannelId(guide, channel.tvgId)) {
+        return channel.tvgId;
+    }
+
+    const tvgName = normalizeIptvText(channel.tvgName);
+    if (tvgName && guide.displayNameToChannelId.has(tvgName)) {
+        return guide.displayNameToChannelId.get(tvgName) ?? null;
+    }
+
+    const channelName = normalizeIptvText(channel.name);
+    if (channelName && guide.displayNameToChannelId.has(channelName)) {
+        return guide.displayNameToChannelId.get(channelName) ?? null;
+    }
+
+    return null;
+}
+
+function roundPercent(value: number): number {
+    return Math.round(value * 10_000) / 10_000;
+}
+
+function formatTime(value: Date, offsetMinutes?: number): string {
+    if (typeof offsetMinutes === "number" && Number.isFinite(offsetMinutes)) {
+        const local = new Date(value.getTime() + offsetMinutes * 60_000);
+        const hour24 = local.getUTCHours();
+        const hour12 = hour24 % 12 || 12;
+        const minute = String(local.getUTCMinutes()).padStart(2, "0");
+        const suffix = hour24 < 12 ? "AM" : "PM";
+        return `${hour12}:${minute} ${suffix}`;
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+    }).format(value);
+}
+
+function getProgrammeState(programme: XmltvProgramme, now: Date): GuideProgrammeState {
+    const nowMs = now.getTime();
+    const startMs = programme.start.getTime();
+    const stopMs = programme.stop.getTime();
+
+    if (startMs <= nowMs && nowMs < stopMs) return "current";
+    if (startMs > nowMs) return "future";
+    return "past";
+}
+
+function toGridProgramme(
+    programme: XmltvProgramme,
+    viewport: GuideGridViewport,
+): GuideGridProgramme | null {
+    const viewportStartMs = viewport.viewportStart.getTime();
+    const viewportEndMs = viewport.viewportEnd.getTime();
+    const viewportDurationMs = viewportEndMs - viewportStartMs;
+    const startMs = programme.start.getTime();
+    const stopMs = programme.stop.getTime();
+
+    if (viewportDurationMs <= 0 || stopMs <= viewportStartMs || startMs >= viewportEndMs) {
+        return null;
+    }
+
+    const clippedStartMs = Math.max(startMs, viewportStartMs);
+    const clippedStopMs = Math.min(stopMs, viewportEndMs);
+    const leftPercent = roundPercent(((clippedStartMs - viewportStartMs) / viewportDurationMs) * 100);
+    const widthPercent = roundPercent(((clippedStopMs - clippedStartMs) / viewportDurationMs) * 100);
+
+    return {
+        id: `${programme.channelId}:${startMs}:${stopMs}:${programme.title}`,
+        title: programme.title,
+        subTitle: programme.subTitle,
+        description: programme.description,
+        start: programme.start,
+        stop: programme.stop,
+        timeRange: `${formatTime(programme.start, programme.startOffsetMinutes)}-${formatTime(
+            programme.stop,
+            programme.stopOffsetMinutes,
+        )}`,
+        leftPercent,
+        widthPercent,
+        state: getProgrammeState(programme, viewport.now),
+        startsBeforeViewport: startMs < viewportStartMs,
+        endsAfterViewport: stopMs > viewportEndMs,
+    };
+}
+
+export function buildGuideRows(
+    channels: IptvChannel[],
+    guide: XmltvGuide | null | undefined,
+    viewport: GuideGridViewport,
+): GuideGridRow[] {
+    return channels.map((channel) => {
+        const guideChannelId = guide ? resolveGuideChannelId(channel, guide) : null;
+        const programmes = guideChannelId ? guide?.programmesByChannel.get(guideChannelId) ?? [] : [];
+
+        return {
+            channel,
+            programmes: programmes
+                .map((programme) => toGridProgramme(programme, viewport))
+                .filter((programme): programme is GuideGridProgramme => Boolean(programme)),
+        };
+    });
+}
+
+export function getNowLinePercent({
+    viewportStart,
+    viewportEnd,
+    now,
+}: GuideGridViewport): number {
+    const viewportStartMs = viewportStart.getTime();
+    const viewportDurationMs = viewportEnd.getTime() - viewportStartMs;
+
+    if (viewportDurationMs <= 0) return 0;
+
+    return roundPercent(((now.getTime() - viewportStartMs) / viewportDurationMs) * 100);
+}

--- a/packages/app/src/lib/iptv/m3u.test.ts
+++ b/packages/app/src/lib/iptv/m3u.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { parseM3U } from "./m3u";
+
+describe("parseM3U", () => {
+    test("parses EXTINF attributes and following stream URL", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 tvg-id="abc.us" tvg-name="ABC" tvg-logo="http://logo/abc.png" group-title="Local",ABC HD
+stream-one
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels).toHaveLength(1);
+        expect(result.channels[0]).toMatchObject({
+            sourceId: "source-1",
+            tvgId: "abc.us",
+            tvgName: "ABC",
+            logo: "http://logo/abc.png",
+            group: "Local",
+            name: "ABC HD",
+            url: "stream-one",
+            order: 0,
+        });
+    });
+
+    test("keeps commas inside quoted EXTINF attributes", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 tvg-id="abc.us" tvg-name="ABC, East" group-title="Local, News",ABC HD
+stream-one
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels).toHaveLength(1);
+        expect(result.channels[0]).toMatchObject({
+            name: "ABC HD",
+            tvgName: "ABC, East",
+            group: "Local, News",
+            url: "stream-one",
+        });
+        expect(result.groups.map((g) => g.name)).toEqual(["Local, News"]);
+    });
+
+    test("keeps provider order and handles missing attributes", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1,One
+stream-one
+#EXTINF:-1 group-title="News",Two
+stream-two
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels.map((c) => c.name)).toEqual(["One", "Two"]);
+        expect(result.channels[0].group).toBe("Ungrouped");
+        expect(result.groups.map((g) => g.name)).toEqual(["Ungrouped", "News"]);
+    });
+
+    test("skips EXTINF entries without a following playable URL", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 group-title="Broken",Broken
+#EXTINF:-1 group-title="Live",Working
+stream-working
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels.map((c) => c.name)).toEqual(["Working"]);
+        expect(result.groups.map((g) => g.name)).toEqual(["Live"]);
+    });
+});

--- a/packages/app/src/lib/iptv/m3u.ts
+++ b/packages/app/src/lib/iptv/m3u.ts
@@ -1,0 +1,116 @@
+import type { IptvChannel, IptvGroup, IptvParseResult } from "./types";
+import { DEFAULT_IPTV_GROUP, parseQuotedAttributes, slugForId } from "./utils";
+
+type PendingExtinf = {
+    attributes: Record<string, string>;
+    displayName: string;
+};
+
+function findExtinfDisplayNameComma(line: string): number {
+    let quote: "\"" | "'" | null = null;
+
+    for (let index = 0; index < line.length; index += 1) {
+        const char = line[index];
+
+        if (char === "\\" && quote) {
+            index += 1;
+            continue;
+        }
+
+        if ((char === "\"" || char === "'") && (!quote || quote === char)) {
+            quote = quote ? null : char;
+            continue;
+        }
+
+        if (char === "," && !quote) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function parseExtinf(line: string): PendingExtinf {
+    const commaIndex = findExtinfDisplayNameComma(line);
+    const metadata = commaIndex >= 0 ? line.slice(0, commaIndex) : line;
+    const displayName = commaIndex >= 0 ? line.slice(commaIndex + 1).trim() : "";
+
+    return {
+        attributes: parseQuotedAttributes(metadata),
+        displayName,
+    };
+}
+
+function isPlayableUrl(line: string): boolean {
+    if (!line) return false;
+    if (line.startsWith("#")) return false;
+    return true;
+}
+
+export function parseM3U(input: string, sourceId: string): IptvParseResult {
+    const channels: IptvChannel[] = [];
+    const groupOrder = new Map<string, number>();
+    const groupCounts = new Map<string, number>();
+    let pending: PendingExtinf | null = null;
+
+    const lines = String(input ?? "").split(/\r?\n/);
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+
+        if (line.startsWith("#EXTINF")) {
+            pending = parseExtinf(line);
+            continue;
+        }
+
+        if (!pending || !isPlayableUrl(line)) {
+            continue;
+        }
+
+        const attributes = pending.attributes;
+        const order = channels.length;
+        const name =
+            pending.displayName ||
+            attributes["tvg-name"]?.trim() ||
+            attributes["tvg-id"]?.trim() ||
+            line;
+        const group = attributes["group-title"]?.trim() || DEFAULT_IPTV_GROUP;
+
+        if (!groupOrder.has(group)) {
+            groupOrder.set(group, groupOrder.size);
+        }
+        groupCounts.set(group, (groupCounts.get(group) ?? 0) + 1);
+
+        channels.push({
+            id: `${sourceId}:${order}:${slugForId(name)}`,
+            sourceId,
+            name,
+            url: line,
+            group,
+            tvgId: attributes["tvg-id"]?.trim() || undefined,
+            tvgName: attributes["tvg-name"]?.trim() || undefined,
+            logo: attributes["tvg-logo"]?.trim() || undefined,
+            number:
+                attributes["tvg-chno"]?.trim() ||
+                attributes["channel-number"]?.trim() ||
+                attributes["tvg-num"]?.trim() ||
+                undefined,
+            order,
+        });
+
+        pending = null;
+    }
+
+    const groups: IptvGroup[] = Array.from(groupOrder.entries())
+        .sort((a, b) => a[1] - b[1])
+        .map(([name, order]) => ({
+            id: `${sourceId}:group:${slugForId(name)}`,
+            sourceId,
+            name,
+            channelCount: groupCounts.get(name) ?? 0,
+            order,
+        }));
+
+    return { channels, groups };
+}

--- a/packages/app/src/lib/iptv/refresh.test.ts
+++ b/packages/app/src/lib/iptv/refresh.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { IptvSource } from "./types";
+import { refreshIptvSource } from "./refresh";
+
+const source: IptvSource = {
+    id: "source-1",
+    name: "Live",
+    kind: "m3u",
+    m3uUrl: "https://iptv.example.test/playlist.m3u",
+    epgUrl: "https://iptv.example.test/guide.xml",
+    createdAt: "2026-06-22T00:00:00.000Z",
+    updatedAt: "2026-06-22T00:00:00.000Z",
+};
+
+describe("refreshIptvSource", () => {
+    test("fetches playlist and guide through an injected fetcher", async () => {
+        const result = await refreshIptvSource(source, {
+            now: () => new Date("2026-06-22T13:30:00.000Z"),
+            fetchText: async (url) => {
+                if (url === source.m3uUrl) {
+                    return `#EXTM3U
+#EXTINF:-1 tvg-id="abc.us" group-title="Local",ABC HD
+stream-one
+#EXTINF:-1 tvg-name="Weather Now" group-title="Weather",Weather
+stream-two
+`;
+                }
+                return `<tv>
+  <channel id="abc.us"><display-name>ABC HD</display-name></channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400"><title>ABC Now</title></programme>
+  <programme channel="abc.us" start="20260622100000 -0400" stop="20260622110000 -0400"><title>ABC Next</title></programme>
+</tv>`;
+            },
+        });
+
+        expect(result.channels.map((channel) => channel.name)).toEqual(["ABC HD", "Weather"]);
+        expect(result.groups.map((group) => group.name)).toEqual(["Local", "Weather"]);
+        expect(result.stats).toMatchObject({
+            channelCount: 2,
+            groupCount: 2,
+            programmeCount: 2,
+        });
+        expect(result.guide).toBeTruthy();
+        expect(result.loadedAt).toBe("2026-06-22T13:30:00.000Z");
+    });
+
+    test("returns a friendly empty playlist error", async () => {
+        await expect(
+            refreshIptvSource(
+                { ...source, epgUrl: undefined },
+                {
+                    fetchText: async () => "#EXTM3U\n",
+                },
+            ),
+        ).rejects.toThrow("The IPTV playlist did not contain any channels");
+    });
+
+    test("wraps XMLTV parser failures with a friendly message", async () => {
+        await expect(
+            refreshIptvSource(source, {
+                fetchText: async (url) =>
+                    url === source.m3uUrl
+                        ? `#EXTM3U
+#EXTINF:-1,One
+stream-one
+`
+                        : "<not-tv>",
+            }),
+        ).rejects.toThrow("The XMLTV guide could not be parsed");
+    });
+});

--- a/packages/app/src/lib/iptv/refresh.ts
+++ b/packages/app/src/lib/iptv/refresh.ts
@@ -1,0 +1,72 @@
+import { iptvFetchText, type IptvFetchText } from "./fetch";
+import { parseM3U } from "./m3u";
+import type { IptvRefreshResult, IptvSource, XmltvGuide } from "./types";
+import { getProgrammeCount, parseXmltv } from "./xmltv";
+
+export type RefreshIptvSourceOptions = {
+    fetchText?: IptvFetchText;
+    now?: () => Date;
+};
+
+const M3U_TIMEOUT_MS = 20_000;
+const XMLTV_TIMEOUT_MS = 60_000;
+const MAX_BYTES = 64 * 1024 * 1024;
+
+function friendlyFetchError(error: unknown, label: string): Error {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Error(`${label} could not be loaded. ${message}`);
+}
+
+export async function refreshIptvSource(
+    source: IptvSource,
+    options: RefreshIptvSourceOptions = {},
+): Promise<IptvRefreshResult> {
+    const fetchText = options.fetchText ?? iptvFetchText;
+    const now = options.now ?? (() => new Date());
+
+    let playlist: string;
+    try {
+        playlist = await fetchText(source.m3uUrl, {
+            timeoutMs: M3U_TIMEOUT_MS,
+            maxBytes: MAX_BYTES,
+        });
+    } catch (error) {
+        throw friendlyFetchError(error, "The IPTV playlist");
+    }
+
+    const parsed = parseM3U(playlist, source.id);
+    if (parsed.channels.length === 0) {
+        throw new Error("The IPTV playlist did not contain any channels");
+    }
+
+    let guide: XmltvGuide | undefined;
+    if (source.epgUrl) {
+        let xmltv: string;
+        try {
+            xmltv = await fetchText(source.epgUrl, {
+                timeoutMs: XMLTV_TIMEOUT_MS,
+                maxBytes: MAX_BYTES,
+            });
+        } catch (error) {
+            throw friendlyFetchError(error, "The XMLTV guide");
+        }
+
+        try {
+            guide = parseXmltv(xmltv);
+        } catch {
+            throw new Error("The XMLTV guide could not be parsed");
+        }
+    }
+
+    return {
+        channels: parsed.channels,
+        groups: parsed.groups,
+        guide,
+        loadedAt: now().toISOString(),
+        stats: {
+            channelCount: parsed.channels.length,
+            groupCount: parsed.groups.length,
+            programmeCount: getProgrammeCount(guide),
+        },
+    };
+}

--- a/packages/app/src/lib/iptv/store.test.ts
+++ b/packages/app/src/lib/iptv/store.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    addIptvSource,
+    getStoredIptvSources,
+    removeIptvSource,
+    updateIptvSource,
+} from "./store";
+
+class MemoryStorage {
+    private values = new Map<string, string>();
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    clear() {
+        this.values.clear();
+    }
+}
+
+describe("IPTV source store helpers", () => {
+    let storage: MemoryStorage;
+
+    beforeEach(() => {
+        storage = new MemoryStorage();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: storage,
+            configurable: true,
+        });
+    });
+
+    test("adds, updates, and removes source config without fetched bodies", () => {
+        const source = addIptvSource({
+            name: "Live",
+            m3uUrl: "https://iptv.example.test/playlist.m3u",
+            epgUrl: "https://iptv.example.test/guide.xml",
+        });
+
+        expect(source.id).toBeTruthy();
+        expect(getStoredIptvSources()).toHaveLength(1);
+
+        const updated = updateIptvSource(source.id, {
+            name: "Live TV",
+            epgUrl: "",
+        });
+
+        expect(updated?.name).toBe("Live TV");
+        expect(updated?.epgUrl).toBeUndefined();
+
+        const rawStored = storage.getItem("raffi_iptv_sources_v1") ?? "";
+        expect(rawStored).not.toContain("#EXTM3U");
+        expect(rawStored).not.toContain("<programme");
+
+        removeIptvSource(source.id);
+
+        expect(getStoredIptvSources()).toEqual([]);
+    });
+
+    test("rejects non-http playlist and guide URLs", () => {
+        expect(() =>
+            addIptvSource({
+                name: "Bad",
+                m3uUrl: "file:///tmp/playlist.m3u",
+            }),
+        ).toThrow("Only http and https IPTV URLs are supported");
+
+        expect(() =>
+            addIptvSource({
+                name: "Bad EPG",
+                m3uUrl: "https://iptv.example.test/playlist.m3u",
+                epgUrl: "ftp://iptv.example.test/guide.xml",
+            }),
+        ).toThrow("Only http and https IPTV URLs are supported");
+    });
+});

--- a/packages/app/src/lib/iptv/store.ts
+++ b/packages/app/src/lib/iptv/store.ts
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 import type { IptvSource } from "./types";
 import { validateIptvUrl } from "./fetch";
+import { clearStoredIptvRefreshResult } from "./cache";
 
 export const IPTV_SOURCES_STORAGE_KEY = "raffi_iptv_sources_v1";
 
@@ -142,4 +143,5 @@ export function updateIptvSource(
 
 export function removeIptvSource(sourceId: string): void {
     setSources(getStoredIptvSources().filter((source) => source.id !== sourceId));
+    clearStoredIptvRefreshResult(sourceId);
 }

--- a/packages/app/src/lib/iptv/store.ts
+++ b/packages/app/src/lib/iptv/store.ts
@@ -1,0 +1,145 @@
+import { writable } from "svelte/store";
+import type { IptvSource } from "./types";
+import { validateIptvUrl } from "./fetch";
+
+export const IPTV_SOURCES_STORAGE_KEY = "raffi_iptv_sources_v1";
+
+type SourceInput = {
+    name: string;
+    m3uUrl: string;
+    epgUrl?: string | null;
+};
+
+function createId(): string {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+        return crypto.randomUUID();
+    }
+    return `iptv-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getStorage(): Storage | null {
+    try {
+        return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch {
+        return null;
+    }
+}
+
+function sanitizeSource(value: any): IptvSource | null {
+    if (!value || typeof value !== "object") return null;
+    if (value.kind !== "m3u") return null;
+    if (typeof value.id !== "string" || !value.id.trim()) return null;
+    if (typeof value.name !== "string" || !value.name.trim()) return null;
+    if (typeof value.m3uUrl !== "string" || !value.m3uUrl.trim()) return null;
+
+    try {
+        const m3uUrl = validateIptvUrl(value.m3uUrl);
+        const epgUrl =
+            typeof value.epgUrl === "string" && value.epgUrl.trim()
+                ? validateIptvUrl(value.epgUrl)
+                : undefined;
+        const now = new Date().toISOString();
+
+        return {
+            id: value.id.trim(),
+            name: value.name.trim(),
+            kind: "m3u",
+            m3uUrl,
+            epgUrl,
+            createdAt: typeof value.createdAt === "string" ? value.createdAt : now,
+            updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : now,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function persistSources(sources: IptvSource[]) {
+    const storage = getStorage();
+    if (!storage) return;
+    storage.setItem(IPTV_SOURCES_STORAGE_KEY, JSON.stringify(sources));
+}
+
+function setSources(sources: IptvSource[]) {
+    persistSources(sources);
+    iptvSources.set(sources);
+}
+
+export function getStoredIptvSources(): IptvSource[] {
+    const storage = getStorage();
+    if (!storage) return [];
+
+    try {
+        const raw = storage.getItem(IPTV_SOURCES_STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.map(sanitizeSource).filter(Boolean) as IptvSource[];
+    } catch {
+        return [];
+    }
+}
+
+function normalizeSourceInput(input: SourceInput) {
+    const name = String(input.name ?? "").trim();
+    if (!name) {
+        throw new Error("Enter a source name");
+    }
+
+    const m3uUrl = validateIptvUrl(input.m3uUrl);
+    const epgUrl =
+        typeof input.epgUrl === "string" && input.epgUrl.trim()
+            ? validateIptvUrl(input.epgUrl)
+            : undefined;
+
+    return { name, m3uUrl, epgUrl };
+}
+
+export const iptvSources = writable<IptvSource[]>(getStoredIptvSources());
+
+export function addIptvSource(input: SourceInput): IptvSource {
+    const normalized = normalizeSourceInput(input);
+    const now = new Date().toISOString();
+    const source: IptvSource = {
+        id: createId(),
+        kind: "m3u",
+        name: normalized.name,
+        m3uUrl: normalized.m3uUrl,
+        epgUrl: normalized.epgUrl,
+        createdAt: now,
+        updatedAt: now,
+    };
+
+    setSources([...getStoredIptvSources(), source]);
+    return source;
+}
+
+export function updateIptvSource(
+    sourceId: string,
+    input: Partial<SourceInput>,
+): IptvSource | null {
+    const sources = getStoredIptvSources();
+    const existing = sources.find((source) => source.id === sourceId);
+    if (!existing) return null;
+
+    const normalized = normalizeSourceInput({
+        name: input.name ?? existing.name,
+        m3uUrl: input.m3uUrl ?? existing.m3uUrl,
+        epgUrl: input.epgUrl === undefined ? existing.epgUrl : input.epgUrl,
+    });
+
+    const updated: IptvSource = {
+        ...existing,
+        name: normalized.name,
+        m3uUrl: normalized.m3uUrl,
+        epgUrl: normalized.epgUrl,
+        updatedAt: new Date().toISOString(),
+    };
+
+    setSources(sources.map((source) => (source.id === sourceId ? updated : source)));
+    return updated;
+}
+
+export function removeIptvSource(sourceId: string): void {
+    setSources(getStoredIptvSources().filter((source) => source.id !== sourceId));
+}

--- a/packages/app/src/lib/iptv/types.ts
+++ b/packages/app/src/lib/iptv/types.ts
@@ -1,0 +1,79 @@
+export type IptvSourceKind = "m3u";
+
+export interface IptvSource {
+    id: string;
+    name: string;
+    kind: IptvSourceKind;
+    m3uUrl: string;
+    epgUrl?: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface IptvChannel {
+    id: string;
+    sourceId: string;
+    name: string;
+    url: string;
+    group: string;
+    tvgId?: string;
+    tvgName?: string;
+    logo?: string;
+    number?: string;
+    order: number;
+}
+
+export interface IptvGroup {
+    id: string;
+    sourceId: string;
+    name: string;
+    channelCount: number;
+    order: number;
+}
+
+export interface IptvParseResult {
+    channels: IptvChannel[];
+    groups: IptvGroup[];
+}
+
+export interface XmltvProgramme {
+    channelId: string;
+    start: Date;
+    stop: Date;
+    title: string;
+    subTitle?: string;
+    description?: string;
+}
+
+export interface XmltvChannel {
+    id: string;
+    displayNames: string[];
+}
+
+export interface XmltvGuide {
+    channels: Map<string, XmltvChannel>;
+    programmesByChannel: Map<string, XmltvProgramme[]>;
+    displayNameToChannelId: Map<string, string>;
+}
+
+export interface IptvRefreshStats {
+    channelCount: number;
+    groupCount: number;
+    programmeCount: number;
+}
+
+export interface IptvRefreshResult {
+    channels: IptvChannel[];
+    groups: IptvGroup[];
+    guide?: XmltvGuide;
+    loadedAt: string;
+    stats: IptvRefreshStats;
+}
+
+export interface IptvLiveChannelMetadata {
+    name: string;
+    group?: string | null;
+    logo?: string | null;
+    tvgId?: string | null;
+    programmeTitle?: string | null;
+}

--- a/packages/app/src/lib/iptv/types.ts
+++ b/packages/app/src/lib/iptv/types.ts
@@ -40,6 +40,8 @@ export interface XmltvProgramme {
     channelId: string;
     start: Date;
     stop: Date;
+    startOffsetMinutes?: number;
+    stopOffsetMinutes?: number;
     title: string;
     subTitle?: string;
     description?: string;

--- a/packages/app/src/lib/iptv/utils.ts
+++ b/packages/app/src/lib/iptv/utils.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_IPTV_GROUP = "Ungrouped";
+
+export function normalizeIptvText(value: string | null | undefined): string {
+    return String(value ?? "")
+        .trim()
+        .toLowerCase()
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/&/g, "and")
+        .replace(/[^a-z0-9]+/g, "");
+}
+
+export function slugForId(value: string | null | undefined): string {
+    const normalized = normalizeIptvText(value);
+    return normalized || "channel";
+}
+
+export function parseQuotedAttributes(value: string): Record<string, string> {
+    const attributes: Record<string, string> = {};
+    const regex = /([\w:-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(value)) !== null) {
+        attributes[match[1]] = match[2] ?? match[3] ?? "";
+    }
+
+    return attributes;
+}

--- a/packages/app/src/lib/iptv/xmltv.test.ts
+++ b/packages/app/src/lib/iptv/xmltv.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { IptvChannel } from "./types";
+import { getNowNext, parseXmltv } from "./xmltv";
+
+const channel = (overrides: Partial<IptvChannel>): IptvChannel => ({
+    id: "source-1:0:test",
+    sourceId: "source-1",
+    name: "Test Channel",
+    url: "stream-one",
+    group: "News",
+    order: 0,
+    ...overrides,
+});
+
+describe("parseXmltv", () => {
+    test("parses XMLTV channels and timezone programme windows", () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="abc.us">
+    <display-name>ABC</display-name>
+    <display-name>ABC HD</display-name>
+  </channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400">
+    <title>Morning News &amp; Weather</title>
+    <sub-title>Local</sub-title>
+    <desc>Headlines &amp; forecast.</desc>
+  </programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(guide.channels.get("abc.us")?.displayNames).toEqual(["ABC", "ABC HD"]);
+        expect(programmes).toHaveLength(1);
+        expect(programmes[0].title).toBe("Morning News & Weather");
+        expect(programmes[0].subTitle).toBe("Local");
+        expect(programmes[0].description).toBe("Headlines & forecast.");
+        expect(programmes[0].start.toISOString()).toBe("2026-06-22T13:00:00.000Z");
+    });
+
+    test("parses single-quoted XMLTV attributes", () => {
+        const xml = `<tv>
+  <channel id='abc.us'><display-name>ABC</display-name></channel>
+  <programme channel='abc.us' start='20260622090000 -0400' stop='20260622100000 -0400'>
+    <title>Morning News</title>
+  </programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(guide.channels.get("abc.us")?.displayNames).toEqual(["ABC"]);
+        expect(programmes).toHaveLength(1);
+        expect(programmes[0].title).toBe("Morning News");
+    });
+
+    test("parses CDATA text inside XMLTV tags", () => {
+        const xml = `<tv>
+  <channel id="abc.us"><display-name><![CDATA[ABC <East>]]></display-name></channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400">
+    <title><![CDATA[Morning <News> & Weather]]></title>
+    <desc><![CDATA[Headlines <local> & forecast.]]></desc>
+  </programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(guide.channels.get("abc.us")?.displayNames).toEqual(["ABC <East>"]);
+        expect(programmes[0].title).toBe("Morning <News> & Weather");
+        expect(programmes[0].description).toBe("Headlines <local> & forecast.");
+    });
+});
+
+describe("getNowNext", () => {
+    const xml = `<tv>
+  <channel id="abc.us"><display-name>ABC</display-name></channel>
+  <channel id="weather"><display-name>Weather Now</display-name></channel>
+  <channel id="sports"><display-name>Sports Plus</display-name></channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400"><title>ABC Now</title></programme>
+  <programme channel="abc.us" start="20260622100000 -0400" stop="20260622110000 -0400"><title>ABC Next</title></programme>
+  <programme channel="weather" start="20260622090000 -0400" stop="20260622100000 -0400"><title>Weather Now</title></programme>
+  <programme channel="sports" start="20260622090000 -0400" stop="20260622100000 -0400"><title>Sports Now</title></programme>
+</tv>`;
+
+    const at = new Date("2026-06-22T13:30:00.000Z");
+    const guide = parseXmltv(xml);
+
+    test("matches by exact tvg-id first", () => {
+        const result = getNowNext(channel({ tvgId: "abc.us", tvgName: "Wrong Name" }), guide, at);
+
+        expect(result.now?.title).toBe("ABC Now");
+        expect(result.next?.title).toBe("ABC Next");
+    });
+
+    test("matches by tvg-name display name", () => {
+        const result = getNowNext(channel({ tvgName: "Weather Now", name: "Weather 1" }), guide, at);
+
+        expect(result.now?.channelId).toBe("weather");
+        expect(result.now?.title).toBe("Weather Now");
+    });
+
+    test("matches by normalized display name fallback", () => {
+        const result = getNowNext(channel({ name: "sports-plus" }), guide, at);
+
+        expect(result.now?.channelId).toBe("sports");
+        expect(result.now?.title).toBe("Sports Now");
+    });
+});

--- a/packages/app/src/lib/iptv/xmltv.ts
+++ b/packages/app/src/lib/iptv/xmltv.ts
@@ -1,0 +1,220 @@
+import type { IptvChannel, XmltvGuide, XmltvProgramme } from "./types";
+import { normalizeIptvText, parseQuotedAttributes } from "./utils";
+
+function decodeXmlEntities(value: string): string {
+    return value.replace(/&(#x?[0-9a-fA-F]+|amp|lt|gt|quot|apos);/g, (match, entity) => {
+        switch (entity) {
+            case "amp":
+                return "&";
+            case "lt":
+                return "<";
+            case "gt":
+                return ">";
+            case "quot":
+                return "\"";
+            case "apos":
+                return "'";
+            default: {
+                const raw = String(entity);
+                const isHex = raw.toLowerCase().startsWith("#x");
+                const numeric = raw.startsWith("#")
+                    ? Number.parseInt(raw.slice(isHex ? 2 : 1), isHex ? 16 : 10)
+                    : Number.NaN;
+                return Number.isFinite(numeric) ? String.fromCodePoint(numeric) : match;
+            }
+        }
+    });
+}
+
+function getTagText(block: string, tagName: string): string | undefined {
+    const regex = new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "i");
+    const match = regex.exec(block);
+    if (!match) return undefined;
+    const text = getXmlTextContent(match[1]);
+    return text || undefined;
+}
+
+function getAllTagText(block: string, tagName: string): string[] {
+    const values: string[] = [];
+    const regex = new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "gi");
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(block)) !== null) {
+        const text = getXmlTextContent(match[1]);
+        if (text) values.push(text);
+    }
+
+    return values;
+}
+
+function getXmlTextContent(value: string): string {
+    let output = "";
+    let cursor = 0;
+    const cdataRegex = /<!\[CDATA\[([\s\S]*?)\]\]>/gi;
+    let match: RegExpExecArray | null;
+
+    while ((match = cdataRegex.exec(value)) !== null) {
+        output += decodeXmlEntities(value.slice(cursor, match.index).replace(/<[^>]+>/g, ""));
+        output += match[1];
+        cursor = cdataRegex.lastIndex;
+    }
+
+    output += decodeXmlEntities(value.slice(cursor).replace(/<[^>]+>/g, ""));
+    return output.trim();
+}
+
+export function parseXmltvTime(value: string): Date {
+    const match = String(value ?? "").trim().match(
+        /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(?:\s*([+-])(\d{2})(\d{2}))?/,
+    );
+
+    if (!match) {
+        throw new Error("Invalid XMLTV time");
+    }
+
+    const [, year, month, day, hour, minute, second, sign, offsetHour, offsetMinute] = match;
+    const utc = Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+    );
+
+    if (!sign) return new Date(utc);
+
+    const offsetMs =
+        (Number(offsetHour) * 60 + Number(offsetMinute)) *
+        60 *
+        1000 *
+        (sign === "+" ? 1 : -1);
+
+    return new Date(utc - offsetMs);
+}
+
+function countProgrammes(guide: XmltvGuide): number {
+    let count = 0;
+    for (const programmes of guide.programmesByChannel.values()) {
+        count += programmes.length;
+    }
+    return count;
+}
+
+export function getProgrammeCount(guide: XmltvGuide | undefined): number {
+    return guide ? countProgrammes(guide) : 0;
+}
+
+export function parseXmltv(xml: string): XmltvGuide {
+    const text = String(xml ?? "");
+    if (!/<tv\b/i.test(text)) {
+        throw new Error("Invalid XMLTV document");
+    }
+
+    const guide: XmltvGuide = {
+        channels: new Map(),
+        programmesByChannel: new Map(),
+        displayNameToChannelId: new Map(),
+    };
+
+    const channelRegex = /<channel\b([^>]*)>([\s\S]*?)<\/channel>/gi;
+    let channelMatch: RegExpExecArray | null;
+
+    while ((channelMatch = channelRegex.exec(text)) !== null) {
+        const attributes = parseQuotedAttributes(channelMatch[1]);
+        const id = attributes.id?.trim();
+        if (!id) continue;
+
+        const displayNames = getAllTagText(channelMatch[2], "display-name");
+        guide.channels.set(id, { id, displayNames });
+
+        for (const displayName of displayNames) {
+            const key = normalizeIptvText(displayName);
+            if (key && !guide.displayNameToChannelId.has(key)) {
+                guide.displayNameToChannelId.set(key, id);
+            }
+        }
+    }
+
+    const programmeRegex = /<programme\b([^>]*)>([\s\S]*?)<\/programme>/gi;
+    let programmeMatch: RegExpExecArray | null;
+
+    while ((programmeMatch = programmeRegex.exec(text)) !== null) {
+        const attributes = parseQuotedAttributes(programmeMatch[1]);
+        const channelId = attributes.channel?.trim();
+        const startRaw = attributes.start?.trim();
+        const stopRaw = attributes.stop?.trim();
+        if (!channelId || !startRaw || !stopRaw) continue;
+
+        const title = getTagText(programmeMatch[2], "title") || "Untitled";
+        const programme: XmltvProgramme = {
+            channelId,
+            start: parseXmltvTime(startRaw),
+            stop: parseXmltvTime(stopRaw),
+            title,
+            subTitle: getTagText(programmeMatch[2], "sub-title"),
+            description: getTagText(programmeMatch[2], "desc"),
+        };
+
+        const programmes = guide.programmesByChannel.get(channelId) ?? [];
+        programmes.push(programme);
+        guide.programmesByChannel.set(channelId, programmes);
+    }
+
+    for (const programmes of guide.programmesByChannel.values()) {
+        programmes.sort((a, b) => a.start.getTime() - b.start.getTime());
+    }
+
+    return guide;
+}
+
+function resolveGuideChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
+    if (channel.tvgId && guide.channels.has(channel.tvgId)) {
+        return channel.tvgId;
+    }
+
+    const tvgName = normalizeIptvText(channel.tvgName);
+    if (tvgName && guide.displayNameToChannelId.has(tvgName)) {
+        return guide.displayNameToChannelId.get(tvgName) ?? null;
+    }
+
+    const displayName = normalizeIptvText(channel.name);
+    if (displayName && guide.displayNameToChannelId.has(displayName)) {
+        return guide.displayNameToChannelId.get(displayName) ?? null;
+    }
+
+    return null;
+}
+
+export function getNowNext(
+    channel: IptvChannel,
+    guide: XmltvGuide,
+    at: Date = new Date(),
+): { now: XmltvProgramme | null; next: XmltvProgramme | null } {
+    const guideChannelId = resolveGuideChannelId(channel, guide);
+    if (!guideChannelId) {
+        return { now: null, next: null };
+    }
+
+    const programmes = guide.programmesByChannel.get(guideChannelId) ?? [];
+    const timestamp = at.getTime();
+    let now: XmltvProgramme | null = null;
+    let next: XmltvProgramme | null = null;
+
+    for (const programme of programmes) {
+        const start = programme.start.getTime();
+        const stop = programme.stop.getTime();
+
+        if (start <= timestamp && timestamp < stop) {
+            now = programme;
+            continue;
+        }
+
+        if (start > timestamp) {
+            next = programme;
+            break;
+        }
+    }
+
+    return { now, next };
+}

--- a/packages/app/src/lib/iptv/xmltv.ts
+++ b/packages/app/src/lib/iptv/xmltv.ts
@@ -93,6 +93,18 @@ export function parseXmltvTime(value: string): Date {
     return new Date(utc - offsetMs);
 }
 
+function getXmltvOffsetMinutes(value: string): number | undefined {
+    const match = String(value ?? "").trim().match(
+        /^\d{14}\s*([+-])(\d{2})(\d{2})/,
+    );
+
+    if (!match) return undefined;
+
+    const [, sign, offsetHour, offsetMinute] = match;
+    const minutes = Number(offsetHour) * 60 + Number(offsetMinute);
+    return minutes * (sign === "+" ? 1 : -1);
+}
+
 function countProgrammes(guide: XmltvGuide): number {
     let count = 0;
     for (const programmes of guide.programmesByChannel.values()) {
@@ -151,6 +163,8 @@ export function parseXmltv(xml: string): XmltvGuide {
             channelId,
             start: parseXmltvTime(startRaw),
             stop: parseXmltvTime(stopRaw),
+            startOffsetMinutes: getXmltvOffsetMinutes(startRaw),
+            stopOffsetMinutes: getXmltvOffsetMinutes(stopRaw),
             title,
             subTitle: getTagText(programmeMatch[2], "sub-title"),
             description: getTagText(programmeMatch[2], "desc"),

--- a/packages/app/src/lib/stores/router.ts
+++ b/packages/app/src/lib/stores/router.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 
-export type Route = "home" | "meta" | "player" | "lists";
+export type Route = "home" | "meta" | "player" | "lists" | "live";
 
 export interface RouterState {
     page: Route;

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-    import { onDestroy, onMount } from "svelte";
+    import { onDestroy, onMount, tick } from "svelte";
     import {
         ChevronLeft,
         Pencil,
-        Play,
         Plus,
         RefreshCw,
         Search,
@@ -20,15 +19,26 @@
         updateIptvSource,
     } from "../../lib/iptv/store";
     import { refreshIptvSource } from "../../lib/iptv/refresh";
+    import {
+        getStoredIptvRefreshResult,
+        persistIptvRefreshResult,
+    } from "../../lib/iptv/cache";
+    import {
+        buildGuideRows,
+        getNowLinePercent,
+        type GuideGridViewport,
+        type GuideProgrammeState,
+    } from "../../lib/iptv/guideGrid";
     import { getNowNext } from "../../lib/iptv/xmltv";
     import type {
         IptvChannel,
         IptvRefreshResult,
         IptvSource,
-        XmltvProgramme,
     } from "../../lib/iptv/types";
 
     const ALL_GROUPS = "__all__";
+    const GUIDE_VIEWPORT_HOURS = 2;
+    const GUIDE_TIMELINE_MIN_WIDTH = 680;
     const IPTV_EXAMPLE_M3U_URL = (
         import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_M3U_URL as string | undefined
     )?.trim();
@@ -46,6 +56,7 @@
 
     let selectedSourceId = "";
     let loadedSourceId = "";
+    let loadedSourceCacheKey = "";
     let refreshResult: IptvRefreshResult | null = null;
     let refreshing = false;
     let refreshError = "";
@@ -58,13 +69,20 @@
     let searchQuery = "";
     let guideNow = new Date();
     let guideTimer: ReturnType<typeof setInterval> | null = null;
+    let showSourceManager = false;
 
     const isDev = import.meta.env.DEV;
 
     $: selectedSource =
         $iptvSources.find((source) => source.id === selectedSourceId) ?? null;
+    $: selectedSourceCacheKey = selectedSource ? getLiveSourceCacheKey(selectedSource) : "";
     $: currentResult =
-        refreshResult && loadedSourceId === selectedSourceId ? refreshResult : null;
+        refreshResult &&
+        loadedSourceId === selectedSourceId &&
+        loadedSourceCacheKey === selectedSourceCacheKey
+            ? refreshResult
+            : null;
+    $: showFullSourcePanel = !currentResult || showSourceManager;
     $: availableGroups = currentResult?.groups ?? [];
     $: sourceSummary = currentResult
         ? `${currentResult.stats.channelCount} channels / ${currentResult.stats.groupCount} groups`
@@ -74,11 +92,31 @@
         selectedGroup,
         searchQuery,
     );
+    $: guideTitle = selectedGroup === ALL_GROUPS ? "Live TV" : selectedGroup;
+    $: guideViewport = getGuideViewport(guideNow);
+    $: guideRows = currentResult
+        ? buildGuideRows(visibleChannels, currentResult.guide, guideViewport)
+        : [];
+    $: guideNowLinePercent = getNowLinePercent(guideViewport);
+    $: showGuideNowLine = guideNowLinePercent >= 0 && guideNowLinePercent <= 100;
+    $: guideTimeTicks = buildGuideTimeTicks(guideViewport);
     $: if (!selectedSourceId && $iptvSources.length > 0) {
         selectedSourceId = $iptvSources[0].id;
     }
     $: if (selectedSourceId && !$iptvSources.some((source) => source.id === selectedSourceId)) {
         selectedSourceId = $iptvSources[0]?.id ?? "";
+    }
+    $: if (
+        selectedSource &&
+        (loadedSourceId !== selectedSource.id ||
+            loadedSourceCacheKey !== selectedSourceCacheKey)
+    ) {
+        hydrateStoredSource(selectedSource, selectedSourceCacheKey);
+    }
+    $: if (!selectedSource && refreshResult) {
+        loadedSourceId = "";
+        loadedSourceCacheKey = "";
+        refreshResult = null;
     }
     $: if (
         selectedGroup !== ALL_GROUPS &&
@@ -104,6 +142,81 @@
                 (channel.tvgId ?? "").toLowerCase().includes(normalizedQuery)
             );
         });
+    }
+
+    function getLiveSourceCacheKey(source: IptvSource) {
+        return `${source.id}\n${source.m3uUrl.trim()}\n${source.epgUrl?.trim() ?? ""}`;
+    }
+
+    function getGuideViewport(now: Date): GuideGridViewport {
+        const viewportStart = new Date(now);
+        viewportStart.setMinutes(0, 0, 0);
+
+        return {
+            viewportStart,
+            viewportEnd: new Date(viewportStart.getTime() + GUIDE_VIEWPORT_HOURS * 60 * 60_000),
+            now,
+        };
+    }
+
+    function getTimePercent(value: Date, viewport: GuideGridViewport) {
+        const viewportStartMs = viewport.viewportStart.getTime();
+        const viewportDurationMs = viewport.viewportEnd.getTime() - viewportStartMs;
+
+        if (viewportDurationMs <= 0) return 0;
+
+        return ((value.getTime() - viewportStartMs) / viewportDurationMs) * 100;
+    }
+
+    function buildGuideTimeTicks(viewport: GuideGridViewport) {
+        const ticks: { value: Date; label: string; leftPercent: number }[] = [];
+        const tickMs = 30 * 60_000;
+
+        for (
+            let timestamp = viewport.viewportStart.getTime();
+            timestamp <= viewport.viewportEnd.getTime();
+            timestamp += tickMs
+        ) {
+            const value = new Date(timestamp);
+            ticks.push({
+                value,
+                label: formatTime(value),
+                leftPercent: getTimePercent(value, viewport),
+            });
+        }
+
+        return ticks;
+    }
+
+    function timeTickClass(leftPercent: number) {
+        const base = "absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-[11px] tabular-nums text-white/42";
+        if (leftPercent <= 1) return `${base} translate-x-0`;
+        if (leftPercent >= 99) return `${base} -translate-x-full`;
+        return `${base} -translate-x-1/2`;
+    }
+
+    function programmeBlockClass(state: GuideProgrammeState) {
+        if (state === "current") {
+            return "border-[#a8b99b]/35 bg-[#809278]/78 text-white shadow-[0_10px_24px_rgba(128,146,120,0.16)] hover:bg-[#8ea084]/86";
+        }
+
+        if (state === "future") {
+            return "border-white/[0.08] bg-[#20262b] text-white/84 hover:bg-[#293039]";
+        }
+
+        return "border-white/[0.06] bg-[#161b20] text-white/46 hover:bg-[#1d2329]";
+    }
+
+    function guideFallbackLabel(hasGuide: boolean) {
+        return hasGuide ? "No guide data" : "Live";
+    }
+
+    function hydrateStoredSource(source: IptvSource, cacheKey: string) {
+        refreshResult = getStoredIptvRefreshResult(source);
+        loadedSourceId = source.id;
+        loadedSourceCacheKey = cacheKey;
+        selectedGroup = ALL_GROUPS;
+        refreshError = "";
     }
 
     function resetForm() {
@@ -167,6 +280,7 @@
         removeIptvSource(source.id);
         if (loadedSourceId === source.id) {
             loadedSourceId = "";
+            loadedSourceCacheKey = "";
             refreshResult = null;
         }
         if (editingSourceId === source.id) {
@@ -181,13 +295,17 @@
             return;
         }
 
+        const source = selectedSource;
+        const sourceCacheKey = selectedSourceCacheKey;
         refreshing = true;
         refreshError = "";
 
         try {
-            const result = await refreshIptvSource(selectedSource);
+            const result = await refreshIptvSource(source);
+            persistIptvRefreshResult(source, result);
             refreshResult = result;
-            loadedSourceId = selectedSource.id;
+            loadedSourceId = source.id;
+            loadedSourceCacheKey = sourceCacheKey;
             selectedGroup = ALL_GROUPS;
             trackEvent("iptv_source_refreshed", {
                 channel_count: result.stats.channelCount,
@@ -250,15 +368,19 @@
         }).format(new Date(value));
     }
 
-    function programmeText(programme: XmltvProgramme | null) {
-        if (!programme) return "";
-        return `${formatTime(programme.start)} ${programme.title}`;
-    }
-
     onMount(() => {
         guideTimer = setInterval(() => {
             guideNow = new Date();
         }, 60_000);
+
+        void tick().then(() => {
+            const source = selectedSource ?? $iptvSources[0] ?? null;
+            if (!source) return;
+            if (!selectedSourceId) {
+                selectedSourceId = source.id;
+            }
+            hydrateStoredSource(source, getLiveSourceCacheKey(source));
+        });
     });
 
     onDestroy(() => {
@@ -285,7 +407,7 @@
                     <Tv size={28} strokeWidth={2} class="text-white/70" />
                     <div class="min-w-0">
                         <h1 class="truncate font-poppins text-[28px] font-semibold leading-tight">
-                            Live TV
+                            {guideTitle}
                         </h1>
                         <p class="truncate text-sm text-white/48">
                             {sourceSummary || "No channels loaded"}
@@ -316,7 +438,10 @@
         </div>
     </div>
 
-    <div class="grid min-h-[calc(100vh-89px)] grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]">
+    <div class={showFullSourcePanel
+        ? "grid min-h-[calc(100vh-89px)] grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]"
+        : "grid min-h-[calc(100vh-89px)] grid-cols-1"}>
+        {#if showFullSourcePanel}
         <aside class="border-b border-white/10 bg-[#111111] p-6 lg:border-b-0 lg:border-r">
             <section class="flex flex-col gap-4">
                 <div class="flex items-center justify-between gap-3">
@@ -428,6 +553,7 @@
                 {/if}
             </section>
         </aside>
+        {/if}
 
         <main class="min-w-0 p-6 lg:p-8">
             <div class="mb-5 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
@@ -459,8 +585,16 @@
                 </div>
 
                 {#if currentResult}
-                    <div class="text-sm text-white/45">
-                        Showing {visibleChannels.length} of {currentResult.stats.channelCount}
+                    <div class="flex items-center gap-3 text-sm text-white/45">
+                        <button
+                            class="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white/70 transition-colors hover:bg-white/[0.09] hover:text-white"
+                            onclick={() => (showSourceManager = !showSourceManager)}
+                        >
+                            {showSourceManager ? "Hide Sources" : "Sources"}
+                        </button>
+                        <span>
+                            Showing {visibleChannels.length} of {currentResult.stats.channelCount}
+                        </span>
                     </div>
                 {/if}
             </div>
@@ -491,62 +625,127 @@
                     No channels match
                 </div>
             {:else}
-                <div class="grid grid-cols-1 gap-3 2xl:grid-cols-2">
-                    {#each visibleChannels as channel (channel.id)}
-                        {@const guide = getChannelGuide(channel)}
-                        <button
-                            class="grid min-h-[92px] grid-cols-[58px_minmax(0,1fr)_auto] items-center gap-4 rounded-lg border border-white/8 bg-white/[0.035] px-4 py-3 text-left transition-colors hover:border-white/20 hover:bg-white/[0.07]"
-                            onclick={() => playChannel(channel)}
-                        >
-                            <div class="flex h-[58px] w-[58px] items-center justify-center overflow-hidden rounded-md bg-black/45">
-                                {#if channel.logo}
-                                    <img
-                                        src={channel.logo}
-                                        alt=""
-                                        class="max-h-full max-w-full object-contain"
-                                        loading="lazy"
-                                        onerror={(event) => {
-                                            (event.currentTarget as HTMLImageElement).style.display = "none";
-                                        }}
-                                    />
-                                {:else}
-                                    <Tv size={24} strokeWidth={2} class="text-white/35" />
-                                {/if}
-                            </div>
+                <section class="overflow-hidden rounded-lg border border-white/10 bg-[#0b1116] shadow-2xl shadow-black/24">
+                    <div class="border-b border-white/10 bg-[#111a20] px-4 py-2 text-center">
+                        <div class="text-xs tabular-nums text-white/46">
+                            {formatTime(guideViewport.viewportStart)} – {formatTime(
+                                guideViewport.viewportEnd,
+                            )}
+                        </div>
+                    </div>
 
-                            <div class="min-w-0">
-                                <div class="flex items-center gap-2">
-                                    {#if channel.number}
-                                        <span class="shrink-0 rounded bg-white/8 px-2 py-0.5 text-xs tabular-nums text-white/52">
-                                            {channel.number}
+                    <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
+                        <div class="border-r border-white/10 bg-[#101820]">
+                            <div class="h-10 border-b border-white/10"></div>
+                            {#each guideRows as row (row.channel.id)}
+                                <button
+                                    class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
+                                    title={row.channel.name}
+                                    aria-label={`Play ${row.channel.name}`}
+                                    onclick={() => playChannel(row.channel)}
+                                >
+                                    <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-md bg-black/42 ring-1 ring-white/[0.06]">
+                                        {#if row.channel.logo}
+                                            <img
+                                                src={row.channel.logo}
+                                                alt=""
+                                                class="max-h-full max-w-full object-contain"
+                                                loading="lazy"
+                                                onerror={(event) => {
+                                                    (event.currentTarget as HTMLImageElement).style.display = "none";
+                                                }}
+                                            />
+                                        {:else}
+                                            <Tv size={22} strokeWidth={2} class="text-white/34" />
+                                        {/if}
+                                    </div>
+                                    {#if row.channel.number}
+                                        <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                            {row.channel.number}
+                                        </span>
+                                    {:else}
+                                        <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+                                            {row.channel.name}
                                         </span>
                                     {/if}
-                                    <span class="truncate font-poppins text-[17px] font-medium text-white">
-                                        {channel.name}
-                                    </span>
-                                </div>
-                                <div class="mt-1 truncate text-sm text-white/45">
-                                    {channel.group}
-                                </div>
-                                {#if guide.now}
-                                    <div class="mt-2 truncate text-sm text-white/72">
-                                        {programmeText(guide.now)}
-                                    </div>
-                                {/if}
-                                {#if guide.next}
-                                    <div class="mt-1 truncate text-xs text-white/42">
-                                        Next: {programmeText(guide.next)}
-                                    </div>
-                                {/if}
-                            </div>
+                                </button>
+                            {/each}
+                        </div>
 
-                            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-black">
-                                <Play size={18} strokeWidth={2.4} fill="currentColor" />
+                        <div class="no-scrollbar min-w-0 overflow-x-auto bg-[#0b1116]">
+                            <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
+                                <div class="relative h-10 border-b border-white/10 bg-[#101820]">
+                                    {#each guideTimeTicks as tick (tick.value.getTime())}
+                                        <div
+                                            class={timeTickClass(tick.leftPercent)}
+                                            style={`left: ${tick.leftPercent}%;`}
+                                        >
+                                            {tick.label}
+                                        </div>
+                                    {/each}
+                                </div>
+
+                                <div class="relative">
+                                    {#if showGuideNowLine}
+                                        <div
+                                            class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
+                                            style={`left: ${guideNowLinePercent}%;`}
+                                        >
+                                            <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-[#a8b99b] shadow-[0_0_16px_rgba(168,185,155,0.75)]"></div>
+                                            <div class="h-full w-px bg-[#a8b99b]/90 shadow-[0_0_12px_rgba(168,185,155,0.45)]"></div>
+                                        </div>
+                                    {/if}
+
+                                    {#each guideRows as row (row.channel.id)}
+                                        <div class="relative h-[86px] border-b border-white/[0.06]">
+                                            {#if row.programmes.length > 0}
+                                                {#each row.programmes as programme (programme.id)}
+                                                    <button
+                                                        class={`absolute inset-y-2 overflow-hidden rounded-md border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
+                                                        style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
+                                                        title={`${programme.timeRange} ${programme.title}`}
+                                                        onclick={() => playChannel(row.channel)}
+                                                    >
+                                                        <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
+                                                            {programme.title}
+                                                        </span>
+                                                        <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
+                                                            {programme.timeRange}
+                                                        </span>
+                                                    </button>
+                                                {/each}
+                                            {:else}
+                                                <button
+                                                    class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-md border border-white/[0.08] bg-[#20262b] px-3 text-left text-white/78 transition-colors hover:bg-[#293039]"
+                                                    onclick={() => playChannel(row.channel)}
+                                                >
+                                                    <span class="font-poppins text-[13px] font-semibold">
+                                                        {guideFallbackLabel(Boolean(currentResult.guide))}
+                                                    </span>
+                                                    <span class="min-w-0 truncate text-[11px] text-white/42">
+                                                        {row.channel.name}
+                                                    </span>
+                                                </button>
+                                            {/if}
+                                        </div>
+                                    {/each}
+                                </div>
                             </div>
-                        </button>
-                    {/each}
-                </div>
+                        </div>
+                    </div>
+                </section>
             {/if}
         </main>
     </div>
 </div>
+
+<style>
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+
+    .no-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+</style>

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -1,0 +1,552 @@
+<script lang="ts">
+    import { onDestroy, onMount } from "svelte";
+    import {
+        ChevronLeft,
+        Pencil,
+        Play,
+        Plus,
+        RefreshCw,
+        Search,
+        Trash2,
+        Tv,
+    } from "@lucide/svelte";
+    import LoadingSpinner from "../../components/common/LoadingSpinner.svelte";
+    import { trackEvent } from "../../lib/analytics";
+    import { router } from "../../lib/stores/router";
+    import {
+        addIptvSource,
+        iptvSources,
+        removeIptvSource,
+        updateIptvSource,
+    } from "../../lib/iptv/store";
+    import { refreshIptvSource } from "../../lib/iptv/refresh";
+    import { getNowNext } from "../../lib/iptv/xmltv";
+    import type {
+        IptvChannel,
+        IptvRefreshResult,
+        IptvSource,
+        XmltvProgramme,
+    } from "../../lib/iptv/types";
+
+    const ALL_GROUPS = "__all__";
+    const IPTV_EXAMPLE_M3U_URL = (
+        import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_M3U_URL as string | undefined
+    )?.trim();
+    const IPTV_EXAMPLE_EPG_URL = (
+        import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_EPG_URL as string | undefined
+    )?.trim();
+    const IPTV_EXAMPLE =
+        IPTV_EXAMPLE_M3U_URL && IPTV_EXAMPLE_EPG_URL
+            ? {
+                  name: "IPTV Example",
+                  m3uUrl: IPTV_EXAMPLE_M3U_URL,
+                  epgUrl: IPTV_EXAMPLE_EPG_URL,
+              }
+            : null;
+
+    let selectedSourceId = "";
+    let loadedSourceId = "";
+    let refreshResult: IptvRefreshResult | null = null;
+    let refreshing = false;
+    let refreshError = "";
+    let formError = "";
+    let editingSourceId: string | null = null;
+    let formName = "";
+    let formM3uUrl = "";
+    let formEpgUrl = "";
+    let selectedGroup = ALL_GROUPS;
+    let searchQuery = "";
+    let guideNow = new Date();
+    let guideTimer: ReturnType<typeof setInterval> | null = null;
+
+    const isDev = import.meta.env.DEV;
+
+    $: selectedSource =
+        $iptvSources.find((source) => source.id === selectedSourceId) ?? null;
+    $: currentResult =
+        refreshResult && loadedSourceId === selectedSourceId ? refreshResult : null;
+    $: availableGroups = currentResult?.groups ?? [];
+    $: sourceSummary = currentResult
+        ? `${currentResult.stats.channelCount} channels / ${currentResult.stats.groupCount} groups`
+        : "";
+    $: visibleChannels = getVisibleChannels(
+        currentResult?.channels ?? [],
+        selectedGroup,
+        searchQuery,
+    );
+    $: if (!selectedSourceId && $iptvSources.length > 0) {
+        selectedSourceId = $iptvSources[0].id;
+    }
+    $: if (selectedSourceId && !$iptvSources.some((source) => source.id === selectedSourceId)) {
+        selectedSourceId = $iptvSources[0]?.id ?? "";
+    }
+    $: if (
+        selectedGroup !== ALL_GROUPS &&
+        !availableGroups.some((group) => group.name === selectedGroup)
+    ) {
+        selectedGroup = ALL_GROUPS;
+    }
+
+    function getVisibleChannels(
+        channels: IptvChannel[],
+        group: string,
+        query: string,
+    ) {
+        const normalizedQuery = query.trim().toLowerCase();
+        return channels.filter((channel) => {
+            if (group !== ALL_GROUPS && channel.group !== group) return false;
+            if (!normalizedQuery) return true;
+
+            return (
+                channel.name.toLowerCase().includes(normalizedQuery) ||
+                channel.group.toLowerCase().includes(normalizedQuery) ||
+                (channel.tvgName ?? "").toLowerCase().includes(normalizedQuery) ||
+                (channel.tvgId ?? "").toLowerCase().includes(normalizedQuery)
+            );
+        });
+    }
+
+    function resetForm() {
+        editingSourceId = null;
+        formName = "";
+        formM3uUrl = "";
+        formEpgUrl = "";
+        formError = "";
+    }
+
+    function editSource(source: IptvSource) {
+        editingSourceId = source.id;
+        formName = source.name;
+        formM3uUrl = source.m3uUrl;
+        formEpgUrl = source.epgUrl ?? "";
+        formError = "";
+    }
+
+    function fillDispatcharrExample() {
+        if (!IPTV_EXAMPLE) return;
+        formName = IPTV_EXAMPLE.name;
+        formM3uUrl = IPTV_EXAMPLE.m3uUrl;
+        formEpgUrl = IPTV_EXAMPLE.epgUrl;
+        formError = "";
+    }
+
+    function saveSource() {
+        try {
+            if (editingSourceId) {
+                const updated = updateIptvSource(editingSourceId, {
+                    name: formName,
+                    m3uUrl: formM3uUrl,
+                    epgUrl: formEpgUrl,
+                });
+                if (!updated) {
+                    throw new Error("The selected IPTV source no longer exists");
+                }
+                selectedSourceId = updated.id;
+                trackEvent("iptv_source_updated");
+            } else {
+                const source = addIptvSource({
+                    name: formName,
+                    m3uUrl: formM3uUrl,
+                    epgUrl: formEpgUrl,
+                });
+                selectedSourceId = source.id;
+                trackEvent("iptv_source_added");
+            }
+            resetForm();
+        } catch (error) {
+            formError = error instanceof Error ? error.message : String(error);
+        }
+    }
+
+    function deleteSource(source: IptvSource) {
+        const confirmed =
+            typeof window === "undefined" ||
+            window.confirm(`Remove IPTV source "${source.name}"?`);
+        if (!confirmed) return;
+
+        removeIptvSource(source.id);
+        if (loadedSourceId === source.id) {
+            loadedSourceId = "";
+            refreshResult = null;
+        }
+        if (editingSourceId === source.id) {
+            resetForm();
+        }
+        trackEvent("iptv_source_removed");
+    }
+
+    async function refreshSelectedSource() {
+        if (!selectedSource) {
+            refreshError = "No IPTV source configured";
+            return;
+        }
+
+        refreshing = true;
+        refreshError = "";
+
+        try {
+            const result = await refreshIptvSource(selectedSource);
+            refreshResult = result;
+            loadedSourceId = selectedSource.id;
+            selectedGroup = ALL_GROUPS;
+            trackEvent("iptv_source_refreshed", {
+                channel_count: result.stats.channelCount,
+                group_count: result.stats.groupCount,
+                programme_count: result.stats.programmeCount,
+                has_epg: Boolean(result.guide),
+            });
+        } catch (error) {
+            refreshError = error instanceof Error ? error.message : String(error);
+            trackEvent("iptv_source_refresh_failed", {
+                error_name: error instanceof Error ? error.name : "unknown",
+            });
+        } finally {
+            refreshing = false;
+        }
+    }
+
+    function getChannelGuide(channel: IptvChannel) {
+        if (!currentResult?.guide) return { now: null, next: null };
+        return getNowNext(channel, currentResult.guide, guideNow);
+    }
+
+    function playChannel(channel: IptvChannel) {
+        const nowNext = getChannelGuide(channel);
+        trackEvent("live_channel_opened", {
+            group: channel.group,
+            has_logo: Boolean(channel.logo),
+            has_programme: Boolean(nowNext.now),
+        });
+        router.navigate("player", {
+            videoSrc: channel.url,
+            startTime: 0,
+            metaData: null,
+            fileIdx: null,
+            season: null,
+            episode: null,
+            liveMode: true,
+            liveChannel: {
+                name: channel.name,
+                group: channel.group,
+                logo: channel.logo ?? null,
+                tvgId: channel.tvgId ?? null,
+                programmeTitle: nowNext.now?.title ?? null,
+            },
+        });
+    }
+
+    function formatTime(value: Date) {
+        return new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+        }).format(value);
+    }
+
+    function formatLoadedAt(value: string) {
+        return new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+        }).format(new Date(value));
+    }
+
+    function programmeText(programme: XmltvProgramme | null) {
+        if (!programme) return "";
+        return `${formatTime(programme.start)} ${programme.title}`;
+    }
+
+    onMount(() => {
+        guideTimer = setInterval(() => {
+            guideNow = new Date();
+        }, 60_000);
+    });
+
+    onDestroy(() => {
+        if (guideTimer) {
+            clearInterval(guideTimer);
+        }
+    });
+</script>
+
+<div class="min-h-screen bg-[#090909] text-white">
+    <div class="sticky top-0 z-40 border-b border-white/10 bg-[#090909]/92 backdrop-blur-xl">
+        <div class="flex items-center justify-between gap-6 px-8 py-5">
+            <div class="flex items-center gap-4 min-w-0">
+                <button
+                    class="flex h-12 w-12 items-center justify-center rounded-full bg-white/8 text-white/80 transition-colors hover:bg-white/14"
+                    aria-label="Back"
+                    onclick={() => {
+                        if (!router.back()) router.navigate("home");
+                    }}
+                >
+                    <ChevronLeft size={26} strokeWidth={2} />
+                </button>
+                <div class="flex items-center gap-3 min-w-0">
+                    <Tv size={28} strokeWidth={2} class="text-white/70" />
+                    <div class="min-w-0">
+                        <h1 class="truncate font-poppins text-[28px] font-semibold leading-tight">
+                            Live TV
+                        </h1>
+                        <p class="truncate text-sm text-white/48">
+                            {sourceSummary || "No channels loaded"}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex items-center gap-3">
+                {#if currentResult}
+                    <span class="hidden text-sm text-white/45 md:inline">
+                        Refreshed {formatLoadedAt(currentResult.loadedAt)}
+                    </span>
+                {/if}
+                <button
+                    class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88 disabled:cursor-not-allowed disabled:opacity-45"
+                    disabled={!selectedSource || refreshing}
+                    onclick={refreshSelectedSource}
+                >
+                    {#if refreshing}
+                        <LoadingSpinner size="16px" color="#111111" />
+                    {:else}
+                        <RefreshCw size={17} strokeWidth={2.4} />
+                    {/if}
+                    Refresh
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="grid min-h-[calc(100vh-89px)] grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <aside class="border-b border-white/10 bg-[#111111] p-6 lg:border-b-0 lg:border-r">
+            <section class="flex flex-col gap-4">
+                <div class="flex items-center justify-between gap-3">
+                    <h2 class="font-poppins text-lg font-semibold">
+                        Sources
+                    </h2>
+                    <button
+                        class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14"
+                        aria-label="Add source"
+                        onclick={resetForm}
+                    >
+                        <Plus size={18} strokeWidth={2.4} />
+                    </button>
+                </div>
+
+                {#if $iptvSources.length > 0}
+                    <select
+                        class="h-11 w-full rounded-lg border border-white/10 bg-black/35 px-3 text-sm text-white outline-none focus:border-white/35"
+                        bind:value={selectedSourceId}
+                    >
+                        {#each $iptvSources as source}
+                            <option value={source.id}>{source.name}</option>
+                        {/each}
+                    </select>
+                {:else}
+                    <div class="rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/56">
+                        No source configured
+                    </div>
+                {/if}
+
+                {#if selectedSource}
+                    <div class="flex gap-2">
+                        <button
+                            class="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-white/8 text-sm text-white/76 transition-colors hover:bg-white/14"
+                            onclick={() => editSource(selectedSource)}
+                        >
+                            <Pencil size={16} strokeWidth={2.2} />
+                            Edit
+                        </button>
+                        <button
+                            class="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-white/8 text-sm text-white/76 transition-colors hover:bg-white/14"
+                            onclick={() => deleteSource(selectedSource)}
+                        >
+                            <Trash2 size={16} strokeWidth={2.2} />
+                            Remove
+                        </button>
+                    </div>
+                {/if}
+            </section>
+
+            <section class="mt-8 flex flex-col gap-4">
+                <h2 class="font-poppins text-lg font-semibold">
+                    {editingSourceId ? "Edit Source" : "Add Source"}
+                </h2>
+                <label class="flex flex-col gap-2 text-sm text-white/62">
+                    Name
+                    <input
+                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                        bind:value={formName}
+                    />
+                </label>
+                <label class="flex flex-col gap-2 text-sm text-white/62">
+                    M3U URL
+                    <input
+                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                        bind:value={formM3uUrl}
+                        inputmode="url"
+                    />
+                </label>
+                <label class="flex flex-col gap-2 text-sm text-white/62">
+                    XMLTV URL
+                    <input
+                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                        bind:value={formEpgUrl}
+                        inputmode="url"
+                    />
+                </label>
+
+                {#if formError}
+                    <div class="rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                        {formError}
+                    </div>
+                {/if}
+
+                <div class="flex gap-2">
+                    <button
+                        class="h-11 flex-1 rounded-lg bg-white text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                        onclick={saveSource}
+                    >
+                        {editingSourceId ? "Save" : "Add"}
+                    </button>
+                    {#if editingSourceId}
+                        <button
+                            class="h-11 flex-1 rounded-lg bg-white/8 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14"
+                            onclick={resetForm}
+                        >
+                            Cancel
+                        </button>
+                    {/if}
+                </div>
+
+                {#if isDev && IPTV_EXAMPLE}
+                    <button
+                        class="h-10 rounded-lg border border-white/10 text-sm text-white/60 transition-colors hover:bg-white/8 hover:text-white/82"
+                        onclick={fillDispatcharrExample}
+                    >
+                        Use IPTV example
+                    </button>
+                {/if}
+            </section>
+        </aside>
+
+        <main class="min-w-0 p-6 lg:p-8">
+            <div class="mb-5 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                <div class="flex min-w-0 flex-1 flex-col gap-3 md:flex-row">
+                    <div class="relative min-w-0 flex-1">
+                        <Search
+                            size={19}
+                            strokeWidth={2.1}
+                            class="absolute left-3 top-1/2 -translate-y-1/2 text-white/42"
+                        />
+                        <input
+                            class="h-12 w-full rounded-lg border border-white/10 bg-white/[0.04] pl-10 pr-3 text-white outline-none focus:border-white/35"
+                            placeholder="Search channels"
+                            bind:value={searchQuery}
+                        />
+                    </div>
+
+                    <select
+                        class="h-12 min-w-[220px] rounded-lg border border-white/10 bg-white/[0.04] px-3 text-white outline-none focus:border-white/35"
+                        bind:value={selectedGroup}
+                    >
+                        <option value={ALL_GROUPS}>All groups</option>
+                        {#each availableGroups as group}
+                            <option value={group.name}>
+                                {group.name} ({group.channelCount})
+                            </option>
+                        {/each}
+                    </select>
+                </div>
+
+                {#if currentResult}
+                    <div class="text-sm text-white/45">
+                        Showing {visibleChannels.length} of {currentResult.stats.channelCount}
+                    </div>
+                {/if}
+            </div>
+
+            {#if refreshError}
+                <div class="mb-5 rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                    {refreshError}
+                </div>
+            {/if}
+
+            {#if refreshing}
+                <div class="flex h-[52vh] items-center justify-center">
+                    <div class="flex flex-col items-center gap-4 text-white/64">
+                        <LoadingSpinner size="46px" />
+                        <span>Refreshing channels</span>
+                    </div>
+                </div>
+            {:else if !selectedSource}
+                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
+                    No source configured
+                </div>
+            {:else if !currentResult}
+                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
+                    No channels loaded
+                </div>
+            {:else if visibleChannels.length === 0}
+                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
+                    No channels match
+                </div>
+            {:else}
+                <div class="grid grid-cols-1 gap-3 2xl:grid-cols-2">
+                    {#each visibleChannels as channel (channel.id)}
+                        {@const guide = getChannelGuide(channel)}
+                        <button
+                            class="grid min-h-[92px] grid-cols-[58px_minmax(0,1fr)_auto] items-center gap-4 rounded-lg border border-white/8 bg-white/[0.035] px-4 py-3 text-left transition-colors hover:border-white/20 hover:bg-white/[0.07]"
+                            onclick={() => playChannel(channel)}
+                        >
+                            <div class="flex h-[58px] w-[58px] items-center justify-center overflow-hidden rounded-md bg-black/45">
+                                {#if channel.logo}
+                                    <img
+                                        src={channel.logo}
+                                        alt=""
+                                        class="max-h-full max-w-full object-contain"
+                                        loading="lazy"
+                                        onerror={(event) => {
+                                            (event.currentTarget as HTMLImageElement).style.display = "none";
+                                        }}
+                                    />
+                                {:else}
+                                    <Tv size={24} strokeWidth={2} class="text-white/35" />
+                                {/if}
+                            </div>
+
+                            <div class="min-w-0">
+                                <div class="flex items-center gap-2">
+                                    {#if channel.number}
+                                        <span class="shrink-0 rounded bg-white/8 px-2 py-0.5 text-xs tabular-nums text-white/52">
+                                            {channel.number}
+                                        </span>
+                                    {/if}
+                                    <span class="truncate font-poppins text-[17px] font-medium text-white">
+                                        {channel.name}
+                                    </span>
+                                </div>
+                                <div class="mt-1 truncate text-sm text-white/45">
+                                    {channel.group}
+                                </div>
+                                {#if guide.now}
+                                    <div class="mt-2 truncate text-sm text-white/72">
+                                        {programmeText(guide.now)}
+                                    </div>
+                                {/if}
+                                {#if guide.next}
+                                    <div class="mt-1 truncate text-xs text-white/42">
+                                        Next: {programmeText(guide.next)}
+                                    </div>
+                                {/if}
+                            </div>
+
+                            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-black">
+                                <Play size={18} strokeWidth={2.4} fill="currentColor" />
+                            </div>
+                        </button>
+                    {/each}
+                </div>
+            {/if}
+        </main>
+    </div>
+</div>

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -94,7 +94,7 @@
         type NextEpisodePrefetchHandoff,
     } from "./nextEpisodePrefetch";
     import { serverUrl } from "../../lib/client";
-    import type { Chapter } from "./types";
+    import type { Chapter, LiveChannelMetadata } from "./types";
 
     // Props
     export let videoSrc: string | null = null;
@@ -111,10 +111,14 @@
     export let joinPartyId: string | null = null;
     export let autoJoin: boolean = false;
     export let autoSkipFromNextEpisode: boolean = false;
+    export let liveMode: boolean = false;
+    export let liveChannel: LiveChannelMetadata | null = null;
 
-    const imdbID = metaData?.meta?.imdb_id || null;
+    let imdbID: string | null = null;
+    $: imdbID = liveMode ? null : metaData?.meta?.imdb_id || null;
 
     const handleProgressInternal = (time: number, dur: number) => {
+        if (liveMode) return;
         if (onProgress) {
             onProgress(time, dur);
         } else if (imdbID) {
@@ -123,6 +127,7 @@
     };
 
     const handleNextEpisodeInternal = () => {
+        if (liveMode) return;
         if (onNextEpisode) {
             return onNextEpisode();
         }
@@ -247,6 +252,9 @@
     const getBrowserPlaybackDetails = () => {
         const src = currentVideoSrc || videoSrc || "";
         const support = src ? Session.getDirectMediaSupport(src, videoElem) : null;
+        if (liveMode) {
+            return "This live stream may use a container or codec this player cannot decode.";
+        }
         const altStreamHint = isDesktopPlatform
             ? "Try an MP4, WebM, or HLS stream. MKV/E-AC-3/DTS streams can be remuxed via the local playback server's transcoder settings."
             : "Try an MP4, WebM, or HLS stream, or use the desktop app for MKV/E-AC-3/DTS streams.";
@@ -265,8 +273,10 @@
         loading.set(false);
         showCanvas.set(false);
         showError.set(true);
-        errorMessage.set("Browser cannot play this stream");
-        errorDetails.set(`${reason} ${getBrowserPlaybackDetails()}`);
+        errorMessage.set(liveMode ? "Live stream failed" : "Browser cannot play this stream");
+        errorDetails.set(
+            `${liveMode && liveChannel?.name ? `${liveChannel.name}: ` : ""}${reason} ${getBrowserPlaybackDetails()}`,
+        );
         trackEvent("browser_direct_stream_failed", {
             reason,
             ...getPlaybackAnalyticsProps(),
@@ -292,7 +302,7 @@
     };
 
     const openWatchPartyModal = () => {
-        if (embedSrc || $localMode || !$cloudSyncStatus.cloudFeaturesAvailable) {
+        if (liveMode || embedSrc || $localMode || !$cloudSyncStatus.cloudFeaturesAvailable) {
             showWatchPartyModal.set(false);
             return;
         }
@@ -324,6 +334,7 @@
             season,
             episode,
             watchPartyActive: $watchParty.isActive,
+            liveMode,
         });
 
     const trackPlaybackClosed = () => {
@@ -354,6 +365,7 @@
     };
 
     const handleEmbedMessage = (event: MessageEvent) => {
+        if (liveMode) return;
         if (!embedSrc || !imdbID || !metaData) return;
 
         const data = parseEmbedMessageData(event.data);
@@ -453,10 +465,10 @@
 
     const handleClose = async () => {
         getWindowControls()?.exitMiniPlayer?.();
-        if (imdbID) {
+        if (!liveMode && imdbID) {
             void flushPendingLibraryProgress(imdbID);
         }
-        if (hasStarted && !traktScrobbler.isStopSent()) {
+        if (!liveMode && hasStarted && !traktScrobbler.isStopSent()) {
             void traktScrobbler.send("stop", true);
         }
         trackPlaybackClosed();
@@ -504,7 +516,7 @@
     });
 
     const computeHasNextEpisode = (): boolean => {
-        if (!metaData || metaData.meta?.type !== "series") return false;
+        if (liveMode || !metaData || metaData.meta?.type !== "series") return false;
         const videos: any[] = Array.isArray((metaData as any).meta?.videos)
             ? ((metaData as any).meta.videos as any[])
             : [];
@@ -522,6 +534,7 @@
     $: hasNextEpisode = computeHasNextEpisode();
 
     $: bingeNextSupported =
+        !liveMode &&
         metaData?.meta?.type === "series" &&
         Boolean($selectedStream?.behaviorHints?.bingeGroup) &&
         !$watchParty.isActive;
@@ -532,7 +545,7 @@
         introDbChapters,
     );
 
-    $: showNextEpisodeAllowed = $showNextEpisode && hasNextEpisode;
+    $: showNextEpisodeAllowed = !liveMode && $showNextEpisode && hasNextEpisode;
 
     const disposeNextEpisodePrefetch = (opts?: { transfer?: boolean }) => {
         nextEpisodePrefetchRunId += 1;
@@ -600,7 +613,7 @@
         },
         getSessionId: () => sessionId,
         getCueLinePercent: () => cueLinePercent,
-        shouldShowSeekStyleInfoModal,
+        shouldShowSeekStyleInfoModal: () => !liveMode && shouldShowSeekStyleInfoModal(),
         setPendingStartAfterSeekStyleModal: (value) => {
             pendingStartAfterSeekStyleModal = value;
         },
@@ -609,6 +622,13 @@
             introDbChapters = chapters;
         },
         resolvePlaybackStart: async ({ sessionData, startTime, metaData, season, episode }) => {
+            if (liveMode) {
+                return {
+                    effectiveStartTime: 0,
+                    introDbChapters: [],
+                };
+            }
+
             let nextIntroDbChapters: Chapter[] = [];
 
             if (metaData?.meta?.type === "series" && metaData.meta.imdb_id && season != null && episode != null) {
@@ -690,7 +710,7 @@
 
         if ($showSeekStyleModal) return;
 
-        if (shouldShowSeekStyleInfoModal()) {
+        if (!liveMode && shouldShowSeekStyleInfoModal()) {
             showSeekStyleModal.set(true);
             pendingStartAfterSeekStyleModal = true;
             return;
@@ -806,6 +826,7 @@
 
         metadataCheckInterval = setInterval(() => {
             if (!videoElem) return;
+            if (liveMode) return;
 
             const currentTime = videoElem.currentTime;
             const durationVal = videoElem.duration;
@@ -847,10 +868,10 @@
             canEnter: false,
         });
         getWindowControls()?.exitMiniPlayer?.();
-        if (imdbID) {
+        if (!liveMode && imdbID) {
             void flushPendingLibraryProgress(imdbID);
         }
-        if (hasStarted && !traktScrobbler.isStopSent()) {
+        if (!liveMode && hasStarted && !traktScrobbler.isStopSent()) {
             void traktScrobbler.send("stop", true);
         }
         trackPlaybackClosed();
@@ -881,9 +902,12 @@
         }
         const time = $playbackOffset + videoElem.currentTime;
         currentTime.set(time);
-        handleProgressInternal(time, $duration);
+        if (!liveMode) {
+            handleProgressInternal(time, $duration);
+        }
 
         if (
+            !liveMode &&
             !traktScrobbler.isStopSent() &&
             $duration > 0 &&
             time / $duration >= TRAKT_COMPLETION_THRESHOLD
@@ -891,7 +915,7 @@
             void traktScrobbler.send("stop", true);
         }
 
-        if (!$seekGuard) {
+        if (!liveMode && !$seekGuard) {
             const result = Chapters.checkChapters(
                 time,
                 $sessionData,
@@ -974,7 +998,9 @@
     const handlePlay = () => {
         isPlaying.set(true);
         hasStarted = true;
-        void traktScrobbler.send("start");
+        if (!liveMode) {
+            void traktScrobbler.send("start");
+        }
         if (!playbackStartTracked) {
             trackEvent("playback_started", getPlaybackAnalyticsProps());
             playbackStartTracked = true;
@@ -995,6 +1021,7 @@
     const handlePause = () => {
         isPlaying.set(false);
         if (
+            !liveMode &&
             !traktScrobbler.isStopSent() &&
             !(
                 $duration > 0 &&
@@ -1070,6 +1097,7 @@
     };
 
     const handleSkipIntro = () => {
+        if (liveMode) return;
         trackEvent("skip_chapter_clicked", {
             chapter_kind: $currentChapter?.kind || null,
             chapter_source: $currentChapter?.source || null,
@@ -1092,10 +1120,10 @@
     });
 
     const handleEnded = () => {
-        if (hasStarted && !traktScrobbler.isStopSent()) {
+        if (!liveMode && hasStarted && !traktScrobbler.isStopSent()) {
             void traktScrobbler.send("stop", true);
         }
-        if (bingeNextSupported && hasNextEpisode && !bingeAutoAdvancing) {
+        if (!liveMode && bingeNextSupported && hasNextEpisode && !bingeAutoAdvancing) {
             bingeAutoAdvancing = true;
             handleNextEpisodeClick();
         }
@@ -1179,6 +1207,7 @@
 
         const handoff = nextEpisodePrefetchHandoff;
         const canReuseHandoff =
+            !liveMode &&
             handoff &&
             handoff.src === videoSrc &&
             handoff.fileIdx === fileIdx &&
@@ -1202,7 +1231,9 @@
         loadVideo(videoSrc, reuseSession ? { reuseSession } : undefined);
     }
 
-    $: effectiveChapterMarkers = Chapters.getEffectiveChapterSegments($sessionData, introDbChapters);
+    $: effectiveChapterMarkers = liveMode
+        ? []
+        : Chapters.getEffectiveChapterSegments($sessionData, introDbChapters);
 
     $: if (videoElem) {
         videoElem.muted = false;
@@ -1237,12 +1268,12 @@
         resizeCounter += 1;
     }
 
-    $: if (pendingAutoJoin && joinPartyId && autoJoin && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable) {
+    $: if (!liveMode && pendingAutoJoin && joinPartyId && autoJoin && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable) {
         showWatchPartyModal.set(true);
         pendingAutoJoin = false;
     }
 
-    $: if ($showWatchPartyModal && (embedSrc || !$cloudSyncStatus.cloudFeaturesAvailable)) {
+    $: if ($showWatchPartyModal && (liveMode || embedSrc || !$cloudSyncStatus.cloudFeaturesAvailable)) {
         showWatchPartyModal.set(false);
     }
 
@@ -1390,6 +1421,7 @@
         loading={$loading && !miniPlayerActive}
         onClose={handleClose}
         {metaData}
+        liveTitle={liveMode ? liveChannel?.name ?? "Live TV" : null}
         backdropSrc={loadingBackdropSrc}
         backdropMode={loadingBackdropMode}
         stage={$loadingStage}
@@ -1419,7 +1451,7 @@
                 <PlayerOverlays
                     showSkipIntro={$showSkipIntro}
                     showNextEpisode={showNextEpisodeAllowed}
-                    isWatchPartyMember={!$localMode && $watchParty.isActive && !$watchParty.isHost}
+                    isWatchPartyMember={!liveMode && !$localMode && $watchParty.isActive && !$watchParty.isHost}
                     skipLabel={skipButtonLabel}
                     skipChapter={handleSkipIntro}
                     nextEpisode={handleNextEpisodeClick}
@@ -1442,10 +1474,10 @@
                         {sessionId}
                         {videoSrc}
                         {metaData}
-                        {hasNextEpisode}
+                        hasNextEpisode={!liveMode && hasNextEpisode}
                         currentAudioLabel={$currentAudioLabel}
                         currentSubtitleLabel={$currentSubtitleLabel}
-                        isWatchPartyMember={!$localMode && $watchParty.isActive && !$watchParty.isHost}
+                        isWatchPartyMember={!liveMode && !$localMode && $watchParty.isActive && !$watchParty.isHost}
                         togglePlay={togglePlayWithFeedback}
                         onSeekInput={(e) =>
                             controlsManager.onSeekInput(e, $duration, pendingSeek.set)}
@@ -1456,11 +1488,11 @@
                         objectFit={$objectFit}
                         toggleObjectFit={handleToggleObjectFit}
                         onNextEpisode={handleNextEpisodeClick}
-                        showWatchParty={!$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
+                        showWatchParty={!liveMode && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
                         onAudioClick={openAudioSelection}
                         onSubtitleClick={openSubtitleSelection}
                         onWatchPartyClick={() => {
-                            if (!$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc) {
+                            if (!liveMode && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc) {
                                 openWatchPartyModal();
                             } else {
                                 showWatchPartyModal.set(false);
@@ -1484,7 +1516,7 @@
         showAudioSelection={$showAudioSelection}
         showSubtitleSelection={$showSubtitleSelection}
         showError={$showError}
-        showWatchPartyModal={$showWatchPartyModal && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
+        showWatchPartyModal={$showWatchPartyModal && !liveMode && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
         showSeekStyleModal={$showSeekStyleModal}
         audioTracks={$audioTracks}
         subtitleTracks={$subtitleTracks}

--- a/packages/app/src/pages/player/components/PlayerLoadingScreen.svelte
+++ b/packages/app/src/pages/player/components/PlayerLoadingScreen.svelte
@@ -21,6 +21,7 @@
     export let loading: boolean;
     export let onClose: () => void;
     export let metaData: ShowResponse | null;
+    export let liveTitle: string | null = null;
 
 	export let stage: string = "Loading...";
 	export let details: string = "";
@@ -58,6 +59,15 @@
                     alt="Logo"
                     class="w-100 object-contain animate-pulse drop-shadow-[0_10px_40px_rgba(0,0,0,0.45)]"
                 />
+            </div>
+        {:else if liveTitle}
+            <div class="relative z-10 flex flex-col items-center gap-2 px-8 text-center">
+                <div class="text-white/92 text-[28px] font-poppins font-semibold leading-tight">
+                    {liveTitle}
+                </div>
+                <div class="text-white/55 text-[14px] uppercase tracking-[0.18em]">
+                    Live TV
+                </div>
             </div>
         {/if}
 

--- a/packages/app/src/pages/player/playerAnalytics.ts
+++ b/packages/app/src/pages/player/playerAnalytics.ts
@@ -14,6 +14,7 @@ export const getPlaybackAnalyticsProps = ({
     season,
     episode,
     watchPartyActive,
+    liveMode,
 }: {
     currentVideoSrc: string | null;
     sessionData: any;
@@ -23,8 +24,9 @@ export const getPlaybackAnalyticsProps = ({
     season: number | null;
     episode: number | null;
     watchPartyActive: boolean;
+    liveMode?: boolean;
 }) => {
-    const sourceType = getPlaybackSourceType(currentVideoSrc, sessionData);
+    const sourceType = liveMode ? "live" : getPlaybackSourceType(currentVideoSrc, sessionData);
     const isTorrent = sourceType === "torrent";
     const isLocal = sourceType === "local";
     const progressPercent = duration > 0 ? Math.round((currentTime / duration) * 100) : null;
@@ -34,6 +36,7 @@ export const getPlaybackAnalyticsProps = ({
         is_torrent: isTorrent,
         is_local: isLocal,
         content_type: metaData?.meta?.type ?? null,
+        live_mode: Boolean(liveMode),
         season: season ?? null,
         episode: episode ?? null,
         watch_party: watchPartyActive,

--- a/packages/app/src/pages/player/types.ts
+++ b/packages/app/src/pages/player/types.ts
@@ -32,6 +32,14 @@ export interface SessionData {
     audioIndex?: number;
 }
 
+export interface LiveChannelMetadata {
+    name: string;
+    group?: string | null;
+    logo?: string | null;
+    tvgId?: string | null;
+    programmeTitle?: string | null;
+}
+
 export interface SeekFeedback {
     type: "forward" | "backward";
     id: number;

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -21,5 +21,8 @@
     "src/**/*.ts",
     "src/**/*.js",
     "src/**/*.svelte"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
   ]
 }

--- a/scripts/smoke-iptv-dispatcharr.mjs
+++ b/scripts/smoke-iptv-dispatcharr.mjs
@@ -1,0 +1,84 @@
+import { parseM3U } from "../packages/app/src/lib/iptv/m3u.ts";
+import { getNowNext, getProgrammeCount, parseXmltv } from "../packages/app/src/lib/iptv/xmltv.ts";
+
+const MAX_M3U_BYTES = 64 * 1024 * 1024;
+const MAX_EPG_BYTES = 128 * 1024 * 1024;
+
+function requireEnv(name) {
+    const value = String(process.env[name] || "").trim();
+    if (!value) {
+        throw new Error(`${name} is required`);
+    }
+    return value;
+}
+
+async function fetchText(label, target, maxBytes) {
+    let response;
+    try {
+        response = await fetch(target, { redirect: "follow" });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`${label} fetch failed before HTTP response: ${message}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+
+    if (arrayBuffer.byteLength > maxBytes) {
+        throw new Error("IPTV response exceeded maximum size");
+    }
+
+    return {
+        status: response.status,
+        ok: response.ok,
+        text: new TextDecoder("utf-8").decode(arrayBuffer),
+    };
+}
+
+async function main() {
+    const m3uUrl = requireEnv("IPTV_M3U_URL");
+    const epgUrl = requireEnv("IPTV_EPG_URL");
+
+    const m3u = await fetchText("M3U", m3uUrl, MAX_M3U_BYTES);
+    if (!m3u.ok) {
+        throw new Error(`M3U fetch failed with HTTP ${m3u.status}`);
+    }
+
+    const parsed = parseM3U(m3u.text, "smoke");
+
+    const epg = await fetchText("EPG", epgUrl, MAX_EPG_BYTES);
+    if (!epg.ok) {
+        throw new Error(`EPG fetch failed with HTTP ${epg.status}`);
+    }
+
+    const guide = parseXmltv(epg.text);
+    const sampleChannels = parsed.channels.slice(0, 50);
+    const nowNextMatchesInFirst50 = sampleChannels.filter((channel) => {
+        const match = getNowNext(channel, guide);
+        return Boolean(match.now || match.next);
+    }).length;
+
+    console.log(
+        JSON.stringify(
+            {
+                m3uStatus: m3u.status,
+                channelCount: parsed.channels.length,
+                groupCount: parsed.groups.length,
+                epgStatus: epg.status,
+                programmeCount: getProgrammeCount(guide),
+                nowNextMatchesInFirst50,
+            },
+            null,
+            2,
+        ),
+    );
+}
+
+main().catch((error) => {
+    console.error(
+        JSON.stringify({
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+        }),
+    );
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds native IPTV / M3U Live TV support with XMLTV guide data and a TV-guide-style EPG grid.

## Highlights

- Add IPTV source management for M3U + XMLTV URLs
- Parse and refresh IPTV playlists
- Parse XMLTV guide metadata
- Persist refreshed channel/group state locally
- Add Live TV guide grid:
  - channel/logo rail
  - horizontal programme blocks
  - current-time marker
  - current/future programme styling
- Add regression tests for IPTV cache and EPG layout

## Verification

- `bun test packages/app/src/lib/iptv/guideGrid.test.ts packages/app/src/lib/iptv/*.test.ts`
- `bun run check:app`
- `bun run check:desktop`
- `bun run build:desktop`
- Packaged and verified in a macOS VM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Live TV support with complete IPTV source management capabilities
  * Interactive electronic program guide displaying real-time channel schedules and current/upcoming programs
  * Live channel discovery with group filtering, search, and channel logos
  * Convenient Live TV access button in the search interface
  * Seamless integration with the player for live stream playback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->