### PR TITLE
Add native IPTV Live TV support

### DIFF
--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -29,6 +29,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('SHOW_ALERT_DIALOG', { message, title }),
     showSelectDialog: (message, title, options) =>
         ipcRenderer.invoke('SHOW_SELECT_DIALOG', { message, title, options }),
+    iptvFetchText: (url, options) =>
+        ipcRenderer.invoke('IPTV_FETCH_TEXT', { url, options }),
     fetchIntroDbSegments: (imdbId, season, episode) =>
         ipcRenderer.invoke('INTRODB_FETCH_SEGMENTS', { imdbId, season, episode }),
     localLibrary: {

--- a/apps/desktop/electron/services/mainIpc.cjs
+++ b/apps/desktop/electron/services/mainIpc.cjs
@@ -1,5 +1,8 @@
 const dns = require("dns").promises;
+const http = require("http");
+const https = require("https");
 const net = require("net");
+const { Readable } = require("stream");
 
 const IPTV_MAX_REDIRECTS = 5;
 const IPTV_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
@@ -30,6 +33,12 @@ iptvBlockedAddressList.addAddress("::", "ipv6");
 iptvBlockedAddressList.addAddress("::1", "ipv6");
 iptvBlockedAddressList.addSubnet("fe80::", 10, "ipv6");
 iptvBlockedAddressList.addSubnet("ff00::", 8, "ipv6");
+
+function createAbortError() {
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+}
 
 function normalizeIptvHostname(hostname) {
   let normalized = String(hostname || "").trim().toLowerCase();
@@ -85,7 +94,7 @@ async function assertSafeIptvFetchUrl(parsed) {
     if (isBlockedIptvAddress(hostname)) {
       throw new Error("IPTV URL host is not allowed");
     }
-    return;
+    return [{ address: hostname, family: net.isIP(hostname) }];
   }
 
   let addresses;
@@ -107,18 +116,142 @@ async function assertSafeIptvFetchUrl(parsed) {
       throw new Error("IPTV URL host is not allowed");
     }
   }
+
+  return addresses.map((entry) => ({
+    address: entry.address,
+    family: entry.family,
+  }));
+}
+
+function getIptvFetchPort(parsed) {
+  if (parsed.port) return parsed.port;
+  return parsed.protocol === "https:" ? "443" : "80";
+}
+
+function getIptvFetchAuth(parsed) {
+  if (!parsed.username && !parsed.password) return undefined;
+  return `${decodeURIComponent(parsed.username)}:${decodeURIComponent(parsed.password)}`;
+}
+
+function headersFromNodeHeaders(nodeHeaders) {
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(nodeHeaders)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+      continue;
+    }
+
+    if (value !== undefined) {
+      headers.set(name, String(value));
+    }
+  }
+
+  return headers;
+}
+
+function fetchIptvUrlAtResolvedAddress(parsed, resolvedAddress, signal) {
+  const client = parsed.protocol === "https:" ? https : http;
+  const hostname = normalizeIptvHostname(parsed.hostname);
+
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    let settled = false;
+    let request;
+    const cleanupRequestAbort = () => {
+      signal?.removeEventListener?.("abort", onRequestAbort);
+    };
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanupRequestAbort();
+      reject(error);
+    };
+    const onRequestAbort = () => {
+      request?.destroy(createAbortError());
+    };
+
+    request = client.request(
+      {
+        protocol: parsed.protocol,
+        hostname: resolvedAddress.address,
+        port: getIptvFetchPort(parsed),
+        path: `${parsed.pathname}${parsed.search}`,
+        method: "GET",
+        auth: getIptvFetchAuth(parsed),
+        headers: {
+          Host: parsed.host,
+        },
+        servername: parsed.protocol === "https:" && !net.isIP(hostname) ? hostname : undefined,
+      },
+      (incoming) => {
+        if (settled) {
+          incoming.destroy();
+          return;
+        }
+
+        settled = true;
+        cleanupRequestAbort();
+
+        const onBodyAbort = () => {
+          incoming.destroy(createAbortError());
+        };
+        if (signal?.aborted) {
+          incoming.destroy(createAbortError());
+        } else if (signal) {
+          signal.addEventListener("abort", onBodyAbort, { once: true });
+          incoming.once("close", () => {
+            signal.removeEventListener("abort", onBodyAbort);
+          });
+        }
+
+        const status = incoming.statusCode || 500;
+        const body = [204, 205, 304].includes(status) ? null : Readable.toWeb(incoming);
+        resolve(
+          new Response(body, {
+            status,
+            statusText: incoming.statusMessage,
+            headers: headersFromNodeHeaders(incoming.headers),
+          }),
+        );
+      },
+    );
+
+    request.once("error", fail);
+    signal?.addEventListener?.("abort", onRequestAbort, { once: true });
+    request.end();
+  });
 }
 
 async function getSafeIptvFetchResponse(initialUrl, signal) {
   let currentUrl = initialUrl;
 
   for (let redirectCount = 0; redirectCount <= IPTV_MAX_REDIRECTS; redirectCount += 1) {
-    await assertSafeIptvFetchUrl(currentUrl);
+    const resolvedAddresses = await assertSafeIptvFetchUrl(currentUrl);
+    let response;
+    let lastFetchError;
 
-    const response = await fetch(currentUrl.toString(), {
-      signal,
-      redirect: "manual",
-    });
+    for (const resolvedAddress of resolvedAddresses) {
+      try {
+        response = await fetchIptvUrlAtResolvedAddress(currentUrl, resolvedAddress, signal);
+        break;
+      } catch (error) {
+        lastFetchError = error;
+        if (error?.name === "AbortError") {
+          throw error;
+        }
+      }
+    }
+
+    if (!response) {
+      throw lastFetchError || new Error("IPTV URL host could not be reached");
+    }
 
     if (!IPTV_REDIRECT_STATUSES.has(response.status)) {
       return { response, url: currentUrl };
@@ -273,6 +406,7 @@ function registerMainIpcHandlers({
       const responseHost = normalizeIptvHostname(responseUrl.hostname);
 
       if (!response.ok) {
+        await response.body?.cancel?.().catch(() => {});
         logToFile("IPTV fetch failed", {
           host: responseHost,
           status: response.status,
@@ -284,6 +418,7 @@ function registerMainIpcHandlers({
       if (!reader) {
         const arrayBuffer = await response.arrayBuffer();
         if (arrayBuffer.byteLength > maxBytes) {
+          await response.body?.cancel?.().catch(() => {});
           throw new Error("IPTV response exceeded maximum size");
         }
         logToFile("IPTV fetch completed", {
@@ -307,6 +442,7 @@ function registerMainIpcHandlers({
         if (!value) continue;
         totalBytes += value.byteLength;
         if (totalBytes > maxBytes) {
+          await reader.cancel().catch(() => {});
           throw new Error("IPTV response exceeded maximum size");
         }
         chunks.push(Buffer.from(value));

--- a/apps/desktop/electron/services/mainIpc.cjs
+++ b/apps/desktop/electron/services/mainIpc.cjs
@@ -1,3 +1,147 @@
+const dns = require("dns").promises;
+const net = require("net");
+
+const IPTV_MAX_REDIRECTS = 5;
+const IPTV_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const IPTV_BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "ip6-localhost",
+  "ip6-loopback",
+  "loopback",
+  "broadcasthost",
+  "metadata",
+  "metadata.google.internal",
+  "instance-data",
+  "instance-data.ec2.internal",
+]);
+const IPTV_BLOCKED_HOSTNAME_SUFFIXES = [
+  ".localhost",
+  ".metadata.google.internal",
+];
+const iptvBlockedAddressList = new net.BlockList();
+iptvBlockedAddressList.addSubnet("0.0.0.0", 8, "ipv4");
+iptvBlockedAddressList.addSubnet("127.0.0.0", 8, "ipv4");
+iptvBlockedAddressList.addSubnet("169.254.0.0", 16, "ipv4");
+iptvBlockedAddressList.addSubnet("224.0.0.0", 4, "ipv4");
+iptvBlockedAddressList.addSubnet("240.0.0.0", 4, "ipv4");
+iptvBlockedAddressList.addSubnet("::", 96, "ipv6");
+iptvBlockedAddressList.addAddress("::", "ipv6");
+iptvBlockedAddressList.addAddress("::1", "ipv6");
+iptvBlockedAddressList.addSubnet("fe80::", 10, "ipv6");
+iptvBlockedAddressList.addSubnet("ff00::", 8, "ipv6");
+
+function normalizeIptvHostname(hostname) {
+  let normalized = String(hostname || "").trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    normalized = normalized.slice(1, -1);
+  }
+  return normalized.replace(/\.+$/, "");
+}
+
+function isBlockedIptvHostname(hostname) {
+  const normalized = normalizeIptvHostname(hostname);
+  return (
+    IPTV_BLOCKED_HOSTNAMES.has(normalized) ||
+    IPTV_BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+  );
+}
+
+function isBlockedIptvAddress(address) {
+  const normalized = normalizeIptvHostname(address);
+  const version = net.isIP(normalized);
+  if (!version) return true;
+  return iptvBlockedAddressList.check(normalized, version === 4 ? "ipv4" : "ipv6");
+}
+
+function parseIptvFetchUrl(target) {
+  let parsed;
+
+  try {
+    parsed = new URL(target);
+  } catch {
+    throw new Error("Enter a valid IPTV URL");
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http/https IPTV URLs are supported");
+  }
+
+  if (!normalizeIptvHostname(parsed.hostname)) {
+    throw new Error("Enter a valid IPTV URL");
+  }
+
+  return parsed;
+}
+
+async function assertSafeIptvFetchUrl(parsed) {
+  const hostname = normalizeIptvHostname(parsed.hostname);
+
+  if (isBlockedIptvHostname(hostname)) {
+    throw new Error("IPTV URL host is not allowed");
+  }
+
+  if (net.isIP(hostname)) {
+    if (isBlockedIptvAddress(hostname)) {
+      throw new Error("IPTV URL host is not allowed");
+    }
+    return;
+  }
+
+  let addresses;
+  try {
+    addresses = await dns.lookup(hostname, {
+      all: true,
+      verbatim: true,
+    });
+  } catch {
+    throw new Error("IPTV URL host could not be resolved");
+  }
+
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new Error("IPTV URL host could not be resolved");
+  }
+
+  for (const entry of addresses) {
+    if (isBlockedIptvAddress(entry.address)) {
+      throw new Error("IPTV URL host is not allowed");
+    }
+  }
+}
+
+async function getSafeIptvFetchResponse(initialUrl, signal) {
+  let currentUrl = initialUrl;
+
+  for (let redirectCount = 0; redirectCount <= IPTV_MAX_REDIRECTS; redirectCount += 1) {
+    await assertSafeIptvFetchUrl(currentUrl);
+
+    const response = await fetch(currentUrl.toString(), {
+      signal,
+      redirect: "manual",
+    });
+
+    if (!IPTV_REDIRECT_STATUSES.has(response.status)) {
+      return { response, url: currentUrl };
+    }
+
+    if (redirectCount >= IPTV_MAX_REDIRECTS) {
+      await response.body?.cancel?.().catch(() => {});
+      throw new Error("IPTV redirect limit exceeded");
+    }
+
+    const location = response.headers.get("location");
+    await response.body?.cancel?.().catch(() => {});
+
+    if (!location) {
+      throw new Error("IPTV redirect did not include a target");
+    }
+
+    currentUrl = parseIptvFetchUrl(new URL(location, currentUrl).toString());
+  }
+
+  throw new Error("IPTV redirect limit exceeded");
+}
+
 function registerMainIpcHandlers({
   ipcMain,
   dialog,
@@ -104,6 +248,89 @@ function registerMainIpcHandlers({
       status: response.status,
       data: await response.json(),
     };
+  });
+
+  ipcMain.handle("IPTV_FETCH_TEXT", async (_event, payload) => {
+    const target = typeof payload?.url === "string" ? payload.url.trim() : "";
+    const initialUrl = parseIptvFetchUrl(target);
+
+    const timeoutMs = Math.min(
+      Math.max(Number(payload?.options?.timeoutMs) || 30000, 1000),
+      120000,
+    );
+    const maxBytes = Math.min(
+      Math.max(Number(payload?.options?.maxBytes) || 64 * 1024 * 1024, 1024),
+      128 * 1024 * 1024,
+    );
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const { response, url: responseUrl } = await getSafeIptvFetchResponse(
+        initialUrl,
+        controller.signal,
+      );
+      const responseHost = normalizeIptvHostname(responseUrl.hostname);
+
+      if (!response.ok) {
+        logToFile("IPTV fetch failed", {
+          host: responseHost,
+          status: response.status,
+        });
+        throw new Error(`Fetch failed with HTTP ${response.status}`);
+      }
+
+      const reader = response.body?.getReader?.();
+      if (!reader) {
+        const arrayBuffer = await response.arrayBuffer();
+        if (arrayBuffer.byteLength > maxBytes) {
+          throw new Error("IPTV response exceeded maximum size");
+        }
+        logToFile("IPTV fetch completed", {
+          host: responseHost,
+          status: response.status,
+          bytes: arrayBuffer.byteLength,
+        });
+        return {
+          ok: true,
+          status: response.status,
+          text: Buffer.from(arrayBuffer).toString("utf8"),
+        };
+      }
+
+      const chunks = [];
+      let totalBytes = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+          throw new Error("IPTV response exceeded maximum size");
+        }
+        chunks.push(Buffer.from(value));
+      }
+
+      logToFile("IPTV fetch completed", {
+        host: responseHost,
+        status: response.status,
+        bytes: totalBytes,
+      });
+
+      return {
+        ok: true,
+        status: response.status,
+        text: Buffer.concat(chunks, totalBytes).toString("utf8"),
+      };
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new Error("IPTV fetch timed out");
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
   });
 
   ipcMain.handle("OPEN_EXTERNAL_URL", async (_event, targetUrl) => {

--- a/packages/app/src/App.svelte
+++ b/packages/app/src/App.svelte
@@ -2,6 +2,7 @@
     import Meta from "./pages/meta/Meta.svelte";
     import Home from "./pages/Home.svelte";
     import Player from "./pages/player/Player.svelte";
+    import LiveTV from "./pages/live/LiveTV.svelte";
     import { router } from "./lib/stores/router";
     import { onMount, tick } from "svelte";
     import { get } from "svelte/store";
@@ -28,6 +29,7 @@
         meta: Meta,
         player: Player,
         lists: Lists,
+        live: LiveTV,
     };
 
     type DecoderStatus = {

--- a/packages/app/src/components/home/SearchBar.svelte
+++ b/packages/app/src/components/home/SearchBar.svelte
@@ -27,7 +27,9 @@
         HOME_SEARCH_BAR_POSITION_BOTTOM,
         HOME_SEARCH_BAR_POSITION_CHANGED_EVENT,
         HOME_SEARCH_BAR_POSITION_HEADER,
+        HOME_LIVE_TV_SHORTCUT_CHANGED_EVENT,
         type HomeSearchBarPosition,
+        getStoredHomeLiveTvShortcutEnabled,
         getStoredHomeSearchBarPosition,
     } from "../../lib/home/searchBarSettings";
 
@@ -47,6 +49,7 @@
     let totalSearchResults = 0;
     let searchBarPositionPreference: HomeSearchBarPosition =
         HOME_SEARCH_BAR_POSITION_AUTO;
+    let liveTvShortcutEnabled = false;
     let autoDockToBottom = false;
     let searchDockBottom = false;
 
@@ -140,6 +143,10 @@
     function refreshSearchBarPositionPreference() {
         searchBarPositionPreference = getStoredHomeSearchBarPosition();
         updateAutoDockPosition();
+    }
+
+    function refreshLiveTvShortcutPreference() {
+        liveTvShortcutEnabled = getStoredHomeLiveTvShortcutEnabled();
     }
 
     const handleScrollOrResize = () => {
@@ -392,6 +399,7 @@
 
     onMount(() => {
         refreshSearchBarPositionPreference();
+        refreshLiveTvShortcutPreference();
         scrollContainer = document.querySelector(
             "[data-scroll-container]",
         ) as HTMLElement | null;
@@ -405,6 +413,10 @@
             HOME_SEARCH_BAR_POSITION_CHANGED_EVENT,
             refreshSearchBarPositionPreference,
         );
+        window.addEventListener(
+            HOME_LIVE_TV_SHORTCUT_CHANGED_EVENT,
+            refreshLiveTvShortcutPreference,
+        );
 
         return () => {
             (scrollContainer ?? window).removeEventListener(
@@ -415,6 +427,10 @@
             window.removeEventListener(
                 HOME_SEARCH_BAR_POSITION_CHANGED_EVENT,
                 refreshSearchBarPositionPreference,
+            );
+            window.removeEventListener(
+                HOME_LIVE_TV_SHORTCUT_CHANGED_EVENT,
+                refreshLiveTvShortcutPreference,
             );
         };
     });
@@ -730,13 +746,15 @@
             <Blocks size={40} strokeWidth={2} color="#C3C3C3" />
         </button>
 
-        <button
-            class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
-            aria-label="live tv"
-            onclick={openLiveTv}
-        >
-            <Tv size={40} strokeWidth={2} color="#C3C3C3" />
-        </button>
+        {#if liveTvShortcutEnabled}
+            <button
+                class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
+                aria-label="live tv"
+                onclick={openLiveTv}
+            >
+                <Tv size={40} strokeWidth={2} color="#C3C3C3" />
+            </button>
+        {/if}
 
         <button
             class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"

--- a/packages/app/src/components/home/SearchBar.svelte
+++ b/packages/app/src/components/home/SearchBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { Search, Link, Blocks, Library, Settings } from "@lucide/svelte";
+    import { Search, Link, Blocks, Library, Settings, Tv } from "@lucide/svelte";
     import {
         searchAddonTitlesSplit,
         searchTitlesSplit,
@@ -323,6 +323,11 @@
 	function openLists() {
 		trackEvent("lists_opened", { source: "search_bar" });
 		router.navigate("lists");
+	}
+
+	function openLiveTv() {
+		trackEvent("live_tv_opened", { source: "search_bar" });
+		router.navigate("live");
 	}
 
 	function openSettings() {
@@ -723,6 +728,14 @@
             onclick={openAddons}
         >
             <Blocks size={40} strokeWidth={2} color="#C3C3C3" />
+        </button>
+
+        <button
+            class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
+            aria-label="live tv"
+            onclick={openLiveTv}
+        >
+            <Tv size={40} strokeWidth={2} color="#C3C3C3" />
         </button>
 
         <button

--- a/packages/app/src/components/home/SearchBar.svelte
+++ b/packages/app/src/components/home/SearchBar.svelte
@@ -762,7 +762,7 @@
         {#if showPlayButton}
             <button
                 class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
-                aria-label="addons"
+                aria-label="play"
                 onclick={openPlayModal}
             >
                 <Link size={40} strokeWidth={2} color="#C3C3C3" />

--- a/packages/app/src/components/home/SearchBar.svelte
+++ b/packages/app/src/components/home/SearchBar.svelte
@@ -36,6 +36,17 @@
 
     export let onOpenAddons: () => void = () => {};
     export let onOpenSettings: () => void = () => {};
+    export let controlledSearch = false;
+    export let searchValue = "";
+    export let searchPlaceholder = "search for anything";
+    export let searchDisabled = false;
+    export let searchWidthClass = "w-[680px] max-w-[62vw]";
+    export let onSearchInput: (value: string) => void = () => {};
+    export let showPlayButton = true;
+    export let showAddonsButton = true;
+    export let showLiveTvButton = true;
+    export let showListsButton = true;
+    export let showSettingsButton = true;
 
     let searchQuery = "";
     let searchResults: SplitSearchResults = { movies: [], series: [] };
@@ -198,6 +209,12 @@
 
 	function handleSearch(e: Event) {
 		const query = (e.target as HTMLInputElement).value;
+        if (controlledSearch) {
+            searchValue = query;
+            onSearchInput(query);
+            return;
+        }
+
 		searchQuery = query;
 		commandHint = "";
 
@@ -288,6 +305,7 @@
 	}
 
 	const handleSearchKeydown = (event: KeyboardEvent) => {
+        if (controlledSearch) return;
 		if (event.key !== "Enter") return;
 		if (searchQuery.trim().startsWith("/")) {
 			event.preventDefault();
@@ -376,6 +394,11 @@
 	}
 
 	$: totalSearchResults = searchResults.movies.length + searchResults.series.length;
+    $: if (controlledSearch) {
+        commandHint = "";
+        showSearchResults = false;
+        loading = false;
+    }
     $: searchDockBottom =
         searchBarPositionPreference === HOME_SEARCH_BAR_POSITION_BOTTOM ||
         (searchBarPositionPreference === HOME_SEARCH_BAR_POSITION_AUTO &&
@@ -528,33 +551,39 @@
                     class="pointer-events-none absolute -inset-x-6 -inset-y-4 -z-10 rounded-[48px] bg-white/[0.09] blur-2xl opacity-35"
                 ></div>
             {/if}
-            <div
-                class={`flex flex-row gap-0 rounded-full overflow-clip w-[680px] max-w-[62vw] backdrop-blur-md z-20 transition-shadow duration-300 ${
-                    searchDockBottom
-                        ? "shadow-[0_18px_54px_rgba(0,0,0,0.6)] ring-1 ring-white/12"
-                        : ""
-                }`}
-            >
-                <div class="p-[20px] bg-[#181818]/50">
-                    <Search size={40} strokeWidth={2} color="#C3C3C3" />
+            <div class="flex items-center justify-center gap-3">
+                <slot name="prefix" />
+
+                <div
+                    class={`flex flex-row gap-0 rounded-full overflow-hidden ${searchWidthClass} backdrop-blur-md z-20 transition-shadow duration-300 ${
+                        searchDockBottom
+                            ? "shadow-[0_18px_54px_rgba(0,0,0,0.6)] ring-1 ring-white/12"
+                            : ""
+                    }`}
+                >
+                    <div class="p-[20px] bg-[#181818]/50">
+                        <Search size={40} strokeWidth={2} color="#C3C3C3" />
+                    </div>
+
+                    <input
+                        type="text"
+                        placeholder={searchPlaceholder}
+                        class="bg-[#000000]/50 text-[#D4D4D4] text-center py-[20px] px-[40px] w-full text-[28px] font-poppins font-normal outline-none focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-55"
+                        oninput={handleSearch}
+                        onkeydown={handleSearchKeydown}
+                        onfocus={() => {
+                            if (!controlledSearch && searchQuery) showSearchResults = true;
+                        }}
+                        onblur={() => {
+                            if (!controlledSearch) closeSearch();
+                        }}
+                        value={controlledSearch ? searchValue : searchQuery}
+                        disabled={searchDisabled}
+                    />
                 </div>
-
-                <input
-                    type="text"
-                    placeholder="search for anything"
-                    class="bg-[#000000]/50 text-[#D4D4D4] text-center py-[20px] px-[40px] w-full text-[28px] font-poppins font-normal outline-none focus:outline-none focus:ring-0"
-                    oninput={handleSearch}
-                    onkeydown={handleSearchKeydown}
-                    onfocus={() => {
-                        if (searchQuery) showSearchResults = true;
-                    }}
-                    onblur={closeSearch}
-                    value={searchQuery}
-                />
-
             </div>
 
-            {#if commandHint}
+            {#if !controlledSearch && commandHint}
                 <div
                     class={`absolute left-0 w-full bg-[#181818]/90 backdrop-blur-xl rounded-[24px] p-4 text-white/70 text-sm z-100 ${
                         searchDockBottom ? "bottom-[90px]" : "top-[90px]"
@@ -563,7 +592,7 @@
                 >
                     {commandHint}
                 </div>
-            {:else if showSearchResults && (totalSearchResults > 0 || loading)}
+            {:else if !controlledSearch && showSearchResults && (totalSearchResults > 0 || loading)}
                 <div
                     class={`absolute left-1/2 -translate-x-1/2 w-[780px] max-w-[72vw] bg-[#181818]/90 backdrop-blur-xl rounded-[24px] p-4 z-100 ${
                         searchDockBottom ? "bottom-[90px]" : "top-[90px]"
@@ -730,23 +759,27 @@
     />
 
     <div class="flex flex-row items-start gap-[10px]">
-        <button
-            class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
-            aria-label="addons"
-            onclick={openPlayModal}
-        >
-            <Link size={40} strokeWidth={2} color="#C3C3C3" />
-        </button>
+        {#if showPlayButton}
+            <button
+                class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
+                aria-label="addons"
+                onclick={openPlayModal}
+            >
+                <Link size={40} strokeWidth={2} color="#C3C3C3" />
+            </button>
+        {/if}
 
-        <button
-            class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
-            aria-label="addons"
-            onclick={openAddons}
-        >
-            <Blocks size={40} strokeWidth={2} color="#C3C3C3" />
-        </button>
+        {#if showAddonsButton}
+            <button
+                class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
+                aria-label="addons"
+                onclick={openAddons}
+            >
+                <Blocks size={40} strokeWidth={2} color="#C3C3C3" />
+            </button>
+        {/if}
 
-        {#if liveTvShortcutEnabled}
+        {#if showLiveTvButton && liveTvShortcutEnabled}
             <button
                 class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
                 aria-label="live tv"
@@ -756,58 +789,62 @@
             </button>
         {/if}
 
-        <button
-            class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
-            aria-label="lists"
-            onclick={openLists}
-        >
-            <Library size={40} strokeWidth={2} color="#C3C3C3" />
-        </button>
-
-        <div class="flex flex-col items-center">
+        {#if showListsButton}
             <button
-                class={`group relative bg-[#2C2C2C]/80 rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 ${$authInitializing
-                    ? "cursor-wait pointer-events-none p-0 overflow-hidden w-[80px] h-[80px]"
-                    : $currentUser
-                        ? "cursor-pointer p-0 overflow-hidden w-[80px] h-[80px]"
-                        : "cursor-pointer p-[20px]"}`
-                }
-                aria-label="settings"
-                onclick={openSettings}
+                class="bg-[#2C2C2C]/80 p-[20px] rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 cursor-pointer"
+                aria-label="lists"
+                onclick={openLists}
             >
-                {#if $authInitializing}
-                    <div class="w-full h-full bg-white/10 flex items-center justify-center">
-                        <LoadingSpinner size="30px" />
-                    </div>
-                {:else if $currentUser}
-                    <div class="w-full h-full bg-white/10 group-hover:bg-black/35 transition-colors duration-300 flex items-center justify-center">
-                        {#if $currentUser.avatar}
-                            <img
-                                src={$currentUser.avatar}
-                                alt="Profile"
-                                class="w-full h-full object-cover"
-                                loading="lazy"
-                            />
-                            <span class="absolute inset-0 bg-black/25 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"></span>
-                        {:else}
-                            <span class="text-white text-2xl font-semibold uppercase">
-                                {($currentUser.name || $currentUser.email || "?").slice(0, 1)}
-                            </span>
-                        {/if}
-                    </div>
-                {:else}
-                    <Settings size={40} strokeWidth={2} color="#C3C3C3" />
-                {/if}
+                <Library size={40} strokeWidth={2} color="#C3C3C3" />
             </button>
+        {/if}
 
-            {#if $updateStatus.available}
-                <div class="mt-2 h-[3px] w-[54px] rounded-full bg-white/25 overflow-hidden">
-                    <div
-                        class="h-full bg-white transition-[width] duration-300"
-                        style={`width: ${updateProgressPercent}%`}
-                    ></div>
-                </div>
-            {/if}
-        </div>
+        {#if showSettingsButton}
+            <div class="flex flex-col items-center">
+                <button
+                    class={`group relative bg-[#2C2C2C]/80 rounded-[24px] hover:bg-[#2C2C2C]/50 backdrop-blur-md transition-colors duration-300 ${$authInitializing
+                        ? "cursor-wait pointer-events-none p-0 overflow-hidden w-[80px] h-[80px]"
+                        : $currentUser
+                            ? "cursor-pointer p-0 overflow-hidden w-[80px] h-[80px]"
+                            : "cursor-pointer p-[20px]"}`
+                    }
+                    aria-label="settings"
+                    onclick={openSettings}
+                >
+                    {#if $authInitializing}
+                        <div class="w-full h-full bg-white/10 flex items-center justify-center">
+                            <LoadingSpinner size="30px" />
+                        </div>
+                    {:else if $currentUser}
+                        <div class="w-full h-full bg-white/10 group-hover:bg-black/35 transition-colors duration-300 flex items-center justify-center">
+                            {#if $currentUser.avatar}
+                                <img
+                                    src={$currentUser.avatar}
+                                    alt="Profile"
+                                    class="w-full h-full object-cover"
+                                    loading="lazy"
+                                />
+                                <span class="absolute inset-0 bg-black/25 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"></span>
+                            {:else}
+                                <span class="text-white text-2xl font-semibold uppercase">
+                                    {($currentUser.name || $currentUser.email || "?").slice(0, 1)}
+                                </span>
+                            {/if}
+                        </div>
+                    {:else}
+                        <Settings size={40} strokeWidth={2} color="#C3C3C3" />
+                    {/if}
+                </button>
+
+                {#if $updateStatus.available}
+                    <div class="mt-2 h-[3px] w-[54px] rounded-full bg-white/25 overflow-hidden">
+                        <div
+                            class="h-full bg-white transition-[width] duration-300"
+                            style={`width: ${updateProgressPercent}%`}
+                        ></div>
+                    </div>
+                {/if}
+            </div>
+        {/if}
     </div>
 </div>

--- a/packages/app/src/components/home/modals/settings/PreferencesSection.svelte
+++ b/packages/app/src/components/home/modals/settings/PreferencesSection.svelte
@@ -27,14 +27,18 @@
 		HOME_SEARCH_BAR_POSITION_BOTTOM,
 		HOME_SEARCH_BAR_POSITION_CHANGED_EVENT,
 		HOME_SEARCH_BAR_POSITION_HEADER,
+		HOME_LIVE_TV_SHORTCUT_CHANGED_EVENT,
 		type HomeSearchBarPosition,
+		getStoredHomeLiveTvShortcutEnabled,
 		getStoredHomeSearchBarPosition,
+		setStoredHomeLiveTvShortcutEnabled,
 		setStoredHomeSearchBarPosition,
 	} from "../../../../lib/home/searchBarSettings";
 
 	let discordRpcEnabled = true;
 	let seekBarStyle = "raffi";
 	let miniPlayerEnabled = true;
+	let liveTvShortcutEnabled = false;
 	let searchBarPosition: HomeSearchBarPosition = HOME_SEARCH_BAR_POSITION_AUTO;
 	let heroSource = HOME_HERO_SOURCE_CINEMETA;
 	let heroSourceOptions: HeroCatalogSourceOption[] = [];
@@ -48,6 +52,7 @@
 		const storedSeek = localStorage.getItem("seek_bar_style");
 		seekBarStyle = storedSeek || "raffi";
 		miniPlayerEnabled = $miniPlayerOnMinimize;
+		liveTvShortcutEnabled = getStoredHomeLiveTvShortcutEnabled();
 		heroSource = getStoredHomeHeroSource();
 		searchBarPosition = getStoredHomeSearchBarPosition();
 		void loadTraktHeroSourceAvailability();
@@ -88,6 +93,17 @@
 			trackEvent("mini_player_on_minimize_toggled", { enabled: nextValue });
 			return nextValue;
 		});
+	}
+
+	function toggleLiveTvShortcut() {
+		liveTvShortcutEnabled = !liveTvShortcutEnabled;
+		setStoredHomeLiveTvShortcutEnabled(liveTvShortcutEnabled);
+		window.dispatchEvent(
+			new CustomEvent(HOME_LIVE_TV_SHORTCUT_CHANGED_EVENT, {
+				detail: { enabled: liveTvShortcutEnabled },
+			}),
+		);
+		trackEvent("home_live_tv_shortcut_toggled", { enabled: liveTvShortcutEnabled });
 	}
 
 	async function loadHeroSourceOptions() {
@@ -295,6 +311,36 @@
 				}`}
 			>
 				{$autoSkipIntros ? "On" : "Off"}
+			</span>
+		</button>
+	</div>
+
+	<div class="rounded-2xl bg-white/8 p-4 flex flex-wrap items-center gap-4 justify-between">
+		<div>
+			<p class="text-white font-medium">
+				Live TV Shortcut
+			</p>
+			<p class="text-white/60 text-sm">
+				Show the Live TV button on the home search controls.
+			</p>
+		</div>
+		<button
+			class={`relative w-16 h-9 rounded-full border border-white/10 transition-colors duration-200 cursor-pointer ${
+				liveTvShortcutEnabled ? "bg-white" : "bg-white/10"
+			}`}
+			on:click={toggleLiveTvShortcut}
+			aria-label="Toggle Live TV shortcut"
+			role="switch"
+			aria-checked={liveTvShortcutEnabled}
+		>
+			<span
+				class={`absolute top-1 left-1 w-7 h-7 rounded-full text-[10px] font-semibold flex items-center justify-center transition-all duration-200 ${
+					liveTvShortcutEnabled
+						? "translate-x-7 bg-black text-white/90"
+						: "translate-x-0 bg-white/80 text-black"
+				}`}
+			>
+				{liveTvShortcutEnabled ? "On" : "Off"}
 			</span>
 		</button>
 	</div>

--- a/packages/app/src/components/player/PlayerControls.svelte
+++ b/packages/app/src/components/player/PlayerControls.svelte
@@ -33,6 +33,7 @@
     export let isWatchPartyMember = false;
     export let hasNextEpisode = true;
     export let showWatchParty = true;
+    export let liveMode = false;
     export let chapterMarkers: Chapter[] = [];
 
     export let seekBarStyle: "raffi" | "normal" = "raffi";
@@ -93,6 +94,10 @@
         onClipPanelOpenChange({ open });
     };
 
+    $: if (liveMode && showClipPanel) {
+        setClipPanelOpen(false);
+    }
+
     const getMarkerLeft = (chapter: Chapter) => {
         if (duration <= 0) return 0;
         const endTime = chapter.kind === "outro" ? duration : chapter.endTime;
@@ -133,11 +138,69 @@
 </script>
 
 <div
-    class="relative z-10 items-center rounded-4xl w-250 flex flex-col gap-2 px-7.5 py-5 text-white overflow-hidden"
+    class={`relative z-10 items-center text-white overflow-hidden ${
+        liveMode
+            ? "flex w-auto max-w-[92vw] rounded-full px-3 py-3"
+            : "rounded-4xl w-250 flex flex-col gap-2 px-7.5 py-5"
+    }`}
 >
-    <div class="absolute inset-0 rounded-4xl bg-[#000000]/10 backdrop-blur-xl pointer-events-none"></div>
+    <div
+        class={`absolute inset-0 bg-[#000000]/10 backdrop-blur-xl pointer-events-none ${
+            liveMode ? "rounded-full" : "rounded-4xl"
+        }`}
+    ></div>
 
-    <div class="relative z-10 flex flex-col gap-2 w-full">
+    <div
+        class={liveMode
+            ? "relative z-10 flex w-full items-center gap-2 sm:gap-3"
+            : "relative z-10 flex flex-col gap-2 w-full"}
+    >
+        {#if liveMode}
+            <button
+                on:click={togglePlay}
+                class="flex h-12 w-12 shrink-0 cursor-pointer items-center justify-center rounded-full bg-[#6E6E6E]/50 transition-colors duration-200 hover:bg-[#7A7A7A]/55"
+                aria-label={isPlaying ? "Pause" : "Play"}
+            >
+                {#if isPlaying}
+                    <CirclePause size={30} color="#FFFFFF" strokeWidth={2} />
+                {:else}
+                    <CirclePlay size={30} color="#FFFFFF" strokeWidth={2} />
+                {/if}
+            </button>
+
+            <ExpandingButton
+                label={objectFit === "contain" ? "Zoom" : "Fit"}
+                onClick={toggleObjectFit}
+            >
+                {#if objectFit === "contain"}
+                    <ZoomIn size={20} color="#E9E9E9" strokeWidth={2} />
+                {:else}
+                    <ZoomOut size={20} color="#E9E9E9" strokeWidth={2} />
+                {/if}
+            </ExpandingButton>
+
+            <ExpandingButton
+                label={"Fullscreen"}
+                onClick={() => {
+                    toggleFullscreen();
+                }}
+            >
+                <Maximize size={22} color="#E9E9E9" strokeWidth={2} />
+            </ExpandingButton>
+
+            <div class="w-28 shrink-0 sm:w-36">
+                <Slider
+                    widthProgress={volume * 100}
+                    widthGrey={100}
+                    onInput={onVolumeChange}
+                    value={volume}
+                    label="Volume"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                />
+            </div>
+        {:else}
         <div class="flex flex-row gap-5 items-center w-full">
             {#if !isWatchPartyMember}
                 <button
@@ -321,5 +384,6 @@
             {isWatchPartyMember}
             onClose={() => setClipPanelOpen(false)}
         />
+        {/if}
     </div>
 </div>

--- a/packages/app/src/lib/home/searchBarSettings.test.ts
+++ b/packages/app/src/lib/home/searchBarSettings.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    getStoredHomeLiveTvShortcutEnabled,
+    setStoredHomeLiveTvShortcutEnabled,
+} from "./searchBarSettings";
+
+class MemoryStorage {
+    private values = new Map<string, string>();
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+}
+
+describe("home search bar settings", () => {
+    let storage: MemoryStorage;
+
+    beforeEach(() => {
+        storage = new MemoryStorage();
+        Object.defineProperty(globalThis, "window", {
+            value: globalThis,
+            configurable: true,
+        });
+        Object.defineProperty(globalThis, "localStorage", {
+            value: storage,
+            configurable: true,
+        });
+    });
+
+    test("defaults the Live TV shortcut off", () => {
+        expect(getStoredHomeLiveTvShortcutEnabled()).toBe(false);
+    });
+
+    test("persists the Live TV shortcut preference", () => {
+        setStoredHomeLiveTvShortcutEnabled(true);
+        expect(getStoredHomeLiveTvShortcutEnabled()).toBe(true);
+
+        setStoredHomeLiveTvShortcutEnabled(false);
+        expect(getStoredHomeLiveTvShortcutEnabled()).toBe(false);
+    });
+});

--- a/packages/app/src/lib/home/searchBarSettings.ts
+++ b/packages/app/src/lib/home/searchBarSettings.ts
@@ -9,8 +9,11 @@ export type HomeSearchBarPosition =
 
 export const HOME_SEARCH_BAR_POSITION_STORAGE_KEY = "raffi:home-search-bar-position";
 export const HOME_SEARCH_BAR_POSITION_CHANGED_EVENT = "raffi:home-search-bar-position-changed";
+export const HOME_LIVE_TV_SHORTCUT_STORAGE_KEY = "raffi:home-live-tv-shortcut";
+export const HOME_LIVE_TV_SHORTCUT_CHANGED_EVENT = "raffi:home-live-tv-shortcut-changed";
 const DEFAULT_HOME_SEARCH_BAR_POSITION: HomeSearchBarPosition =
     HOME_SEARCH_BAR_POSITION_AUTO;
+const DEFAULT_HOME_LIVE_TV_SHORTCUT_ENABLED = false;
 
 const VALID_POSITIONS = new Set<HomeSearchBarPosition>([
     HOME_SEARCH_BAR_POSITION_HEADER,
@@ -40,6 +43,25 @@ export function setStoredHomeSearchBarPosition(value: HomeSearchBarPosition) {
             return;
         }
         localStorage.setItem(HOME_SEARCH_BAR_POSITION_STORAGE_KEY, value);
+    } catch {
+        // ignore
+    }
+}
+
+export function getStoredHomeLiveTvShortcutEnabled(): boolean {
+    if (typeof window === "undefined") return DEFAULT_HOME_LIVE_TV_SHORTCUT_ENABLED;
+    try {
+        const raw = localStorage.getItem(HOME_LIVE_TV_SHORTCUT_STORAGE_KEY);
+        return raw === "true";
+    } catch {
+        return DEFAULT_HOME_LIVE_TV_SHORTCUT_ENABLED;
+    }
+}
+
+export function setStoredHomeLiveTvShortcutEnabled(enabled: boolean) {
+    if (typeof window === "undefined") return;
+    try {
+        localStorage.setItem(HOME_LIVE_TV_SHORTCUT_STORAGE_KEY, enabled.toString());
     } catch {
         // ignore
     }

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -162,24 +162,25 @@ describe("IPTV refresh result cache", () => {
         expect(getStoredIptvRefreshResult(source)).toBeNull();
     });
 
-    test("matches Xtream caches by credentials without storing the plain password in cache metadata", () => {
+    test("does not cache Xtream channels because stream URLs can contain credentials", () => {
         const xtreamSource: IptvSource = {
             id: "xtream-1",
             kind: "xtream",
             name: "Xtream Live",
             serverUrl: "https://panel.example.test:8443/",
-            username: "user@example",
+            username: "xtream-user",
             credential: "secret-pass",
             createdAt: "2026-06-22T10:00:00.000Z",
             updatedAt: "2026-06-22T10:00:00.000Z",
         };
-
+        const xtreamCacheKey = "raffi_iptv_refresh_result_v1:xtream-1";
         const xtreamResult: IptvRefreshResult = {
             ...result,
             channels: result.channels.map((channel) => ({
                 ...channel,
                 id: channel.id.replace(source.id, xtreamSource.id),
                 sourceId: xtreamSource.id,
+                url: "https://panel.example.test:8443/live/xtream-user/secret-pass/1.ts",
             })),
             groups: result.groups.map((group) => ({
                 ...group,
@@ -188,16 +189,15 @@ describe("IPTV refresh result cache", () => {
             })),
         };
 
+        storage.setItem(xtreamCacheKey, "legacy cache containing secret-pass");
         persistIptvRefreshResult(xtreamSource, xtreamResult);
 
-        expect(getStoredIptvRefreshResult(xtreamSource)?.channels.map((channel) => channel.name)).toEqual(["ABC"]);
-        expect(getStoredIptvRefreshResult({
-            ...xtreamSource,
-            credential: "rotated-secret",
-        })).toBeNull();
+        expect(storage.getItem(xtreamCacheKey)).toBeNull();
+        expect(getStoredIptvRefreshResult(xtreamSource)).toBeNull();
 
-        const rawStored = storage.getItem("raffi_iptv_refresh_result_v1:xtream-1") ?? "";
-        expect(rawStored).not.toContain("secret-pass");
-        expect(rawStored).not.toContain("user@example");
+        storage.setItem(xtreamCacheKey, "legacy cache containing secret-pass");
+
+        expect(getStoredIptvRefreshResult(xtreamSource)).toBeNull();
+        expect(storage.getItem(xtreamCacheKey)).toBeNull();
     });
 });

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -72,6 +72,8 @@ const result: IptvRefreshResult = {
     },
 };
 
+const cacheKey = "raffi_iptv_refresh_result_v1:source-1";
+
 describe("IPTV refresh result cache", () => {
     let storage: MemoryStorage;
 
@@ -97,7 +99,49 @@ describe("IPTV refresh result cache", () => {
             programmeCount: 42,
         });
         expect(cached?.guide).toBeUndefined();
-        expect(JSON.stringify(storage)).not.toContain("programmesByChannel");
+
+        const rawStored = storage.getItem(cacheKey) ?? "";
+        const stored = JSON.parse(rawStored) as Record<string, unknown>;
+        expect(Object.hasOwn(stored, "guide")).toBe(false);
+        expect(Object.hasOwn(stored, "programmesByChannel")).toBe(false);
+    });
+
+    test("ignores cached results with mismatched child source ids", () => {
+        persistIptvRefreshResult(source, result);
+        const stored = JSON.parse(storage.getItem(cacheKey) ?? "{}");
+
+        storage.setItem(
+            cacheKey,
+            JSON.stringify({
+                ...stored,
+                channels: [{ ...stored.channels[0], sourceId: "other-source" }],
+            }),
+        );
+        expect(getStoredIptvRefreshResult(source)).toBeNull();
+
+        storage.setItem(
+            cacheKey,
+            JSON.stringify({
+                ...stored,
+                groups: [{ ...stored.groups[0], sourceId: "other-source" }],
+            }),
+        );
+        expect(getStoredIptvRefreshResult(source)).toBeNull();
+    });
+
+    test("ignores cached results with invalid loaded timestamps", () => {
+        persistIptvRefreshResult(source, result);
+        const stored = JSON.parse(storage.getItem(cacheKey) ?? "{}");
+
+        storage.setItem(
+            cacheKey,
+            JSON.stringify({
+                ...stored,
+                loadedAt: "not-a-date",
+            }),
+        );
+
+        expect(getStoredIptvRefreshResult(source)).toBeNull();
     });
 
     test("ignores cached channels after the source URL changes", () => {
@@ -130,7 +174,21 @@ describe("IPTV refresh result cache", () => {
             updatedAt: "2026-06-22T10:00:00.000Z",
         };
 
-        persistIptvRefreshResult(xtreamSource, result);
+        const xtreamResult: IptvRefreshResult = {
+            ...result,
+            channels: result.channels.map((channel) => ({
+                ...channel,
+                id: channel.id.replace(source.id, xtreamSource.id),
+                sourceId: xtreamSource.id,
+            })),
+            groups: result.groups.map((group) => ({
+                ...group,
+                id: group.id.replace(source.id, xtreamSource.id),
+                sourceId: xtreamSource.id,
+            })),
+        };
+
+        persistIptvRefreshResult(xtreamSource, xtreamResult);
 
         expect(getStoredIptvRefreshResult(xtreamSource)?.channels.map((channel) => channel.name)).toEqual(["ABC"]);
         expect(getStoredIptvRefreshResult({

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -61,14 +61,32 @@ const result: IptvRefreshResult = {
         },
     ],
     guide: {
-        channels: new Map(),
-        programmesByChannel: new Map(),
-        displayNameToChannelId: new Map(),
+        channels: new Map([
+            ["abc.us", { id: "abc.us", displayNames: ["ABC"] }],
+        ]),
+        programmesByChannel: new Map([
+            [
+                "abc.us",
+                [
+                    {
+                        channelId: "abc.us",
+                        start: new Date("2026-06-22T14:00:00.000Z"),
+                        stop: new Date("2026-06-22T15:00:00.000Z"),
+                        startOffsetMinutes: -240,
+                        stopOffsetMinutes: -240,
+                        title: "Morning News",
+                        subTitle: "Top stories",
+                        description: "Daily update",
+                    },
+                ],
+            ],
+        ]),
+        displayNameToChannelId: new Map([["abc", "abc.us"]]),
     },
     stats: {
         channelCount: 1,
         groupCount: 1,
-        programmeCount: 42,
+        programmeCount: 1,
     },
 };
 
@@ -85,7 +103,7 @@ describe("IPTV refresh result cache", () => {
         });
     });
 
-    test("hydrates cached channels and groups for the same source without persisting guide maps", () => {
+    test("hydrates cached channels, groups, and guide for the same source", () => {
         persistIptvRefreshResult(source, result);
 
         const cached = getStoredIptvRefreshResult(source);
@@ -96,14 +114,20 @@ describe("IPTV refresh result cache", () => {
         expect(cached?.stats).toEqual({
             channelCount: 1,
             groupCount: 1,
-            programmeCount: 42,
+            programmeCount: 1,
         });
-        expect(cached?.guide).toBeUndefined();
+        expect(cached?.guide?.channels.get("abc.us")?.displayNames).toEqual(["ABC"]);
+        expect(cached?.guide?.displayNameToChannelId.get("abc")).toBe("abc.us");
+        const programme = cached?.guide?.programmesByChannel.get("abc.us")?.[0];
+        expect(programme?.title).toBe("Morning News");
+        expect(programme?.start).toEqual(new Date("2026-06-22T14:00:00.000Z"));
+        expect(programme?.stop).toEqual(new Date("2026-06-22T15:00:00.000Z"));
+        expect(programme?.subTitle).toBe("Top stories");
+        expect(programme?.description).toBe("Daily update");
 
         const rawStored = storage.getItem(cacheKey) ?? "";
         const stored = JSON.parse(rawStored) as Record<string, unknown>;
-        expect(Object.hasOwn(stored, "guide")).toBe(false);
-        expect(Object.hasOwn(stored, "programmesByChannel")).toBe(false);
+        expect(Object.hasOwn(stored, "guide")).toBe(true);
     });
 
     test("ignores cached results with mismatched child source ids", () => {

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    clearStoredIptvRefreshResult,
+    getStoredIptvRefreshResult,
+    persistIptvRefreshResult,
+} from "./cache";
+import type { IptvRefreshResult, IptvSource } from "./types";
+
+class MemoryStorage {
+    private values = new Map<string, string>();
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    clear() {
+        this.values.clear();
+    }
+}
+
+const source: IptvSource = {
+    id: "source-1",
+    kind: "m3u",
+    name: "Dispatcharr",
+    m3uUrl: "https://dispatcharr.example.test/output/m3u",
+    epgUrl: "https://dispatcharr.example.test/output/epg",
+    createdAt: "2026-06-22T10:00:00.000Z",
+    updatedAt: "2026-06-22T10:00:00.000Z",
+};
+
+const result: IptvRefreshResult = {
+    loadedAt: "2026-06-22T14:00:00.000Z",
+    channels: [
+        {
+            id: "source-1:0:abc",
+            sourceId: "source-1",
+            name: "ABC",
+            url: "https://dispatcharr.example.test/proxy/ts/stream/abc",
+            group: "News",
+            tvgId: "abc.us",
+            tvgName: "ABC",
+            logo: "https://dispatcharr.example.test/logo/abc.png",
+            order: 0,
+        },
+    ],
+    groups: [
+        {
+            id: "source-1:group:news",
+            sourceId: "source-1",
+            name: "News",
+            channelCount: 1,
+            order: 0,
+        },
+    ],
+    guide: {
+        channels: new Map(),
+        programmesByChannel: new Map(),
+        displayNameToChannelId: new Map(),
+    },
+    stats: {
+        channelCount: 1,
+        groupCount: 1,
+        programmeCount: 42,
+    },
+};
+
+describe("IPTV refresh result cache", () => {
+    let storage: MemoryStorage;
+
+    beforeEach(() => {
+        storage = new MemoryStorage();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: storage,
+            configurable: true,
+        });
+    });
+
+    test("hydrates cached channels and groups for the same source without persisting guide maps", () => {
+        persistIptvRefreshResult(source, result);
+
+        const cached = getStoredIptvRefreshResult(source);
+
+        expect(cached?.channels.map((channel) => channel.name)).toEqual(["ABC"]);
+        expect(cached?.groups.map((group) => group.name)).toEqual(["News"]);
+        expect(cached?.loadedAt).toBe(result.loadedAt);
+        expect(cached?.stats).toEqual({
+            channelCount: 1,
+            groupCount: 1,
+            programmeCount: 42,
+        });
+        expect(cached?.guide).toBeUndefined();
+        expect(JSON.stringify(storage)).not.toContain("programmesByChannel");
+    });
+
+    test("ignores cached channels after the source URL changes", () => {
+        persistIptvRefreshResult(source, result);
+
+        expect(
+            getStoredIptvRefreshResult({
+                ...source,
+                m3uUrl: "https://dispatcharr.example.test/output/m3u/clean",
+            }),
+        ).toBeNull();
+    });
+
+    test("can clear cached channels for removed sources", () => {
+        persistIptvRefreshResult(source, result);
+        clearStoredIptvRefreshResult(source.id);
+
+        expect(getStoredIptvRefreshResult(source)).toBeNull();
+    });
+});

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -117,4 +117,29 @@ describe("IPTV refresh result cache", () => {
 
         expect(getStoredIptvRefreshResult(source)).toBeNull();
     });
+
+    test("matches Xtream caches by credentials without storing the plain password in cache metadata", () => {
+        const xtreamSource: IptvSource = {
+            id: "xtream-1",
+            kind: "xtream",
+            name: "Xtream Live",
+            serverUrl: "https://panel.example.test:8443/",
+            username: "user@example",
+            credential: "secret-pass",
+            createdAt: "2026-06-22T10:00:00.000Z",
+            updatedAt: "2026-06-22T10:00:00.000Z",
+        };
+
+        persistIptvRefreshResult(xtreamSource, result);
+
+        expect(getStoredIptvRefreshResult(xtreamSource)?.channels.map((channel) => channel.name)).toEqual(["ABC"]);
+        expect(getStoredIptvRefreshResult({
+            ...xtreamSource,
+            credential: "rotated-secret",
+        })).toBeNull();
+
+        const rawStored = storage.getItem("raffi_iptv_refresh_result_v1:xtream-1") ?? "";
+        expect(rawStored).not.toContain("secret-pass");
+        expect(rawStored).not.toContain("user@example");
+    });
 });

--- a/packages/app/src/lib/iptv/cache.test.ts
+++ b/packages/app/src/lib/iptv/cache.test.ts
@@ -130,6 +130,34 @@ describe("IPTV refresh result cache", () => {
         expect(Object.hasOwn(stored, "guide")).toBe(true);
     });
 
+    test("persists feed-controlled guide channel ids as data keys", () => {
+        const protoProgramme = {
+            channelId: "__proto__",
+            start: new Date("2026-06-22T16:00:00.000Z"),
+            stop: new Date("2026-06-22T17:00:00.000Z"),
+            title: "Prototype News",
+        };
+        persistIptvRefreshResult(source, {
+            ...result,
+            guide: {
+                channels: new Map([
+                    ["__proto__", { id: "__proto__", displayNames: ["Prototype"] }],
+                ]),
+                programmesByChannel: new Map([["__proto__", [protoProgramme]]]),
+                displayNameToChannelId: new Map([["prototype", "__proto__"]]),
+            },
+        });
+
+        const stored = JSON.parse(storage.getItem(cacheKey) ?? "{}");
+        expect(Object.hasOwn(stored.guide.programmesByChannel, "__proto__")).toBe(true);
+        const cachedGuide = getStoredIptvRefreshResult(source)?.guide;
+        expect(cachedGuide?.channels.get("__proto__")?.displayNames).toEqual([
+            "Prototype",
+        ]);
+        expect(cachedGuide?.displayNameToChannelId.get("prototype")).toBe("__proto__");
+        expect(cachedGuide?.programmesByChannel.get("__proto__")?.[0]?.title).toBe("Prototype News");
+    });
+
     test("ignores cached results with mismatched child source ids", () => {
         persistIptvRefreshResult(source, result);
         const stored = JSON.parse(storage.getItem(cacheKey) ?? "{}");

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -262,6 +262,15 @@ export function persistIptvRefreshResult(source: IptvSource, result: IptvRefresh
     const storage = getStorage();
     if (!storage) return;
 
+    if (source.kind === "xtream") {
+        try {
+            storage.removeItem(cacheKeyForSourceId(source.id));
+        } catch {
+            // Best-effort cache clears should not block Live TV refreshes.
+        }
+        return;
+    }
+
     const stored: StoredIptvRefreshResult = {
         version: CACHE_VERSION,
         sourceId: source.id,
@@ -282,6 +291,15 @@ export function persistIptvRefreshResult(source: IptvSource, result: IptvRefresh
 export function getStoredIptvRefreshResult(source: IptvSource): IptvRefreshResult | null {
     const storage = getStorage();
     if (!storage) return null;
+
+    if (source.kind === "xtream") {
+        try {
+            storage.removeItem(cacheKeyForSourceId(source.id));
+        } catch {
+            // Ignore unavailable storage when discarding old Xtream caches.
+        }
+        return null;
+    }
 
     try {
         const raw = storage.getItem(cacheKeyForSourceId(source.id));

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -102,6 +102,10 @@ function optionalString(value: unknown): string | undefined {
     return typeof value === "string" && value ? value : undefined;
 }
 
+function isValidDateString(value: string): boolean {
+    return !Number.isNaN(new Date(value).getTime());
+}
+
 function sanitizeChannel(value: unknown): IptvChannel | null {
     if (!isRecord(value)) return null;
     if (
@@ -179,6 +183,7 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
         value.version !== CACHE_VERSION ||
         typeof value.sourceId !== "string" ||
         typeof value.loadedAt !== "string" ||
+        !isValidDateString(value.loadedAt) ||
         !Array.isArray(value.channels) ||
         !Array.isArray(value.groups)
     ) {
@@ -209,6 +214,15 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
         return null;
     }
 
+    const sanitizedChannels = channels as IptvChannel[];
+    const sanitizedGroups = groups as IptvGroup[];
+    if (
+        sanitizedChannels.some((channel) => channel.sourceId !== value.sourceId) ||
+        sanitizedGroups.some((group) => group.sourceId !== value.sourceId)
+    ) {
+        return null;
+    }
+
     return {
         version: CACHE_VERSION,
         sourceId: value.sourceId,
@@ -223,8 +237,8 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
             typeof value.credentialFingerprint === "string"
                 ? value.credentialFingerprint
                 : undefined,
-        channels: channels as IptvChannel[],
-        groups: groups as IptvGroup[],
+        channels: sanitizedChannels,
+        groups: sanitizedGroups,
         loadedAt: value.loadedAt,
         stats,
     };

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -5,11 +5,35 @@ import type {
     IptvRefreshStats,
     IptvSource,
     IptvSourceKind,
+    XmltvGuide,
+    XmltvProgramme,
 } from "./types";
+import { normalizeIptvText } from "./utils";
 import { normalizeXtreamServerUrl } from "./xtream";
 
 const IPTV_REFRESH_CACHE_KEY_PREFIX = "raffi_iptv_refresh_result_v1";
 const CACHE_VERSION = 1;
+
+type StoredXmltvChannel = {
+    id: string;
+    displayNames: string[];
+};
+
+type StoredXmltvProgramme = {
+    channelId: string;
+    start: string;
+    stop: string;
+    startOffsetMinutes?: number;
+    stopOffsetMinutes?: number;
+    title: string;
+    subTitle?: string;
+    description?: string;
+};
+
+type StoredXmltvGuide = {
+    channels: StoredXmltvChannel[];
+    programmesByChannel: Record<string, StoredXmltvProgramme[]>;
+};
 
 type StoredIptvRefreshResult = {
     version: typeof CACHE_VERSION;
@@ -21,6 +45,7 @@ type StoredIptvRefreshResult = {
     credentialFingerprint?: string;
     channels: IptvChannel[];
     groups: IptvGroup[];
+    guide?: StoredXmltvGuide;
     loadedAt: string;
     stats: IptvRefreshStats;
 };
@@ -177,7 +202,120 @@ function sanitizeStats(value: unknown): IptvRefreshStats | null {
     };
 }
 
-function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
+function optionalNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function sanitizeStoredProgramme(value: unknown): XmltvProgramme | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.channelId !== "string" ||
+        typeof value.start !== "string" ||
+        typeof value.stop !== "string" ||
+        typeof value.title !== "string" ||
+        !isValidDateString(value.start) ||
+        !isValidDateString(value.stop)
+    ) {
+        return null;
+    }
+
+    return {
+        channelId: value.channelId,
+        start: new Date(value.start),
+        stop: new Date(value.stop),
+        startOffsetMinutes: optionalNumber(value.startOffsetMinutes),
+        stopOffsetMinutes: optionalNumber(value.stopOffsetMinutes),
+        title: value.title,
+        subTitle: optionalString(value.subTitle),
+        description: optionalString(value.description),
+    };
+}
+
+function sanitizeStoredProgrammes(value: unknown): XmltvProgramme[] | null {
+    if (!Array.isArray(value)) return null;
+
+    const programmes: XmltvProgramme[] = [];
+    for (const rawProgramme of value) {
+        const programme = sanitizeStoredProgramme(rawProgramme);
+        if (!programme) return null;
+        programmes.push(programme);
+    }
+
+    return programmes.sort((a, b) => a.start.getTime() - b.start.getTime());
+}
+
+function sanitizeStoredGuide(value: unknown): XmltvGuide | null | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value) || !Array.isArray(value.channels) || !isRecord(value.programmesByChannel)) {
+        return null;
+    }
+
+    const guide: XmltvGuide = {
+        channels: new Map(),
+        programmesByChannel: new Map(),
+        displayNameToChannelId: new Map(),
+    };
+
+    for (const channel of value.channels) {
+        if (!isRecord(channel) || typeof channel.id !== "string" || !Array.isArray(channel.displayNames)) {
+            return null;
+        }
+        const displayNames = channel.displayNames.filter(
+            (displayName): displayName is string => typeof displayName === "string" && Boolean(displayName.trim()),
+        );
+        guide.channels.set(channel.id, { id: channel.id, displayNames });
+        for (const displayName of displayNames) {
+            const key = normalizeIptvText(displayName);
+            if (key && !guide.displayNameToChannelId.has(key)) {
+                guide.displayNameToChannelId.set(key, channel.id);
+            }
+        }
+    }
+
+    for (const [channelId, rawProgrammes] of Object.entries(value.programmesByChannel)) {
+        const programmes = sanitizeStoredProgrammes(rawProgrammes);
+        if (!programmes) return null;
+        guide.programmesByChannel.set(channelId, programmes);
+    }
+
+    return guide;
+}
+
+function serializeProgramme(programme: XmltvProgramme): StoredXmltvProgramme {
+    return {
+        channelId: programme.channelId,
+        start: programme.start.toISOString(),
+        stop: programme.stop.toISOString(),
+        startOffsetMinutes: programme.startOffsetMinutes,
+        stopOffsetMinutes: programme.stopOffsetMinutes,
+        title: programme.title,
+        subTitle: programme.subTitle,
+        description: programme.description,
+    };
+}
+
+function serializeGuide(guide: XmltvGuide | undefined): StoredXmltvGuide | undefined {
+    if (!guide) return undefined;
+
+    const programmesByChannel: Record<string, StoredXmltvProgramme[]> = {};
+    for (const [channelId, programmes] of guide.programmesByChannel.entries()) {
+        programmesByChannel[channelId] = programmes.map(serializeProgramme);
+    }
+
+    return {
+        channels: Array.from(guide.channels.values()).map((channel) => ({
+            id: channel.id,
+            displayNames: channel.displayNames,
+        })),
+        programmesByChannel,
+    };
+}
+
+type HydratedStoredIptvRefreshResult = Omit<StoredIptvRefreshResult, "guide"> & {
+    guide?: XmltvGuide;
+};
+
+function sanitizeStoredResult(value: unknown): HydratedStoredIptvRefreshResult | null {
     if (!isRecord(value)) return null;
     if (
         value.version !== CACHE_VERSION ||
@@ -210,7 +348,13 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
     const channels = value.channels.map(sanitizeChannel);
     const groups = value.groups.map(sanitizeGroup);
     const stats = sanitizeStats(value.stats);
-    if (!stats || channels.some((channel) => !channel) || groups.some((group) => !group)) {
+    const guide = sanitizeStoredGuide(value.guide);
+    if (
+        !stats ||
+        guide === null ||
+        channels.some((channel) => !channel) ||
+        groups.some((group) => !group)
+    ) {
         return null;
     }
 
@@ -239,12 +383,13 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
                 : undefined,
         channels: sanitizedChannels,
         groups: sanitizedGroups,
+        guide,
         loadedAt: value.loadedAt,
         stats,
     };
 }
 
-function storedResultMatchesSource(source: IptvSource, stored: StoredIptvRefreshResult): boolean {
+function storedResultMatchesSource(source: IptvSource, stored: HydratedStoredIptvRefreshResult): boolean {
     if (stored.sourceId !== source.id || stored.sourceKind !== source.kind) return false;
 
     const metadata = getStoredSourceMetadata(source);
@@ -277,6 +422,7 @@ export function persistIptvRefreshResult(source: IptvSource, result: IptvRefresh
         ...getStoredSourceMetadata(source),
         channels: result.channels,
         groups: result.groups,
+        guide: serializeGuide(result.guide),
         loadedAt: result.loadedAt,
         stats: result.stats,
     };
@@ -284,7 +430,13 @@ export function persistIptvRefreshResult(source: IptvSource, result: IptvRefresh
     try {
         storage.setItem(cacheKeyForSourceId(source.id), JSON.stringify(stored));
     } catch {
-        // Best-effort cache writes should not block Live TV refreshes.
+        try {
+            const fallbackStored = { ...stored };
+            delete fallbackStored.guide;
+            storage.setItem(cacheKeyForSourceId(source.id), JSON.stringify(fallbackStored));
+        } catch {
+            // Best-effort cache writes should not block Live TV refreshes.
+        }
     }
 }
 
@@ -313,6 +465,7 @@ export function getStoredIptvRefreshResult(source: IptvSource): IptvRefreshResul
         return {
             channels: stored.channels,
             groups: stored.groups,
+            guide: stored.guide,
             loadedAt: stored.loadedAt,
             stats: stored.stats,
         };

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -1,0 +1,219 @@
+import type {
+    IptvChannel,
+    IptvGroup,
+    IptvRefreshResult,
+    IptvRefreshStats,
+    IptvSource,
+} from "./types";
+
+const IPTV_REFRESH_CACHE_KEY_PREFIX = "raffi_iptv_refresh_result_v1";
+const CACHE_VERSION = 1;
+
+type StoredIptvRefreshResult = {
+    version: typeof CACHE_VERSION;
+    sourceId: string;
+    m3uUrl: string;
+    epgUrl: string | null;
+    channels: IptvChannel[];
+    groups: IptvGroup[];
+    loadedAt: string;
+    stats: IptvRefreshStats;
+};
+
+function getStorage(): Storage | null {
+    try {
+        return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch {
+        return null;
+    }
+}
+
+function cacheKeyForSourceId(sourceId: string): string {
+    return `${IPTV_REFRESH_CACHE_KEY_PREFIX}:${sourceId}`;
+}
+
+function normalizeOptionalUrl(url: string | undefined): string | null {
+    const trimmed = String(url ?? "").trim();
+    return trimmed || null;
+}
+
+function getSourceUrls(source: IptvSource) {
+    return {
+        m3uUrl: source.m3uUrl.trim(),
+        epgUrl: normalizeOptionalUrl(source.epgUrl),
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+    return typeof value === "string" && value ? value : undefined;
+}
+
+function sanitizeChannel(value: unknown): IptvChannel | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.id !== "string" ||
+        typeof value.sourceId !== "string" ||
+        typeof value.name !== "string" ||
+        typeof value.url !== "string" ||
+        typeof value.group !== "string" ||
+        typeof value.order !== "number" ||
+        !Number.isFinite(value.order)
+    ) {
+        return null;
+    }
+
+    return {
+        id: value.id,
+        sourceId: value.sourceId,
+        name: value.name,
+        url: value.url,
+        group: value.group,
+        tvgId: optionalString(value.tvgId),
+        tvgName: optionalString(value.tvgName),
+        logo: optionalString(value.logo),
+        number: optionalString(value.number),
+        order: value.order,
+    };
+}
+
+function sanitizeGroup(value: unknown): IptvGroup | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.id !== "string" ||
+        typeof value.sourceId !== "string" ||
+        typeof value.name !== "string" ||
+        typeof value.channelCount !== "number" ||
+        typeof value.order !== "number" ||
+        !Number.isFinite(value.channelCount) ||
+        !Number.isFinite(value.order)
+    ) {
+        return null;
+    }
+
+    return {
+        id: value.id,
+        sourceId: value.sourceId,
+        name: value.name,
+        channelCount: value.channelCount,
+        order: value.order,
+    };
+}
+
+function sanitizeStats(value: unknown): IptvRefreshStats | null {
+    if (!isRecord(value)) return null;
+    if (
+        typeof value.channelCount !== "number" ||
+        typeof value.groupCount !== "number" ||
+        typeof value.programmeCount !== "number" ||
+        !Number.isFinite(value.channelCount) ||
+        !Number.isFinite(value.groupCount) ||
+        !Number.isFinite(value.programmeCount)
+    ) {
+        return null;
+    }
+
+    return {
+        channelCount: value.channelCount,
+        groupCount: value.groupCount,
+        programmeCount: value.programmeCount,
+    };
+}
+
+function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
+    if (!isRecord(value)) return null;
+    if (
+        value.version !== CACHE_VERSION ||
+        typeof value.sourceId !== "string" ||
+        typeof value.m3uUrl !== "string" ||
+        (value.epgUrl !== null && typeof value.epgUrl !== "string") ||
+        typeof value.loadedAt !== "string" ||
+        !Array.isArray(value.channels) ||
+        !Array.isArray(value.groups)
+    ) {
+        return null;
+    }
+
+    const channels = value.channels.map(sanitizeChannel);
+    const groups = value.groups.map(sanitizeGroup);
+    const stats = sanitizeStats(value.stats);
+    if (!stats || channels.some((channel) => !channel) || groups.some((group) => !group)) {
+        return null;
+    }
+
+    return {
+        version: CACHE_VERSION,
+        sourceId: value.sourceId,
+        m3uUrl: value.m3uUrl,
+        epgUrl: value.epgUrl,
+        channels: channels as IptvChannel[],
+        groups: groups as IptvGroup[],
+        loadedAt: value.loadedAt,
+        stats,
+    };
+}
+
+function storedResultMatchesSource(source: IptvSource, stored: StoredIptvRefreshResult): boolean {
+    const urls = getSourceUrls(source);
+    return (
+        stored.sourceId === source.id &&
+        stored.m3uUrl === urls.m3uUrl &&
+        stored.epgUrl === urls.epgUrl
+    );
+}
+
+export function persistIptvRefreshResult(source: IptvSource, result: IptvRefreshResult): void {
+    const storage = getStorage();
+    if (!storage) return;
+
+    const urls = getSourceUrls(source);
+    const stored: StoredIptvRefreshResult = {
+        version: CACHE_VERSION,
+        sourceId: source.id,
+        m3uUrl: urls.m3uUrl,
+        epgUrl: urls.epgUrl,
+        channels: result.channels,
+        groups: result.groups,
+        loadedAt: result.loadedAt,
+        stats: result.stats,
+    };
+
+    try {
+        storage.setItem(cacheKeyForSourceId(source.id), JSON.stringify(stored));
+    } catch {
+        // Best-effort cache writes should not block Live TV refreshes.
+    }
+}
+
+export function getStoredIptvRefreshResult(source: IptvSource): IptvRefreshResult | null {
+    const storage = getStorage();
+    if (!storage) return null;
+
+    try {
+        const raw = storage.getItem(cacheKeyForSourceId(source.id));
+        if (!raw) return null;
+
+        const stored = sanitizeStoredResult(JSON.parse(raw));
+        if (!stored || !storedResultMatchesSource(source, stored)) {
+            return null;
+        }
+
+        return {
+            channels: stored.channels,
+            groups: stored.groups,
+            loadedAt: stored.loadedAt,
+            stats: stored.stats,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function clearStoredIptvRefreshResult(sourceId: string): void {
+    const storage = getStorage();
+    if (!storage) return;
+    storage.removeItem(cacheKeyForSourceId(sourceId));
+}

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -4,7 +4,9 @@ import type {
     IptvRefreshResult,
     IptvRefreshStats,
     IptvSource,
+    IptvSourceKind,
 } from "./types";
+import { normalizeXtreamServerUrl } from "./xtream";
 
 const IPTV_REFRESH_CACHE_KEY_PREFIX = "raffi_iptv_refresh_result_v1";
 const CACHE_VERSION = 1;
@@ -12,8 +14,11 @@ const CACHE_VERSION = 1;
 type StoredIptvRefreshResult = {
     version: typeof CACHE_VERSION;
     sourceId: string;
-    m3uUrl: string;
-    epgUrl: string | null;
+    sourceKind: IptvSourceKind;
+    m3uUrl?: string;
+    epgUrl?: string | null;
+    serverUrl?: string;
+    credentialFingerprint?: string;
     channels: IptvChannel[];
     groups: IptvGroup[];
     loadedAt: string;
@@ -37,8 +42,53 @@ function normalizeOptionalUrl(url: string | undefined): string | null {
     return trimmed || null;
 }
 
-function getSourceUrls(source: IptvSource) {
+function hashString(input: string): string {
+    let hash = 0x811c9dc5;
+    for (let index = 0; index < input.length; index += 1) {
+        hash ^= input.charCodeAt(index);
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function fingerprintXtreamCredentials(source: IptvSource): string {
+    if (source.kind !== "xtream") return "";
+    return hashString(
+        [
+            normalizeXtreamServerUrl(source.serverUrl),
+            source.username,
+            source.credential,
+        ].join("\n"),
+    );
+}
+
+export function getIptvSourceCacheFingerprint(source: IptvSource): string {
+    if (source.kind === "xtream") {
+        return [
+            source.kind,
+            normalizeXtreamServerUrl(source.serverUrl),
+            fingerprintXtreamCredentials(source),
+        ].join("\n");
+    }
+
+    return [
+        source.kind,
+        source.m3uUrl.trim(),
+        normalizeOptionalUrl(source.epgUrl) ?? "",
+    ].join("\n");
+}
+
+function getStoredSourceMetadata(source: IptvSource) {
+    if (source.kind === "xtream") {
+        return {
+            sourceKind: source.kind,
+            serverUrl: normalizeXtreamServerUrl(source.serverUrl),
+            credentialFingerprint: fingerprintXtreamCredentials(source),
+        };
+    }
+
     return {
+        sourceKind: source.kind,
         m3uUrl: source.m3uUrl.trim(),
         epgUrl: normalizeOptionalUrl(source.epgUrl),
     };
@@ -128,11 +178,26 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
     if (
         value.version !== CACHE_VERSION ||
         typeof value.sourceId !== "string" ||
-        typeof value.m3uUrl !== "string" ||
-        (value.epgUrl !== null && typeof value.epgUrl !== "string") ||
         typeof value.loadedAt !== "string" ||
         !Array.isArray(value.channels) ||
         !Array.isArray(value.groups)
+    ) {
+        return null;
+    }
+
+    const sourceKind = value.sourceKind === "xtream" ? "xtream" : "m3u";
+    if (
+        sourceKind === "xtream" &&
+        (typeof value.serverUrl !== "string" ||
+            typeof value.credentialFingerprint !== "string")
+    ) {
+        return null;
+    }
+
+    if (
+        sourceKind === "m3u" &&
+        (typeof value.m3uUrl !== "string" ||
+            (value.epgUrl !== null && typeof value.epgUrl !== "string"))
     ) {
         return null;
     }
@@ -147,8 +212,17 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
     return {
         version: CACHE_VERSION,
         sourceId: value.sourceId,
-        m3uUrl: value.m3uUrl,
-        epgUrl: value.epgUrl,
+        sourceKind,
+        m3uUrl: typeof value.m3uUrl === "string" ? value.m3uUrl : undefined,
+        epgUrl:
+            typeof value.epgUrl === "string" || value.epgUrl === null
+                ? value.epgUrl
+                : undefined,
+        serverUrl: typeof value.serverUrl === "string" ? value.serverUrl : undefined,
+        credentialFingerprint:
+            typeof value.credentialFingerprint === "string"
+                ? value.credentialFingerprint
+                : undefined,
         channels: channels as IptvChannel[],
         groups: groups as IptvGroup[],
         loadedAt: value.loadedAt,
@@ -157,24 +231,27 @@ function sanitizeStoredResult(value: unknown): StoredIptvRefreshResult | null {
 }
 
 function storedResultMatchesSource(source: IptvSource, stored: StoredIptvRefreshResult): boolean {
-    const urls = getSourceUrls(source);
-    return (
-        stored.sourceId === source.id &&
-        stored.m3uUrl === urls.m3uUrl &&
-        stored.epgUrl === urls.epgUrl
-    );
+    if (stored.sourceId !== source.id || stored.sourceKind !== source.kind) return false;
+
+    const metadata = getStoredSourceMetadata(source);
+    if (source.kind === "xtream") {
+        return (
+            stored.serverUrl === metadata.serverUrl &&
+            stored.credentialFingerprint === metadata.credentialFingerprint
+        );
+    }
+
+    return stored.m3uUrl === metadata.m3uUrl && stored.epgUrl === metadata.epgUrl;
 }
 
 export function persistIptvRefreshResult(source: IptvSource, result: IptvRefreshResult): void {
     const storage = getStorage();
     if (!storage) return;
 
-    const urls = getSourceUrls(source);
     const stored: StoredIptvRefreshResult = {
         version: CACHE_VERSION,
         sourceId: source.id,
-        m3uUrl: urls.m3uUrl,
-        epgUrl: urls.epgUrl,
+        ...getStoredSourceMetadata(source),
         channels: result.channels,
         groups: result.groups,
         loadedAt: result.loadedAt,

--- a/packages/app/src/lib/iptv/cache.ts
+++ b/packages/app/src/lib/iptv/cache.ts
@@ -297,7 +297,7 @@ function serializeProgramme(programme: XmltvProgramme): StoredXmltvProgramme {
 function serializeGuide(guide: XmltvGuide | undefined): StoredXmltvGuide | undefined {
     if (!guide) return undefined;
 
-    const programmesByChannel: Record<string, StoredXmltvProgramme[]> = {};
+    const programmesByChannel = Object.create(null) as Record<string, StoredXmltvProgramme[]>;
     for (const [channelId, programmes] of guide.programmesByChannel.entries()) {
         programmesByChannel[channelId] = programmes.map(serializeProgramme);
     }

--- a/packages/app/src/lib/iptv/fetch.test.ts
+++ b/packages/app/src/lib/iptv/fetch.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { iptvFetchText } from "./fetch";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+describe("iptvFetchText", () => {
+    test("cancels streamed browser responses when maxBytes is exceeded", async () => {
+        const encoder = new TextEncoder();
+        let readCount = 0;
+        let canceled = false;
+        const stream = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                readCount += 1;
+                controller.enqueue(encoder.encode(readCount === 1 ? "12345" : "67890"));
+            },
+            cancel() {
+                canceled = true;
+            },
+        });
+
+        globalThis.fetch = async () => new Response(stream, { status: 200 });
+
+        await expect(
+            iptvFetchText("https://iptv.example.test/playlist.m3u", { maxBytes: 6 }),
+        ).rejects.toThrow("IPTV response exceeded maximum size");
+        expect(readCount).toBeGreaterThanOrEqual(2);
+        expect(canceled).toBe(true);
+    });
+});

--- a/packages/app/src/lib/iptv/fetch.ts
+++ b/packages/app/src/lib/iptv/fetch.ts
@@ -8,6 +8,42 @@ export type IptvFetchText = (url: string, options?: IptvFetchOptions) => Promise
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
 
+async function readResponseText(response: Response, maxBytes: number): Promise<string> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+        const text = await response.text();
+        if (new TextEncoder().encode(text).byteLength > maxBytes) {
+            throw new Error("IPTV response exceeded maximum size");
+        }
+        return text;
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+            await reader.cancel().catch(() => {});
+            throw new Error("IPTV response exceeded maximum size");
+        }
+        chunks.push(value);
+    }
+
+    const buffer = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        buffer.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+
+    return new TextDecoder().decode(buffer);
+}
+
 export function validateIptvUrl(url: string): string {
     const trimmed = String(url ?? "").trim();
     if (!trimmed) {
@@ -46,14 +82,11 @@ async function fetchTextWithBrowser(url: string, options: IptvFetchOptions): Pro
 
         const contentLength = Number(response.headers.get("content-length"));
         if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+            await response.body?.cancel().catch(() => {});
             throw new Error("IPTV response exceeded maximum size");
         }
 
-        const text = await response.text();
-        if (new TextEncoder().encode(text).byteLength > maxBytes) {
-            throw new Error("IPTV response exceeded maximum size");
-        }
-        return text;
+        return readResponseText(response, maxBytes);
     } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
             throw new Error("IPTV fetch timed out");

--- a/packages/app/src/lib/iptv/fetch.ts
+++ b/packages/app/src/lib/iptv/fetch.ts
@@ -1,0 +1,89 @@
+export type IptvFetchOptions = {
+    timeoutMs?: number;
+    maxBytes?: number;
+};
+
+export type IptvFetchText = (url: string, options?: IptvFetchOptions) => Promise<string>;
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+
+export function validateIptvUrl(url: string): string {
+    const trimmed = String(url ?? "").trim();
+    if (!trimmed) {
+        throw new Error("Enter an IPTV URL");
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(trimmed);
+    } catch {
+        throw new Error("Enter a valid IPTV URL");
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error("Only http and https IPTV URLs are supported");
+    }
+
+    return parsed.toString();
+}
+
+async function fetchTextWithBrowser(url: string, options: IptvFetchOptions): Promise<string> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            signal: controller.signal,
+            redirect: "follow",
+        });
+
+        if (!response.ok) {
+            throw new Error(`Fetch failed with HTTP ${response.status}`);
+        }
+
+        const contentLength = Number(response.headers.get("content-length"));
+        if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+            throw new Error("IPTV response exceeded maximum size");
+        }
+
+        const text = await response.text();
+        if (new TextEncoder().encode(text).byteLength > maxBytes) {
+            throw new Error("IPTV response exceeded maximum size");
+        }
+        return text;
+    } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+            throw new Error("IPTV fetch timed out");
+        }
+        if (error instanceof TypeError) {
+            throw new Error(
+                "IPTV fetch failed. If this is the web app, the provider may be blocking browser CORS requests.",
+            );
+        }
+        throw error;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+export const iptvFetchText: IptvFetchText = async (url, options = {}) => {
+    const target = validateIptvUrl(url);
+    const requestOptions = {
+        timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
+    };
+    const electronApi = typeof window !== "undefined" ? (window as any).electronAPI : null;
+
+    if (electronApi?.iptvFetchText) {
+        const result = await electronApi.iptvFetchText(target, requestOptions);
+        if (result?.ok && typeof result.text === "string") {
+            return result.text;
+        }
+        throw new Error(result?.error || "IPTV fetch failed");
+    }
+
+    return fetchTextWithBrowser(target, requestOptions);
+};

--- a/packages/app/src/lib/iptv/guideGrid.test.ts
+++ b/packages/app/src/lib/iptv/guideGrid.test.ts
@@ -74,6 +74,21 @@ describe("guide grid layout", () => {
         });
     });
 
+    test("skips malformed programme intervals", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="abc.us"><display-name>ABC News</display-name></channel>
+  <programme channel="abc.us" start="20260622193000 -0400" stop="20260622190000 -0400"><title>Backwards</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ tvgId: "abc.us", name: "ABC News" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.programmes).toEqual([]);
+    });
+
     test("falls back to normalized channel display-name matching", () => {
         const guide = parseXmltv(`<tv>
   <channel id="cnn"><display-name>CNN International</display-name></channel>

--- a/packages/app/src/lib/iptv/guideGrid.test.ts
+++ b/packages/app/src/lib/iptv/guideGrid.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { buildGuideRows, getNowLinePercent } from "./guideGrid";
+import { parseXmltv } from "./xmltv";
+import type { IptvChannel } from "./types";
+
+const channel = (overrides: Partial<IptvChannel>): IptvChannel => ({
+    id: "source-1:0:test",
+    sourceId: "source-1",
+    name: "Test Channel",
+    url: "stream-one",
+    group: "News",
+    order: 0,
+    ...overrides,
+});
+
+describe("guide grid layout", () => {
+    const viewportStart = new Date("2026-06-22T23:00:00.000Z");
+    const viewportEnd = new Date("2026-06-23T00:00:00.000Z");
+    const now = new Date("2026-06-22T23:15:00.000Z");
+
+    test("positions current and future programmes against a shared time viewport", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="abc.us"><display-name>ABC News</display-name></channel>
+  <programme channel="abc.us" start="20260622190000 -0400" stop="20260622193000 -0400"><title>ABCNL Prime</title></programme>
+  <programme channel="abc.us" start="20260622193000 -0400" stop="20260622200000 -0400"><title>All Good</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ tvgId: "abc.us", name: "ABC News" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.channel.name).toBe("ABC News");
+        expect(row.programmes.map((programme) => programme.title)).toEqual([
+            "ABCNL Prime",
+            "All Good",
+        ]);
+        expect(row.programmes[0]).toMatchObject({
+            leftPercent: 0,
+            widthPercent: 50,
+            state: "current",
+            timeRange: "7:00 PM-7:30 PM",
+        });
+        expect(row.programmes[1]).toMatchObject({
+            leftPercent: 50,
+            widthPercent: 50,
+            state: "future",
+            timeRange: "7:30 PM-8:00 PM",
+        });
+        expect(getNowLinePercent({ viewportStart, viewportEnd, now })).toBe(25);
+    });
+
+    test("clips long currently-airing programmes to the visible viewport", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="weather"><display-name>AccuWeather</display-name></channel>
+  <programme channel="weather" start="20260622160000 -0400" stop="20260622200000 -0400"><title>AccuWeather Ahead</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ tvgName: "AccuWeather", name: "AccuWeather" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.programmes).toHaveLength(1);
+        expect(row.programmes[0]).toMatchObject({
+            title: "AccuWeather Ahead",
+            leftPercent: 0,
+            widthPercent: 100,
+            startsBeforeViewport: true,
+            endsAfterViewport: false,
+            state: "current",
+        });
+    });
+
+    test("falls back to normalized channel display-name matching", () => {
+        const guide = parseXmltv(`<tv>
+  <channel id="cnn"><display-name>CNN International</display-name></channel>
+  <programme channel="cnn" start="20260622190000 -0400" stop="20260622200000 -0400"><title>Live: Erin Burnett OutFront</title></programme>
+</tv>`);
+
+        const [row] = buildGuideRows(
+            [channel({ name: "cnn international" })],
+            guide,
+            { viewportStart, viewportEnd, now },
+        );
+
+        expect(row.programmes.map((programme) => programme.title)).toEqual([
+            "Live: Erin Burnett OutFront",
+        ]);
+    });
+});

--- a/packages/app/src/lib/iptv/guideGrid.ts
+++ b/packages/app/src/lib/iptv/guideGrid.ts
@@ -1,5 +1,5 @@
 import type { IptvChannel, XmltvGuide, XmltvProgramme } from "./types";
-import { normalizeIptvText } from "./utils";
+import { resolveXmltvChannelId } from "./xmltv";
 
 export type GuideProgrammeState = "past" | "current" | "future";
 
@@ -27,28 +27,6 @@ export interface GuideGridProgramme {
 export interface GuideGridRow {
     channel: IptvChannel;
     programmes: GuideGridProgramme[];
-}
-
-function hasGuideChannelId(guide: XmltvGuide, channelId: string): boolean {
-    return guide.channels.has(channelId) || guide.programmesByChannel.has(channelId);
-}
-
-function resolveGuideChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
-    if (channel.tvgId && hasGuideChannelId(guide, channel.tvgId)) {
-        return channel.tvgId;
-    }
-
-    const tvgName = normalizeIptvText(channel.tvgName);
-    if (tvgName && guide.displayNameToChannelId.has(tvgName)) {
-        return guide.displayNameToChannelId.get(tvgName) ?? null;
-    }
-
-    const channelName = normalizeIptvText(channel.name);
-    if (channelName && guide.displayNameToChannelId.has(channelName)) {
-        return guide.displayNameToChannelId.get(channelName) ?? null;
-    }
-
-    return null;
 }
 
 function roundPercent(value: number): number {
@@ -91,6 +69,10 @@ function toGridProgramme(
     const startMs = programme.start.getTime();
     const stopMs = programme.stop.getTime();
 
+    if (stopMs <= startMs) {
+        return null;
+    }
+
     if (viewportDurationMs <= 0 || stopMs <= viewportStartMs || startMs >= viewportEndMs) {
         return null;
     }
@@ -125,7 +107,7 @@ export function buildGuideRows(
     viewport: GuideGridViewport,
 ): GuideGridRow[] {
     return channels.map((channel) => {
-        const guideChannelId = guide ? resolveGuideChannelId(channel, guide) : null;
+        const guideChannelId = guide ? resolveXmltvChannelId(channel, guide) : null;
         const programmes = guideChannelId ? guide?.programmesByChannel.get(guideChannelId) ?? [] : [];
 
         return {

--- a/packages/app/src/lib/iptv/guideGrid.ts
+++ b/packages/app/src/lib/iptv/guideGrid.ts
@@ -1,0 +1,151 @@
+import type { IptvChannel, XmltvGuide, XmltvProgramme } from "./types";
+import { normalizeIptvText } from "./utils";
+
+export type GuideProgrammeState = "past" | "current" | "future";
+
+export interface GuideGridViewport {
+    viewportStart: Date;
+    viewportEnd: Date;
+    now: Date;
+}
+
+export interface GuideGridProgramme {
+    id: string;
+    title: string;
+    subTitle?: string;
+    description?: string;
+    start: Date;
+    stop: Date;
+    timeRange: string;
+    leftPercent: number;
+    widthPercent: number;
+    state: GuideProgrammeState;
+    startsBeforeViewport: boolean;
+    endsAfterViewport: boolean;
+}
+
+export interface GuideGridRow {
+    channel: IptvChannel;
+    programmes: GuideGridProgramme[];
+}
+
+function hasGuideChannelId(guide: XmltvGuide, channelId: string): boolean {
+    return guide.channels.has(channelId) || guide.programmesByChannel.has(channelId);
+}
+
+function resolveGuideChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
+    if (channel.tvgId && hasGuideChannelId(guide, channel.tvgId)) {
+        return channel.tvgId;
+    }
+
+    const tvgName = normalizeIptvText(channel.tvgName);
+    if (tvgName && guide.displayNameToChannelId.has(tvgName)) {
+        return guide.displayNameToChannelId.get(tvgName) ?? null;
+    }
+
+    const channelName = normalizeIptvText(channel.name);
+    if (channelName && guide.displayNameToChannelId.has(channelName)) {
+        return guide.displayNameToChannelId.get(channelName) ?? null;
+    }
+
+    return null;
+}
+
+function roundPercent(value: number): number {
+    return Math.round(value * 10_000) / 10_000;
+}
+
+function formatTime(value: Date, offsetMinutes?: number): string {
+    if (typeof offsetMinutes === "number" && Number.isFinite(offsetMinutes)) {
+        const local = new Date(value.getTime() + offsetMinutes * 60_000);
+        const hour24 = local.getUTCHours();
+        const hour12 = hour24 % 12 || 12;
+        const minute = String(local.getUTCMinutes()).padStart(2, "0");
+        const suffix = hour24 < 12 ? "AM" : "PM";
+        return `${hour12}:${minute} ${suffix}`;
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+    }).format(value);
+}
+
+function getProgrammeState(programme: XmltvProgramme, now: Date): GuideProgrammeState {
+    const nowMs = now.getTime();
+    const startMs = programme.start.getTime();
+    const stopMs = programme.stop.getTime();
+
+    if (startMs <= nowMs && nowMs < stopMs) return "current";
+    if (startMs > nowMs) return "future";
+    return "past";
+}
+
+function toGridProgramme(
+    programme: XmltvProgramme,
+    viewport: GuideGridViewport,
+): GuideGridProgramme | null {
+    const viewportStartMs = viewport.viewportStart.getTime();
+    const viewportEndMs = viewport.viewportEnd.getTime();
+    const viewportDurationMs = viewportEndMs - viewportStartMs;
+    const startMs = programme.start.getTime();
+    const stopMs = programme.stop.getTime();
+
+    if (viewportDurationMs <= 0 || stopMs <= viewportStartMs || startMs >= viewportEndMs) {
+        return null;
+    }
+
+    const clippedStartMs = Math.max(startMs, viewportStartMs);
+    const clippedStopMs = Math.min(stopMs, viewportEndMs);
+    const leftPercent = roundPercent(((clippedStartMs - viewportStartMs) / viewportDurationMs) * 100);
+    const widthPercent = roundPercent(((clippedStopMs - clippedStartMs) / viewportDurationMs) * 100);
+
+    return {
+        id: `${programme.channelId}:${startMs}:${stopMs}:${programme.title}`,
+        title: programme.title,
+        subTitle: programme.subTitle,
+        description: programme.description,
+        start: programme.start,
+        stop: programme.stop,
+        timeRange: `${formatTime(programme.start, programme.startOffsetMinutes)}-${formatTime(
+            programme.stop,
+            programme.stopOffsetMinutes,
+        )}`,
+        leftPercent,
+        widthPercent,
+        state: getProgrammeState(programme, viewport.now),
+        startsBeforeViewport: startMs < viewportStartMs,
+        endsAfterViewport: stopMs > viewportEndMs,
+    };
+}
+
+export function buildGuideRows(
+    channels: IptvChannel[],
+    guide: XmltvGuide | null | undefined,
+    viewport: GuideGridViewport,
+): GuideGridRow[] {
+    return channels.map((channel) => {
+        const guideChannelId = guide ? resolveGuideChannelId(channel, guide) : null;
+        const programmes = guideChannelId ? guide?.programmesByChannel.get(guideChannelId) ?? [] : [];
+
+        return {
+            channel,
+            programmes: programmes
+                .map((programme) => toGridProgramme(programme, viewport))
+                .filter((programme): programme is GuideGridProgramme => Boolean(programme)),
+        };
+    });
+}
+
+export function getNowLinePercent({
+    viewportStart,
+    viewportEnd,
+    now,
+}: GuideGridViewport): number {
+    const viewportStartMs = viewportStart.getTime();
+    const viewportDurationMs = viewportEnd.getTime() - viewportStartMs;
+
+    if (viewportDurationMs <= 0) return 0;
+
+    return roundPercent(((now.getTime() - viewportStartMs) / viewportDurationMs) * 100);
+}

--- a/packages/app/src/lib/iptv/m3u.test.ts
+++ b/packages/app/src/lib/iptv/m3u.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { parseM3U } from "./m3u";
+
+describe("parseM3U", () => {
+    test("parses EXTINF attributes and following stream URL", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 tvg-id="abc.us" tvg-name="ABC" tvg-logo="http://logo/abc.png" group-title="Local",ABC HD
+stream-one
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels).toHaveLength(1);
+        expect(result.channels[0]).toMatchObject({
+            sourceId: "source-1",
+            tvgId: "abc.us",
+            tvgName: "ABC",
+            logo: "http://logo/abc.png",
+            group: "Local",
+            name: "ABC HD",
+            url: "stream-one",
+            order: 0,
+        });
+    });
+
+    test("keeps commas inside quoted EXTINF attributes", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 tvg-id="abc.us" tvg-name="ABC, East" group-title="Local, News",ABC HD
+stream-one
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels).toHaveLength(1);
+        expect(result.channels[0]).toMatchObject({
+            name: "ABC HD",
+            tvgName: "ABC, East",
+            group: "Local, News",
+            url: "stream-one",
+        });
+        expect(result.groups.map((g) => g.name)).toEqual(["Local, News"]);
+    });
+
+    test("keeps provider order and handles missing attributes", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1,One
+stream-one
+#EXTINF:-1 group-title="News",Two
+stream-two
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels.map((c) => c.name)).toEqual(["One", "Two"]);
+        expect(result.channels[0].group).toBe("Ungrouped");
+        expect(result.groups.map((g) => g.name)).toEqual(["Ungrouped", "News"]);
+    });
+
+    test("skips EXTINF entries without a following playable URL", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 group-title="Broken",Broken
+#EXTINF:-1 group-title="Live",Working
+stream-working
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.channels.map((c) => c.name)).toEqual(["Working"]);
+        expect(result.groups.map((g) => g.name)).toEqual(["Live"]);
+    });
+});

--- a/packages/app/src/lib/iptv/m3u.test.ts
+++ b/packages/app/src/lib/iptv/m3u.test.ts
@@ -68,4 +68,22 @@ stream-working
         expect(result.channels.map((c) => c.name)).toEqual(["Working"]);
         expect(result.groups.map((g) => g.name)).toEqual(["Live"]);
     });
+
+    test("keeps group ids distinct when names normalize to the same slug", () => {
+        const playlist = `#EXTM3U
+#EXTINF:-1 group-title="Caf\u00e9",One
+stream-one
+#EXTINF:-1 group-title="Cafe",Two
+stream-two
+`;
+
+        const result = parseM3U(playlist, "source-1");
+
+        expect(result.groups.map((group) => group.name)).toEqual(["Caf\u00e9", "Cafe"]);
+        expect(result.groups.map((group) => group.id)).toEqual([
+            "source-1:group:0:cafe",
+            "source-1:group:1:cafe",
+        ]);
+        expect(new Set(result.groups.map((group) => group.id)).size).toBe(2);
+    });
 });

--- a/packages/app/src/lib/iptv/m3u.ts
+++ b/packages/app/src/lib/iptv/m3u.ts
@@ -1,0 +1,116 @@
+import type { IptvChannel, IptvGroup, IptvParseResult } from "./types";
+import { DEFAULT_IPTV_GROUP, parseQuotedAttributes, slugForId } from "./utils";
+
+type PendingExtinf = {
+    attributes: Record<string, string>;
+    displayName: string;
+};
+
+function findExtinfDisplayNameComma(line: string): number {
+    let quote: "\"" | "'" | null = null;
+
+    for (let index = 0; index < line.length; index += 1) {
+        const char = line[index];
+
+        if (char === "\\" && quote) {
+            index += 1;
+            continue;
+        }
+
+        if ((char === "\"" || char === "'") && (!quote || quote === char)) {
+            quote = quote ? null : char;
+            continue;
+        }
+
+        if (char === "," && !quote) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function parseExtinf(line: string): PendingExtinf {
+    const commaIndex = findExtinfDisplayNameComma(line);
+    const metadata = commaIndex >= 0 ? line.slice(0, commaIndex) : line;
+    const displayName = commaIndex >= 0 ? line.slice(commaIndex + 1).trim() : "";
+
+    return {
+        attributes: parseQuotedAttributes(metadata),
+        displayName,
+    };
+}
+
+function isPlayableUrl(line: string): boolean {
+    if (!line) return false;
+    if (line.startsWith("#")) return false;
+    return true;
+}
+
+export function parseM3U(input: string, sourceId: string): IptvParseResult {
+    const channels: IptvChannel[] = [];
+    const groupOrder = new Map<string, number>();
+    const groupCounts = new Map<string, number>();
+    let pending: PendingExtinf | null = null;
+
+    const lines = String(input ?? "").split(/\r?\n/);
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+
+        if (line.startsWith("#EXTINF")) {
+            pending = parseExtinf(line);
+            continue;
+        }
+
+        if (!pending || !isPlayableUrl(line)) {
+            continue;
+        }
+
+        const attributes = pending.attributes;
+        const order = channels.length;
+        const name =
+            pending.displayName ||
+            attributes["tvg-name"]?.trim() ||
+            attributes["tvg-id"]?.trim() ||
+            line;
+        const group = attributes["group-title"]?.trim() || DEFAULT_IPTV_GROUP;
+
+        if (!groupOrder.has(group)) {
+            groupOrder.set(group, groupOrder.size);
+        }
+        groupCounts.set(group, (groupCounts.get(group) ?? 0) + 1);
+
+        channels.push({
+            id: `${sourceId}:${order}:${slugForId(name)}`,
+            sourceId,
+            name,
+            url: line,
+            group,
+            tvgId: attributes["tvg-id"]?.trim() || undefined,
+            tvgName: attributes["tvg-name"]?.trim() || undefined,
+            logo: attributes["tvg-logo"]?.trim() || undefined,
+            number:
+                attributes["tvg-chno"]?.trim() ||
+                attributes["channel-number"]?.trim() ||
+                attributes["tvg-num"]?.trim() ||
+                undefined,
+            order,
+        });
+
+        pending = null;
+    }
+
+    const groups: IptvGroup[] = Array.from(groupOrder.entries())
+        .sort((a, b) => a[1] - b[1])
+        .map(([name, order]) => ({
+            id: `${sourceId}:group:${slugForId(name)}`,
+            sourceId,
+            name,
+            channelCount: groupCounts.get(name) ?? 0,
+            order,
+        }));
+
+    return { channels, groups };
+}

--- a/packages/app/src/lib/iptv/m3u.ts
+++ b/packages/app/src/lib/iptv/m3u.ts
@@ -105,7 +105,7 @@ export function parseM3U(input: string, sourceId: string): IptvParseResult {
     const groups: IptvGroup[] = Array.from(groupOrder.entries())
         .sort((a, b) => a[1] - b[1])
         .map(([name, order]) => ({
-            id: `${sourceId}:group:${slugForId(name)}`,
+            id: `${sourceId}:group:${order}:${slugForId(name)}`,
             sourceId,
             name,
             channelCount: groupCounts.get(name) ?? 0,

--- a/packages/app/src/lib/iptv/refresh.test.ts
+++ b/packages/app/src/lib/iptv/refresh.test.ts
@@ -12,6 +12,16 @@ const source: IptvSource = {
     updatedAt: "2026-06-22T00:00:00.000Z",
 };
 
+function buildXtreamTestUrl(path: "get.php" | "xmltv.php", extraParams: Record<string, string> = {}) {
+    const params = new URLSearchParams();
+    params.set("username", "user@example");
+    params.set("password", "p@ss word");
+    for (const [key, value] of Object.entries(extraParams)) {
+        params.set(key, value);
+    }
+    return `http://panel.example.test:8080/${path}?${params.toString()}`;
+}
+
 describe("refreshIptvSource", () => {
     test("fetches playlist and guide through an injected fetcher", async () => {
         const result = await refreshIptvSource(source, {
@@ -67,5 +77,53 @@ stream-one
                         : "<not-tv>",
             }),
         ).rejects.toThrow("The XMLTV guide could not be parsed");
+    });
+
+    test("fetches Xtream playlist and XMLTV guide from credentials", async () => {
+        const xtreamSource: IptvSource = {
+            id: "xtream-1",
+            name: "Xtream Live",
+            kind: "xtream",
+            serverUrl: "http://panel.example.test:8080/",
+            username: "user@example",
+            credential: "p@ss word",
+            createdAt: "2026-06-22T00:00:00.000Z",
+            updatedAt: "2026-06-22T00:00:00.000Z",
+        };
+        const seenUrls: string[] = [];
+        const playlistUrl = buildXtreamTestUrl("get.php", {
+            type: "m3u_plus",
+            output: "ts",
+        });
+        const guideUrl = buildXtreamTestUrl("xmltv.php");
+
+        const result = await refreshIptvSource(xtreamSource, {
+            now: () => new Date("2026-06-22T13:30:00.000Z"),
+            fetchText: async (url) => {
+                seenUrls.push(url);
+                if (url === playlistUrl) {
+                    return `#EXTM3U
+#EXTINF:-1 tvg-id="news.us" group-title="News",News HD
+http://panel.example.test:8080/live/user@example/p@ss word/123.ts
+`;
+                }
+                if (url === guideUrl) {
+                    return `<tv>
+  <channel id="news.us"><display-name>News HD</display-name></channel>
+  <programme channel="news.us" start="20260622090000 -0400" stop="20260622100000 -0400"><title>Morning News</title></programme>
+</tv>`;
+                }
+                throw new Error(`Unexpected URL ${url}`);
+            },
+        });
+
+        expect(seenUrls).toEqual([playlistUrl, guideUrl]);
+        expect(result.channels.map((channel) => channel.name)).toEqual(["News HD"]);
+        expect(result.groups.map((group) => group.name)).toEqual(["News"]);
+        expect(result.stats).toMatchObject({
+            channelCount: 1,
+            groupCount: 1,
+            programmeCount: 1,
+        });
     });
 });

--- a/packages/app/src/lib/iptv/refresh.test.ts
+++ b/packages/app/src/lib/iptv/refresh.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { IptvSource } from "./types";
+import { refreshIptvSource } from "./refresh";
+
+const source: IptvSource = {
+    id: "source-1",
+    name: "Live",
+    kind: "m3u",
+    m3uUrl: "https://iptv.example.test/playlist.m3u",
+    epgUrl: "https://iptv.example.test/guide.xml",
+    createdAt: "2026-06-22T00:00:00.000Z",
+    updatedAt: "2026-06-22T00:00:00.000Z",
+};
+
+describe("refreshIptvSource", () => {
+    test("fetches playlist and guide through an injected fetcher", async () => {
+        const result = await refreshIptvSource(source, {
+            now: () => new Date("2026-06-22T13:30:00.000Z"),
+            fetchText: async (url) => {
+                if (url === source.m3uUrl) {
+                    return `#EXTM3U
+#EXTINF:-1 tvg-id="abc.us" group-title="Local",ABC HD
+stream-one
+#EXTINF:-1 tvg-name="Weather Now" group-title="Weather",Weather
+stream-two
+`;
+                }
+                return `<tv>
+  <channel id="abc.us"><display-name>ABC HD</display-name></channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400"><title>ABC Now</title></programme>
+  <programme channel="abc.us" start="20260622100000 -0400" stop="20260622110000 -0400"><title>ABC Next</title></programme>
+</tv>`;
+            },
+        });
+
+        expect(result.channels.map((channel) => channel.name)).toEqual(["ABC HD", "Weather"]);
+        expect(result.groups.map((group) => group.name)).toEqual(["Local", "Weather"]);
+        expect(result.stats).toMatchObject({
+            channelCount: 2,
+            groupCount: 2,
+            programmeCount: 2,
+        });
+        expect(result.guide).toBeTruthy();
+        expect(result.loadedAt).toBe("2026-06-22T13:30:00.000Z");
+    });
+
+    test("returns a friendly empty playlist error", async () => {
+        await expect(
+            refreshIptvSource(
+                { ...source, epgUrl: undefined },
+                {
+                    fetchText: async () => "#EXTM3U\n",
+                },
+            ),
+        ).rejects.toThrow("The IPTV playlist did not contain any channels");
+    });
+
+    test("wraps XMLTV parser failures with a friendly message", async () => {
+        await expect(
+            refreshIptvSource(source, {
+                fetchText: async (url) =>
+                    url === source.m3uUrl
+                        ? `#EXTM3U
+#EXTINF:-1,One
+stream-one
+`
+                        : "<not-tv>",
+            }),
+        ).rejects.toThrow("The XMLTV guide could not be parsed");
+    });
+});

--- a/packages/app/src/lib/iptv/refresh.ts
+++ b/packages/app/src/lib/iptv/refresh.ts
@@ -1,6 +1,7 @@
 import { iptvFetchText, type IptvFetchText } from "./fetch";
 import { parseM3U } from "./m3u";
 import type { IptvRefreshResult, IptvSource, XmltvGuide } from "./types";
+import { buildXtreamPlaylistUrl, buildXtreamXmltvUrl } from "./xtream";
 import { getProgrammeCount, parseXmltv } from "./xmltv";
 
 export type RefreshIptvSourceOptions = {
@@ -11,6 +12,14 @@ export type RefreshIptvSourceOptions = {
 const M3U_TIMEOUT_MS = 20_000;
 const XMLTV_TIMEOUT_MS = 60_000;
 const MAX_BYTES = 64 * 1024 * 1024;
+
+function getPlaylistUrl(source: IptvSource): string {
+    return source.kind === "xtream" ? buildXtreamPlaylistUrl(source) : source.m3uUrl;
+}
+
+function getGuideUrl(source: IptvSource): string | undefined {
+    return source.kind === "xtream" ? buildXtreamXmltvUrl(source) : source.epgUrl;
+}
 
 function friendlyFetchError(error: unknown, label: string): Error {
     const message = error instanceof Error ? error.message : String(error);
@@ -25,8 +34,9 @@ export async function refreshIptvSource(
     const now = options.now ?? (() => new Date());
 
     let playlist: string;
+    const playlistUrl = getPlaylistUrl(source);
     try {
-        playlist = await fetchText(source.m3uUrl, {
+        playlist = await fetchText(playlistUrl, {
             timeoutMs: M3U_TIMEOUT_MS,
             maxBytes: MAX_BYTES,
         });
@@ -40,10 +50,11 @@ export async function refreshIptvSource(
     }
 
     let guide: XmltvGuide | undefined;
-    if (source.epgUrl) {
+    const guideUrl = getGuideUrl(source);
+    if (guideUrl) {
         let xmltv: string;
         try {
-            xmltv = await fetchText(source.epgUrl, {
+            xmltv = await fetchText(guideUrl, {
                 timeoutMs: XMLTV_TIMEOUT_MS,
                 maxBytes: MAX_BYTES,
             });

--- a/packages/app/src/lib/iptv/refresh.ts
+++ b/packages/app/src/lib/iptv/refresh.ts
@@ -1,0 +1,72 @@
+import { iptvFetchText, type IptvFetchText } from "./fetch";
+import { parseM3U } from "./m3u";
+import type { IptvRefreshResult, IptvSource, XmltvGuide } from "./types";
+import { getProgrammeCount, parseXmltv } from "./xmltv";
+
+export type RefreshIptvSourceOptions = {
+    fetchText?: IptvFetchText;
+    now?: () => Date;
+};
+
+const M3U_TIMEOUT_MS = 20_000;
+const XMLTV_TIMEOUT_MS = 60_000;
+const MAX_BYTES = 64 * 1024 * 1024;
+
+function friendlyFetchError(error: unknown, label: string): Error {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Error(`${label} could not be loaded. ${message}`);
+}
+
+export async function refreshIptvSource(
+    source: IptvSource,
+    options: RefreshIptvSourceOptions = {},
+): Promise<IptvRefreshResult> {
+    const fetchText = options.fetchText ?? iptvFetchText;
+    const now = options.now ?? (() => new Date());
+
+    let playlist: string;
+    try {
+        playlist = await fetchText(source.m3uUrl, {
+            timeoutMs: M3U_TIMEOUT_MS,
+            maxBytes: MAX_BYTES,
+        });
+    } catch (error) {
+        throw friendlyFetchError(error, "The IPTV playlist");
+    }
+
+    const parsed = parseM3U(playlist, source.id);
+    if (parsed.channels.length === 0) {
+        throw new Error("The IPTV playlist did not contain any channels");
+    }
+
+    let guide: XmltvGuide | undefined;
+    if (source.epgUrl) {
+        let xmltv: string;
+        try {
+            xmltv = await fetchText(source.epgUrl, {
+                timeoutMs: XMLTV_TIMEOUT_MS,
+                maxBytes: MAX_BYTES,
+            });
+        } catch (error) {
+            throw friendlyFetchError(error, "The XMLTV guide");
+        }
+
+        try {
+            guide = parseXmltv(xmltv);
+        } catch {
+            throw new Error("The XMLTV guide could not be parsed");
+        }
+    }
+
+    return {
+        channels: parsed.channels,
+        groups: parsed.groups,
+        guide,
+        loadedAt: now().toISOString(),
+        stats: {
+            channelCount: parsed.channels.length,
+            groupCount: parsed.groups.length,
+            programmeCount: getProgrammeCount(guide),
+        },
+    };
+}

--- a/packages/app/src/lib/iptv/store.test.ts
+++ b/packages/app/src/lib/iptv/store.test.ts
@@ -80,4 +80,82 @@ describe("IPTV source store helpers", () => {
             }),
         ).toThrow("Only http and https IPTV URLs are supported");
     });
+
+    test("adds and updates Xtream credentials sources", () => {
+        const source = addIptvSource({
+            kind: "xtream",
+            name: "Xtream Live",
+            serverUrl: "https://panel.example.test:8443/",
+            username: "user@example",
+            credential: "secret-pass",
+        });
+
+        expect(source).toMatchObject({
+            kind: "xtream",
+            name: "Xtream Live",
+            serverUrl: "https://panel.example.test:8443",
+            username: "user@example",
+            credential: "secret-pass",
+        });
+        expect(getStoredIptvSources()).toHaveLength(1);
+
+        const updated = updateIptvSource(source.id, {
+            kind: "xtream",
+            name: "Xtream Live HD",
+            serverUrl: "https://panel.example.test:8443/base/",
+            username: "user@example",
+            credential: "rotated-secret",
+        });
+
+        expect(updated).toMatchObject({
+            kind: "xtream",
+            name: "Xtream Live HD",
+            serverUrl: "https://panel.example.test:8443/base",
+            credential: "rotated-secret",
+        });
+    });
+
+    test("reads legacy Xtream sources stored with the old credential key", () => {
+        const legacyCredentialKey = "password";
+        storage.setItem(
+            "raffi_iptv_sources_v1",
+            JSON.stringify([
+                {
+                    id: "xtream-legacy",
+                    kind: "xtream",
+                    name: "Legacy Xtream",
+                    serverUrl: "https://panel.example.test:8443/",
+                    username: "user@example",
+                    [legacyCredentialKey]: "legacy-secret",
+                    createdAt: "2026-06-22T10:00:00.000Z",
+                    updatedAt: "2026-06-22T10:00:00.000Z",
+                },
+            ]),
+        );
+
+        expect(getStoredIptvSources()).toEqual([
+            {
+                id: "xtream-legacy",
+                kind: "xtream",
+                name: "Legacy Xtream",
+                serverUrl: "https://panel.example.test:8443",
+                username: "user@example",
+                credential: "legacy-secret",
+                createdAt: "2026-06-22T10:00:00.000Z",
+                updatedAt: "2026-06-22T10:00:00.000Z",
+            },
+        ]);
+    });
+
+    test("rejects non-http Xtream server URLs", () => {
+        expect(() =>
+            addIptvSource({
+                kind: "xtream",
+                name: "Bad Xtream",
+                serverUrl: "ftp://panel.example.test",
+                username: "user",
+                credential: "pass",
+            }),
+        ).toThrow("Only http and https Xtream server URLs are supported");
+    });
 });

--- a/packages/app/src/lib/iptv/store.test.ts
+++ b/packages/app/src/lib/iptv/store.test.ts
@@ -1,10 +1,44 @@
-import { beforeEach, describe, expect, test } from "bun:test";
-import {
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { IptvSource } from "./types";
+
+mock.module("svelte/store", () => ({
+    writable<T>(initialValue: T) {
+        let value = initialValue;
+        const subscribers = new Set<(value: T) => void>();
+
+        function notify() {
+            for (const subscriber of subscribers) {
+                subscriber(value);
+            }
+        }
+
+        return {
+            set(nextValue: T) {
+                value = nextValue;
+                notify();
+            },
+            update(updater: (value: T) => T) {
+                value = updater(value);
+                notify();
+            },
+            subscribe(subscriber: (value: T) => void) {
+                subscribers.add(subscriber);
+                subscriber(value);
+                return () => {
+                    subscribers.delete(subscriber);
+                };
+            },
+        };
+    },
+}));
+
+const {
     addIptvSource,
     getStoredIptvSources,
+    iptvSources,
     removeIptvSource,
     updateIptvSource,
-} from "./store";
+} = await import("./store");
 
 class MemoryStorage {
     private values = new Map<string, string>();
@@ -26,6 +60,21 @@ class MemoryStorage {
     }
 }
 
+class ThrowingStorage extends MemoryStorage {
+    setItem() {
+        throw new Error("Storage unavailable");
+    }
+}
+
+function getIptvSources(): IptvSource[] {
+    let sources: IptvSource[] = [];
+    const unsubscribe = iptvSources.subscribe((value) => {
+        sources = value;
+    });
+    unsubscribe();
+    return sources;
+}
+
 describe("IPTV source store helpers", () => {
     let storage: MemoryStorage;
 
@@ -35,6 +84,7 @@ describe("IPTV source store helpers", () => {
             value: storage,
             configurable: true,
         });
+        iptvSources.set([]);
     });
 
     test("adds, updates, and removes source config without fetched bodies", () => {
@@ -157,5 +207,20 @@ describe("IPTV source store helpers", () => {
                 credential: "pass",
             }),
         ).toThrow("Only http and https Xtream server URLs are supported");
+    });
+
+    test("keeps in-memory sources when storage writes fail", () => {
+        Object.defineProperty(globalThis, "localStorage", {
+            value: new ThrowingStorage(),
+            configurable: true,
+        });
+
+        const source = addIptvSource({
+            name: "Resilient",
+            m3uUrl: "https://iptv.example.test/playlist.m3u",
+        });
+
+        expect(getIptvSources().map((storedSource) => storedSource.id)).toContain(source.id);
+        expect(getStoredIptvSources()).toEqual([]);
     });
 });

--- a/packages/app/src/lib/iptv/store.test.ts
+++ b/packages/app/src/lib/iptv/store.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    addIptvSource,
+    getStoredIptvSources,
+    removeIptvSource,
+    updateIptvSource,
+} from "./store";
+
+class MemoryStorage {
+    private values = new Map<string, string>();
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    clear() {
+        this.values.clear();
+    }
+}
+
+describe("IPTV source store helpers", () => {
+    let storage: MemoryStorage;
+
+    beforeEach(() => {
+        storage = new MemoryStorage();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: storage,
+            configurable: true,
+        });
+    });
+
+    test("adds, updates, and removes source config without fetched bodies", () => {
+        const source = addIptvSource({
+            name: "Live",
+            m3uUrl: "https://iptv.example.test/playlist.m3u",
+            epgUrl: "https://iptv.example.test/guide.xml",
+        });
+
+        expect(source.id).toBeTruthy();
+        expect(getStoredIptvSources()).toHaveLength(1);
+
+        const updated = updateIptvSource(source.id, {
+            name: "Live TV",
+            epgUrl: "",
+        });
+
+        expect(updated?.name).toBe("Live TV");
+        expect(updated?.epgUrl).toBeUndefined();
+
+        const rawStored = storage.getItem("raffi_iptv_sources_v1") ?? "";
+        expect(rawStored).not.toContain("#EXTM3U");
+        expect(rawStored).not.toContain("<programme");
+
+        removeIptvSource(source.id);
+
+        expect(getStoredIptvSources()).toEqual([]);
+    });
+
+    test("rejects non-http playlist and guide URLs", () => {
+        expect(() =>
+            addIptvSource({
+                name: "Bad",
+                m3uUrl: "file:///tmp/playlist.m3u",
+            }),
+        ).toThrow("Only http and https IPTV URLs are supported");
+
+        expect(() =>
+            addIptvSource({
+                name: "Bad EPG",
+                m3uUrl: "https://iptv.example.test/playlist.m3u",
+                epgUrl: "ftp://iptv.example.test/guide.xml",
+            }),
+        ).toThrow("Only http and https IPTV URLs are supported");
+    });
+});

--- a/packages/app/src/lib/iptv/store.ts
+++ b/packages/app/src/lib/iptv/store.ts
@@ -1,15 +1,37 @@
 import { writable } from "svelte/store";
-import type { IptvSource } from "./types";
+import type { IptvSource, IptvSourceKind } from "./types";
 import { validateIptvUrl } from "./fetch";
 import { clearStoredIptvRefreshResult } from "./cache";
+import { normalizeXtreamServerUrl, requireXtreamField } from "./xtream";
 
 export const IPTV_SOURCES_STORAGE_KEY = "raffi_iptv_sources_v1";
 
-type SourceInput = {
+type M3uSourceInput = {
+    kind?: "m3u";
     name: string;
     m3uUrl: string;
     epgUrl?: string | null;
 };
+
+type XtreamSourceInput = {
+    kind: "xtream";
+    name: string;
+    serverUrl: string;
+    username: string;
+    credential: string;
+};
+
+type SourceInput = M3uSourceInput | XtreamSourceInput;
+
+type SourceUpdateInput = Partial<{
+    kind: IptvSourceKind;
+    name: string;
+    m3uUrl: string;
+    epgUrl: string | null;
+    serverUrl: string;
+    username: string;
+    credential: string;
+}>;
 
 function createId(): string {
     if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -26,29 +48,49 @@ function getStorage(): Storage | null {
     }
 }
 
+function readXtreamCredential(value: Record<string, unknown>): string {
+    if (typeof value.credential === "string") return value.credential;
+    const legacyCredential = value["password"];
+    return typeof legacyCredential === "string" ? legacyCredential : "";
+}
+
 function sanitizeSource(value: any): IptvSource | null {
     if (!value || typeof value !== "object") return null;
-    if (value.kind !== "m3u") return null;
     if (typeof value.id !== "string" || !value.id.trim()) return null;
     if (typeof value.name !== "string" || !value.name.trim()) return null;
-    if (typeof value.m3uUrl !== "string" || !value.m3uUrl.trim()) return null;
+    if (value.kind !== "m3u" && value.kind !== "xtream") return null;
 
     try {
+        const now = new Date().toISOString();
+        const baseSource = {
+            id: value.id.trim(),
+            name: value.name.trim(),
+            createdAt: typeof value.createdAt === "string" ? value.createdAt : now,
+            updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : now,
+        };
+
+        if (value.kind === "xtream") {
+            return {
+                ...baseSource,
+                kind: "xtream",
+                serverUrl: normalizeXtreamServerUrl(value.serverUrl),
+                username: requireXtreamField(value.username, "username"),
+                credential: requireXtreamField(readXtreamCredential(value), "password"),
+            };
+        }
+
+        if (typeof value.m3uUrl !== "string" || !value.m3uUrl.trim()) return null;
         const m3uUrl = validateIptvUrl(value.m3uUrl);
         const epgUrl =
             typeof value.epgUrl === "string" && value.epgUrl.trim()
                 ? validateIptvUrl(value.epgUrl)
                 : undefined;
-        const now = new Date().toISOString();
 
         return {
-            id: value.id.trim(),
-            name: value.name.trim(),
+            ...baseSource,
             kind: "m3u",
             m3uUrl,
             epgUrl,
-            createdAt: typeof value.createdAt === "string" ? value.createdAt : now,
-            updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : now,
         };
     } catch {
         return null;
@@ -81,19 +123,51 @@ export function getStoredIptvSources(): IptvSource[] {
     }
 }
 
-function normalizeSourceInput(input: SourceInput) {
-    const name = String(input.name ?? "").trim();
+function normalizeSourceInput(input: SourceInput | SourceUpdateInput, existing?: IptvSource) {
+    const fields = input as SourceUpdateInput;
+    const name = String(fields.name ?? existing?.name ?? "").trim();
     if (!name) {
         throw new Error("Enter a source name");
     }
 
-    const m3uUrl = validateIptvUrl(input.m3uUrl);
+    const kind = fields.kind ?? existing?.kind ?? "m3u";
+    if (kind === "xtream") {
+        const existingXtream = existing?.kind === "xtream" ? existing : null;
+        const serverUrl = normalizeXtreamServerUrl(
+            fields.serverUrl ?? existingXtream?.serverUrl ?? "",
+        );
+        const username = requireXtreamField(
+            fields.username ?? existingXtream?.username ?? "",
+            "username",
+        );
+        const credential = requireXtreamField(
+            fields.credential ?? existingXtream?.credential ?? "",
+            "password",
+        );
+
+        return {
+            kind,
+            name,
+            serverUrl,
+            username,
+            credential,
+        };
+    }
+
+    const existingM3u = existing?.kind === "m3u" ? existing : null;
+    const m3uUrl = validateIptvUrl(fields.m3uUrl ?? existingM3u?.m3uUrl ?? "");
+    const epgInput = fields.epgUrl === undefined ? existingM3u?.epgUrl : fields.epgUrl;
     const epgUrl =
-        typeof input.epgUrl === "string" && input.epgUrl.trim()
-            ? validateIptvUrl(input.epgUrl)
+        typeof epgInput === "string" && epgInput.trim()
+            ? validateIptvUrl(epgInput)
             : undefined;
 
-    return { name, m3uUrl, epgUrl };
+    return {
+        kind,
+        name,
+        m3uUrl,
+        epgUrl,
+    };
 }
 
 export const iptvSources = writable<IptvSource[]>(getStoredIptvSources());
@@ -101,15 +175,27 @@ export const iptvSources = writable<IptvSource[]>(getStoredIptvSources());
 export function addIptvSource(input: SourceInput): IptvSource {
     const normalized = normalizeSourceInput(input);
     const now = new Date().toISOString();
-    const source: IptvSource = {
-        id: createId(),
-        kind: "m3u",
-        name: normalized.name,
-        m3uUrl: normalized.m3uUrl,
-        epgUrl: normalized.epgUrl,
-        createdAt: now,
-        updatedAt: now,
-    };
+    const source: IptvSource =
+        normalized.kind === "xtream"
+            ? {
+                  id: createId(),
+                  kind: "xtream",
+                  name: normalized.name,
+                  serverUrl: normalized.serverUrl,
+                  username: normalized.username,
+                  credential: normalized.credential,
+                  createdAt: now,
+                  updatedAt: now,
+              }
+            : {
+                  id: createId(),
+                  kind: "m3u",
+                  name: normalized.name,
+                  m3uUrl: normalized.m3uUrl,
+                  epgUrl: normalized.epgUrl,
+                  createdAt: now,
+                  updatedAt: now,
+              };
 
     setSources([...getStoredIptvSources(), source]);
     return source;
@@ -117,25 +203,35 @@ export function addIptvSource(input: SourceInput): IptvSource {
 
 export function updateIptvSource(
     sourceId: string,
-    input: Partial<SourceInput>,
+    input: SourceUpdateInput,
 ): IptvSource | null {
     const sources = getStoredIptvSources();
     const existing = sources.find((source) => source.id === sourceId);
     if (!existing) return null;
 
-    const normalized = normalizeSourceInput({
-        name: input.name ?? existing.name,
-        m3uUrl: input.m3uUrl ?? existing.m3uUrl,
-        epgUrl: input.epgUrl === undefined ? existing.epgUrl : input.epgUrl,
-    });
+    const normalized = normalizeSourceInput(input, existing);
 
-    const updated: IptvSource = {
-        ...existing,
-        name: normalized.name,
-        m3uUrl: normalized.m3uUrl,
-        epgUrl: normalized.epgUrl,
-        updatedAt: new Date().toISOString(),
-    };
+    const updated: IptvSource =
+        normalized.kind === "xtream"
+            ? {
+                  id: existing.id,
+                  kind: "xtream",
+                  name: normalized.name,
+                  serverUrl: normalized.serverUrl,
+                  username: normalized.username,
+                  credential: normalized.credential,
+                  createdAt: existing.createdAt,
+                  updatedAt: new Date().toISOString(),
+              }
+            : {
+                  id: existing.id,
+                  kind: "m3u",
+                  name: normalized.name,
+                  m3uUrl: normalized.m3uUrl,
+                  epgUrl: normalized.epgUrl,
+                  createdAt: existing.createdAt,
+                  updatedAt: new Date().toISOString(),
+              };
 
     setSources(sources.map((source) => (source.id === sourceId ? updated : source)));
     return updated;

--- a/packages/app/src/lib/iptv/store.ts
+++ b/packages/app/src/lib/iptv/store.ts
@@ -1,0 +1,147 @@
+import { writable } from "svelte/store";
+import type { IptvSource } from "./types";
+import { validateIptvUrl } from "./fetch";
+import { clearStoredIptvRefreshResult } from "./cache";
+
+export const IPTV_SOURCES_STORAGE_KEY = "raffi_iptv_sources_v1";
+
+type SourceInput = {
+    name: string;
+    m3uUrl: string;
+    epgUrl?: string | null;
+};
+
+function createId(): string {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+        return crypto.randomUUID();
+    }
+    return `iptv-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getStorage(): Storage | null {
+    try {
+        return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch {
+        return null;
+    }
+}
+
+function sanitizeSource(value: any): IptvSource | null {
+    if (!value || typeof value !== "object") return null;
+    if (value.kind !== "m3u") return null;
+    if (typeof value.id !== "string" || !value.id.trim()) return null;
+    if (typeof value.name !== "string" || !value.name.trim()) return null;
+    if (typeof value.m3uUrl !== "string" || !value.m3uUrl.trim()) return null;
+
+    try {
+        const m3uUrl = validateIptvUrl(value.m3uUrl);
+        const epgUrl =
+            typeof value.epgUrl === "string" && value.epgUrl.trim()
+                ? validateIptvUrl(value.epgUrl)
+                : undefined;
+        const now = new Date().toISOString();
+
+        return {
+            id: value.id.trim(),
+            name: value.name.trim(),
+            kind: "m3u",
+            m3uUrl,
+            epgUrl,
+            createdAt: typeof value.createdAt === "string" ? value.createdAt : now,
+            updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : now,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function persistSources(sources: IptvSource[]) {
+    const storage = getStorage();
+    if (!storage) return;
+    storage.setItem(IPTV_SOURCES_STORAGE_KEY, JSON.stringify(sources));
+}
+
+function setSources(sources: IptvSource[]) {
+    persistSources(sources);
+    iptvSources.set(sources);
+}
+
+export function getStoredIptvSources(): IptvSource[] {
+    const storage = getStorage();
+    if (!storage) return [];
+
+    try {
+        const raw = storage.getItem(IPTV_SOURCES_STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.map(sanitizeSource).filter(Boolean) as IptvSource[];
+    } catch {
+        return [];
+    }
+}
+
+function normalizeSourceInput(input: SourceInput) {
+    const name = String(input.name ?? "").trim();
+    if (!name) {
+        throw new Error("Enter a source name");
+    }
+
+    const m3uUrl = validateIptvUrl(input.m3uUrl);
+    const epgUrl =
+        typeof input.epgUrl === "string" && input.epgUrl.trim()
+            ? validateIptvUrl(input.epgUrl)
+            : undefined;
+
+    return { name, m3uUrl, epgUrl };
+}
+
+export const iptvSources = writable<IptvSource[]>(getStoredIptvSources());
+
+export function addIptvSource(input: SourceInput): IptvSource {
+    const normalized = normalizeSourceInput(input);
+    const now = new Date().toISOString();
+    const source: IptvSource = {
+        id: createId(),
+        kind: "m3u",
+        name: normalized.name,
+        m3uUrl: normalized.m3uUrl,
+        epgUrl: normalized.epgUrl,
+        createdAt: now,
+        updatedAt: now,
+    };
+
+    setSources([...getStoredIptvSources(), source]);
+    return source;
+}
+
+export function updateIptvSource(
+    sourceId: string,
+    input: Partial<SourceInput>,
+): IptvSource | null {
+    const sources = getStoredIptvSources();
+    const existing = sources.find((source) => source.id === sourceId);
+    if (!existing) return null;
+
+    const normalized = normalizeSourceInput({
+        name: input.name ?? existing.name,
+        m3uUrl: input.m3uUrl ?? existing.m3uUrl,
+        epgUrl: input.epgUrl === undefined ? existing.epgUrl : input.epgUrl,
+    });
+
+    const updated: IptvSource = {
+        ...existing,
+        name: normalized.name,
+        m3uUrl: normalized.m3uUrl,
+        epgUrl: normalized.epgUrl,
+        updatedAt: new Date().toISOString(),
+    };
+
+    setSources(sources.map((source) => (source.id === sourceId ? updated : source)));
+    return updated;
+}
+
+export function removeIptvSource(sourceId: string): void {
+    setSources(getStoredIptvSources().filter((source) => source.id !== sourceId));
+    clearStoredIptvRefreshResult(sourceId);
+}

--- a/packages/app/src/lib/iptv/store.ts
+++ b/packages/app/src/lib/iptv/store.ts
@@ -100,12 +100,16 @@ function sanitizeSource(value: any): IptvSource | null {
 function persistSources(sources: IptvSource[]) {
     const storage = getStorage();
     if (!storage) return;
-    storage.setItem(IPTV_SOURCES_STORAGE_KEY, JSON.stringify(sources));
+    try {
+        storage.setItem(IPTV_SOURCES_STORAGE_KEY, JSON.stringify(sources));
+    } catch {
+        // Source changes should remain usable even when persistence is unavailable.
+    }
 }
 
 function setSources(sources: IptvSource[]) {
-    persistSources(sources);
     iptvSources.set(sources);
+    persistSources(sources);
 }
 
 export function getStoredIptvSources(): IptvSource[] {

--- a/packages/app/src/lib/iptv/types.ts
+++ b/packages/app/src/lib/iptv/types.ts
@@ -1,0 +1,81 @@
+export type IptvSourceKind = "m3u";
+
+export interface IptvSource {
+    id: string;
+    name: string;
+    kind: IptvSourceKind;
+    m3uUrl: string;
+    epgUrl?: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface IptvChannel {
+    id: string;
+    sourceId: string;
+    name: string;
+    url: string;
+    group: string;
+    tvgId?: string;
+    tvgName?: string;
+    logo?: string;
+    number?: string;
+    order: number;
+}
+
+export interface IptvGroup {
+    id: string;
+    sourceId: string;
+    name: string;
+    channelCount: number;
+    order: number;
+}
+
+export interface IptvParseResult {
+    channels: IptvChannel[];
+    groups: IptvGroup[];
+}
+
+export interface XmltvProgramme {
+    channelId: string;
+    start: Date;
+    stop: Date;
+    startOffsetMinutes?: number;
+    stopOffsetMinutes?: number;
+    title: string;
+    subTitle?: string;
+    description?: string;
+}
+
+export interface XmltvChannel {
+    id: string;
+    displayNames: string[];
+}
+
+export interface XmltvGuide {
+    channels: Map<string, XmltvChannel>;
+    programmesByChannel: Map<string, XmltvProgramme[]>;
+    displayNameToChannelId: Map<string, string>;
+}
+
+export interface IptvRefreshStats {
+    channelCount: number;
+    groupCount: number;
+    programmeCount: number;
+}
+
+export interface IptvRefreshResult {
+    channels: IptvChannel[];
+    groups: IptvGroup[];
+    guide?: XmltvGuide;
+    loadedAt: string;
+    stats: IptvRefreshStats;
+}
+
+export interface IptvLiveChannelMetadata {
+    name: string;
+    group?: string | null;
+    logo?: string | null;
+    tvgId?: string | null;
+    programmeTitle?: string | null;
+}

--- a/packages/app/src/lib/iptv/types.ts
+++ b/packages/app/src/lib/iptv/types.ts
@@ -1,14 +1,27 @@
-export type IptvSourceKind = "m3u";
+export type IptvSourceKind = "m3u" | "xtream";
 
-export interface IptvSource {
+interface IptvBaseSource {
     id: string;
     name: string;
     kind: IptvSourceKind;
-    m3uUrl: string;
-    epgUrl?: string;
     createdAt: string;
     updatedAt: string;
 }
+
+export interface IptvM3uSource extends IptvBaseSource {
+    kind: "m3u";
+    m3uUrl: string;
+    epgUrl?: string;
+}
+
+export interface IptvXtreamSource extends IptvBaseSource {
+    kind: "xtream";
+    serverUrl: string;
+    username: string;
+    credential: string;
+}
+
+export type IptvSource = IptvM3uSource | IptvXtreamSource;
 
 export interface IptvChannel {
     id: string;

--- a/packages/app/src/lib/iptv/utils.ts
+++ b/packages/app/src/lib/iptv/utils.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_IPTV_GROUP = "Ungrouped";
+
+export function normalizeIptvText(value: string | null | undefined): string {
+    return String(value ?? "")
+        .trim()
+        .toLowerCase()
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/&/g, "and")
+        .replace(/[^a-z0-9]+/g, "");
+}
+
+export function slugForId(value: string | null | undefined): string {
+    const normalized = normalizeIptvText(value);
+    return normalized || "channel";
+}
+
+export function parseQuotedAttributes(value: string): Record<string, string> {
+    const attributes: Record<string, string> = {};
+    const regex = /([\w:-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(value)) !== null) {
+        attributes[match[1]] = match[2] ?? match[3] ?? "";
+    }
+
+    return attributes;
+}

--- a/packages/app/src/lib/iptv/xmltv.test.ts
+++ b/packages/app/src/lib/iptv/xmltv.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { IptvChannel } from "./types";
+import { getNowNext, parseXmltv } from "./xmltv";
+
+const channel = (overrides: Partial<IptvChannel>): IptvChannel => ({
+    id: "source-1:0:test",
+    sourceId: "source-1",
+    name: "Test Channel",
+    url: "stream-one",
+    group: "News",
+    order: 0,
+    ...overrides,
+});
+
+describe("parseXmltv", () => {
+    test("parses XMLTV channels and timezone programme windows", () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="abc.us">
+    <display-name>ABC</display-name>
+    <display-name>ABC HD</display-name>
+  </channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400">
+    <title>Morning News &amp; Weather</title>
+    <sub-title>Local</sub-title>
+    <desc>Headlines &amp; forecast.</desc>
+  </programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(guide.channels.get("abc.us")?.displayNames).toEqual(["ABC", "ABC HD"]);
+        expect(programmes).toHaveLength(1);
+        expect(programmes[0].title).toBe("Morning News & Weather");
+        expect(programmes[0].subTitle).toBe("Local");
+        expect(programmes[0].description).toBe("Headlines & forecast.");
+        expect(programmes[0].start.toISOString()).toBe("2026-06-22T13:00:00.000Z");
+    });
+
+    test("parses single-quoted XMLTV attributes", () => {
+        const xml = `<tv>
+  <channel id='abc.us'><display-name>ABC</display-name></channel>
+  <programme channel='abc.us' start='20260622090000 -0400' stop='20260622100000 -0400'>
+    <title>Morning News</title>
+  </programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(guide.channels.get("abc.us")?.displayNames).toEqual(["ABC"]);
+        expect(programmes).toHaveLength(1);
+        expect(programmes[0].title).toBe("Morning News");
+    });
+
+    test("parses CDATA text inside XMLTV tags", () => {
+        const xml = `<tv>
+  <channel id="abc.us"><display-name><![CDATA[ABC <East>]]></display-name></channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400">
+    <title><![CDATA[Morning <News> & Weather]]></title>
+    <desc><![CDATA[Headlines <local> & forecast.]]></desc>
+  </programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(guide.channels.get("abc.us")?.displayNames).toEqual(["ABC <East>"]);
+        expect(programmes[0].title).toBe("Morning <News> & Weather");
+        expect(programmes[0].description).toBe("Headlines <local> & forecast.");
+    });
+});
+
+describe("getNowNext", () => {
+    const xml = `<tv>
+  <channel id="abc.us"><display-name>ABC</display-name></channel>
+  <channel id="weather"><display-name>Weather Now</display-name></channel>
+  <channel id="sports"><display-name>Sports Plus</display-name></channel>
+  <programme channel="abc.us" start="20260622090000 -0400" stop="20260622100000 -0400"><title>ABC Now</title></programme>
+  <programme channel="abc.us" start="20260622100000 -0400" stop="20260622110000 -0400"><title>ABC Next</title></programme>
+  <programme channel="weather" start="20260622090000 -0400" stop="20260622100000 -0400"><title>Weather Now</title></programme>
+  <programme channel="sports" start="20260622090000 -0400" stop="20260622100000 -0400"><title>Sports Now</title></programme>
+</tv>`;
+
+    const at = new Date("2026-06-22T13:30:00.000Z");
+    const guide = parseXmltv(xml);
+
+    test("matches by exact tvg-id first", () => {
+        const result = getNowNext(channel({ tvgId: "abc.us", tvgName: "Wrong Name" }), guide, at);
+
+        expect(result.now?.title).toBe("ABC Now");
+        expect(result.next?.title).toBe("ABC Next");
+    });
+
+    test("matches by tvg-name display name", () => {
+        const result = getNowNext(channel({ tvgName: "Weather Now", name: "Weather 1" }), guide, at);
+
+        expect(result.now?.channelId).toBe("weather");
+        expect(result.now?.title).toBe("Weather Now");
+    });
+
+    test("matches by normalized display name fallback", () => {
+        const result = getNowNext(channel({ name: "sports-plus" }), guide, at);
+
+        expect(result.now?.channelId).toBe("sports");
+        expect(result.now?.title).toBe("Sports Now");
+    });
+});

--- a/packages/app/src/lib/iptv/xmltv.test.ts
+++ b/packages/app/src/lib/iptv/xmltv.test.ts
@@ -70,6 +70,19 @@ describe("parseXmltv", () => {
         expect(programmes[0].title).toBe("Morning <News> & Weather");
         expect(programmes[0].description).toBe("Headlines <local> & forecast.");
     });
+
+    test("skips programmes with malformed timestamps", () => {
+        const xml = `<tv>
+  <channel id="abc.us"><display-name>ABC</display-name></channel>
+  <programme channel="abc.us" start="bad-time" stop="20260622100000 -0400"><title>Broken</title></programme>
+  <programme channel="abc.us" start="20260622100000 -0400" stop="20260622110000 -0400"><title>Valid</title></programme>
+</tv>`;
+
+        const guide = parseXmltv(xml);
+        const programmes = guide.programmesByChannel.get("abc.us") ?? [];
+
+        expect(programmes.map((programme) => programme.title)).toEqual(["Valid"]);
+    });
 });
 
 describe("getNowNext", () => {
@@ -91,6 +104,15 @@ describe("getNowNext", () => {
 
         expect(result.now?.title).toBe("ABC Now");
         expect(result.next?.title).toBe("ABC Next");
+    });
+
+    test("matches tvg-id programme keys even without channel metadata", () => {
+        const guideWithoutChannel = parseXmltv(`<tv>
+  <programme channel="orphan" start="20260622090000 -0400" stop="20260622100000 -0400"><title>Orphan Now</title></programme>
+</tv>`);
+        const result = getNowNext(channel({ tvgId: "orphan", name: "Orphan" }), guideWithoutChannel, at);
+
+        expect(result.now?.title).toBe("Orphan Now");
     });
 
     test("matches by tvg-name display name", () => {

--- a/packages/app/src/lib/iptv/xmltv.ts
+++ b/packages/app/src/lib/iptv/xmltv.ts
@@ -1,0 +1,234 @@
+import type { IptvChannel, XmltvGuide, XmltvProgramme } from "./types";
+import { normalizeIptvText, parseQuotedAttributes } from "./utils";
+
+function decodeXmlEntities(value: string): string {
+    return value.replace(/&(#x?[0-9a-fA-F]+|amp|lt|gt|quot|apos);/g, (match, entity) => {
+        switch (entity) {
+            case "amp":
+                return "&";
+            case "lt":
+                return "<";
+            case "gt":
+                return ">";
+            case "quot":
+                return "\"";
+            case "apos":
+                return "'";
+            default: {
+                const raw = String(entity);
+                const isHex = raw.toLowerCase().startsWith("#x");
+                const numeric = raw.startsWith("#")
+                    ? Number.parseInt(raw.slice(isHex ? 2 : 1), isHex ? 16 : 10)
+                    : Number.NaN;
+                return Number.isFinite(numeric) ? String.fromCodePoint(numeric) : match;
+            }
+        }
+    });
+}
+
+function getTagText(block: string, tagName: string): string | undefined {
+    const regex = new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "i");
+    const match = regex.exec(block);
+    if (!match) return undefined;
+    const text = getXmlTextContent(match[1]);
+    return text || undefined;
+}
+
+function getAllTagText(block: string, tagName: string): string[] {
+    const values: string[] = [];
+    const regex = new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "gi");
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(block)) !== null) {
+        const text = getXmlTextContent(match[1]);
+        if (text) values.push(text);
+    }
+
+    return values;
+}
+
+function getXmlTextContent(value: string): string {
+    let output = "";
+    let cursor = 0;
+    const cdataRegex = /<!\[CDATA\[([\s\S]*?)\]\]>/gi;
+    let match: RegExpExecArray | null;
+
+    while ((match = cdataRegex.exec(value)) !== null) {
+        output += decodeXmlEntities(value.slice(cursor, match.index).replace(/<[^>]+>/g, ""));
+        output += match[1];
+        cursor = cdataRegex.lastIndex;
+    }
+
+    output += decodeXmlEntities(value.slice(cursor).replace(/<[^>]+>/g, ""));
+    return output.trim();
+}
+
+export function parseXmltvTime(value: string): Date {
+    const match = String(value ?? "").trim().match(
+        /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(?:\s*([+-])(\d{2})(\d{2}))?/,
+    );
+
+    if (!match) {
+        throw new Error("Invalid XMLTV time");
+    }
+
+    const [, year, month, day, hour, minute, second, sign, offsetHour, offsetMinute] = match;
+    const utc = Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+    );
+
+    if (!sign) return new Date(utc);
+
+    const offsetMs =
+        (Number(offsetHour) * 60 + Number(offsetMinute)) *
+        60 *
+        1000 *
+        (sign === "+" ? 1 : -1);
+
+    return new Date(utc - offsetMs);
+}
+
+function getXmltvOffsetMinutes(value: string): number | undefined {
+    const match = String(value ?? "").trim().match(
+        /^\d{14}\s*([+-])(\d{2})(\d{2})/,
+    );
+
+    if (!match) return undefined;
+
+    const [, sign, offsetHour, offsetMinute] = match;
+    const minutes = Number(offsetHour) * 60 + Number(offsetMinute);
+    return minutes * (sign === "+" ? 1 : -1);
+}
+
+function countProgrammes(guide: XmltvGuide): number {
+    let count = 0;
+    for (const programmes of guide.programmesByChannel.values()) {
+        count += programmes.length;
+    }
+    return count;
+}
+
+export function getProgrammeCount(guide: XmltvGuide | undefined): number {
+    return guide ? countProgrammes(guide) : 0;
+}
+
+export function parseXmltv(xml: string): XmltvGuide {
+    const text = String(xml ?? "");
+    if (!/<tv\b/i.test(text)) {
+        throw new Error("Invalid XMLTV document");
+    }
+
+    const guide: XmltvGuide = {
+        channels: new Map(),
+        programmesByChannel: new Map(),
+        displayNameToChannelId: new Map(),
+    };
+
+    const channelRegex = /<channel\b([^>]*)>([\s\S]*?)<\/channel>/gi;
+    let channelMatch: RegExpExecArray | null;
+
+    while ((channelMatch = channelRegex.exec(text)) !== null) {
+        const attributes = parseQuotedAttributes(channelMatch[1]);
+        const id = attributes.id?.trim();
+        if (!id) continue;
+
+        const displayNames = getAllTagText(channelMatch[2], "display-name");
+        guide.channels.set(id, { id, displayNames });
+
+        for (const displayName of displayNames) {
+            const key = normalizeIptvText(displayName);
+            if (key && !guide.displayNameToChannelId.has(key)) {
+                guide.displayNameToChannelId.set(key, id);
+            }
+        }
+    }
+
+    const programmeRegex = /<programme\b([^>]*)>([\s\S]*?)<\/programme>/gi;
+    let programmeMatch: RegExpExecArray | null;
+
+    while ((programmeMatch = programmeRegex.exec(text)) !== null) {
+        const attributes = parseQuotedAttributes(programmeMatch[1]);
+        const channelId = attributes.channel?.trim();
+        const startRaw = attributes.start?.trim();
+        const stopRaw = attributes.stop?.trim();
+        if (!channelId || !startRaw || !stopRaw) continue;
+
+        const title = getTagText(programmeMatch[2], "title") || "Untitled";
+        const programme: XmltvProgramme = {
+            channelId,
+            start: parseXmltvTime(startRaw),
+            stop: parseXmltvTime(stopRaw),
+            startOffsetMinutes: getXmltvOffsetMinutes(startRaw),
+            stopOffsetMinutes: getXmltvOffsetMinutes(stopRaw),
+            title,
+            subTitle: getTagText(programmeMatch[2], "sub-title"),
+            description: getTagText(programmeMatch[2], "desc"),
+        };
+
+        const programmes = guide.programmesByChannel.get(channelId) ?? [];
+        programmes.push(programme);
+        guide.programmesByChannel.set(channelId, programmes);
+    }
+
+    for (const programmes of guide.programmesByChannel.values()) {
+        programmes.sort((a, b) => a.start.getTime() - b.start.getTime());
+    }
+
+    return guide;
+}
+
+function resolveGuideChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
+    if (channel.tvgId && guide.channels.has(channel.tvgId)) {
+        return channel.tvgId;
+    }
+
+    const tvgName = normalizeIptvText(channel.tvgName);
+    if (tvgName && guide.displayNameToChannelId.has(tvgName)) {
+        return guide.displayNameToChannelId.get(tvgName) ?? null;
+    }
+
+    const displayName = normalizeIptvText(channel.name);
+    if (displayName && guide.displayNameToChannelId.has(displayName)) {
+        return guide.displayNameToChannelId.get(displayName) ?? null;
+    }
+
+    return null;
+}
+
+export function getNowNext(
+    channel: IptvChannel,
+    guide: XmltvGuide,
+    at: Date = new Date(),
+): { now: XmltvProgramme | null; next: XmltvProgramme | null } {
+    const guideChannelId = resolveGuideChannelId(channel, guide);
+    if (!guideChannelId) {
+        return { now: null, next: null };
+    }
+
+    const programmes = guide.programmesByChannel.get(guideChannelId) ?? [];
+    const timestamp = at.getTime();
+    let now: XmltvProgramme | null = null;
+    let next: XmltvProgramme | null = null;
+
+    for (const programme of programmes) {
+        const start = programme.start.getTime();
+        const stop = programme.stop.getTime();
+
+        if (start <= timestamp && timestamp < stop) {
+            now = programme;
+            continue;
+        }
+
+        if (start > timestamp) {
+            next = programme;
+            break;
+        }
+    }
+
+    return { now, next };
+}

--- a/packages/app/src/lib/iptv/xmltv.ts
+++ b/packages/app/src/lib/iptv/xmltv.ts
@@ -159,10 +159,19 @@ export function parseXmltv(xml: string): XmltvGuide {
         if (!channelId || !startRaw || !stopRaw) continue;
 
         const title = getTagText(programmeMatch[2], "title") || "Untitled";
+        let start: Date;
+        let stop: Date;
+        try {
+            start = parseXmltvTime(startRaw);
+            stop = parseXmltvTime(stopRaw);
+        } catch {
+            continue;
+        }
+
         const programme: XmltvProgramme = {
             channelId,
-            start: parseXmltvTime(startRaw),
-            stop: parseXmltvTime(stopRaw),
+            start,
+            stop,
             startOffsetMinutes: getXmltvOffsetMinutes(startRaw),
             stopOffsetMinutes: getXmltvOffsetMinutes(stopRaw),
             title,
@@ -182,8 +191,12 @@ export function parseXmltv(xml: string): XmltvGuide {
     return guide;
 }
 
-function resolveGuideChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
-    if (channel.tvgId && guide.channels.has(channel.tvgId)) {
+function hasGuideChannelId(guide: XmltvGuide, channelId: string): boolean {
+    return guide.channels.has(channelId) || guide.programmesByChannel.has(channelId);
+}
+
+export function resolveXmltvChannelId(channel: IptvChannel, guide: XmltvGuide): string | null {
+    if (channel.tvgId && hasGuideChannelId(guide, channel.tvgId)) {
         return channel.tvgId;
     }
 
@@ -205,7 +218,7 @@ export function getNowNext(
     guide: XmltvGuide,
     at: Date = new Date(),
 ): { now: XmltvProgramme | null; next: XmltvProgramme | null } {
-    const guideChannelId = resolveGuideChannelId(channel, guide);
+    const guideChannelId = resolveXmltvChannelId(channel, guide);
     if (!guideChannelId) {
         return { now: null, next: null };
     }

--- a/packages/app/src/lib/iptv/xtream.ts
+++ b/packages/app/src/lib/iptv/xtream.ts
@@ -1,0 +1,68 @@
+import type { IptvXtreamSource } from "./types";
+
+const XTREAM_URL_PROTOCOL_ERROR = "Only http and https Xtream server URLs are supported";
+
+export function normalizeXtreamServerUrl(url: string): string {
+    const trimmed = String(url ?? "").trim();
+    if (!trimmed) {
+        throw new Error("Enter an Xtream server URL");
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(trimmed);
+    } catch {
+        throw new Error("Enter a valid Xtream server URL");
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error(XTREAM_URL_PROTOCOL_ERROR);
+    }
+
+    parsed.search = "";
+    parsed.hash = "";
+
+    const pathname = parsed.pathname.replace(/\/+$/, "");
+    return `${parsed.origin}${pathname}`;
+}
+
+export function requireXtreamField(value: string, label: string): string {
+    const trimmed = String(value ?? "").trim();
+    if (!trimmed) {
+        throw new Error(`Enter an Xtream ${label}`);
+    }
+    return trimmed;
+}
+
+function buildXtreamUrl(
+    source: Pick<IptvXtreamSource, "serverUrl" | "username" | "credential">,
+    path: "get.php" | "xmltv.php",
+    extraParams: Record<string, string> = {},
+): string {
+    const serverUrl = normalizeXtreamServerUrl(source.serverUrl);
+    const username = requireXtreamField(source.username, "username");
+    const credential = requireXtreamField(source.credential, "password");
+    const params = new URLSearchParams();
+    params.set("username", username);
+    params.set("password", credential);
+    for (const [key, value] of Object.entries(extraParams)) {
+        params.set(key, value);
+    }
+
+    return `${serverUrl}/${path}?${params.toString()}`;
+}
+
+export function buildXtreamPlaylistUrl(
+    source: Pick<IptvXtreamSource, "serverUrl" | "username" | "credential">,
+): string {
+    return buildXtreamUrl(source, "get.php", {
+        type: "m3u_plus",
+        output: "ts",
+    });
+}
+
+export function buildXtreamXmltvUrl(
+    source: Pick<IptvXtreamSource, "serverUrl" | "username" | "credential">,
+): string {
+    return buildXtreamUrl(source, "xmltv.php");
+}

--- a/packages/app/src/lib/stores/router.ts
+++ b/packages/app/src/lib/stores/router.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 
-export type Route = "home" | "meta" | "player" | "lists";
+export type Route = "home" | "meta" | "player" | "lists" | "live";
 
 export interface RouterState {
     page: Route;

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -12,7 +12,10 @@
         getNowLinePercent,
     } from "../../lib/iptv/guideGrid";
     import { refreshIptvSource } from "../../lib/iptv/refresh";
-    import { iptvSources } from "../../lib/iptv/store";
+    import {
+        getStoredIptvSources,
+        iptvSources,
+    } from "../../lib/iptv/store";
     import type {
         IptvChannel,
         IptvRefreshResult,
@@ -29,12 +32,19 @@
         ALL_GROUPS,
         GUIDE_CHANNEL_PAGE_SIZE,
         GUIDE_INITIAL_CHANNEL_LIMIT,
+        LIVE_TV_AUTO_REFRESH_RETRY_MS,
+        LIVE_TV_REFRESH_CHECK_INTERVAL_MS,
         buildGuideTimeTicks,
         formatLoadedAt,
         getGuideViewport,
         getLiveSourceCacheKey,
         getLiveSourceSummary,
+        getStoredLiveTvGroup,
+        getStoredLiveTvSelection,
         getVisibleChannels,
+        setStoredLiveTvGroup,
+        setStoredLiveTvSourceId,
+        shouldAutoRefreshLiveTvSource,
     } from "./liveHelpers";
 
     const IPTV_EXAMPLE_M3U_URL = (
@@ -54,16 +64,40 @@
 
     const isDev = import.meta.env.DEV;
 
-    let selectedSourceId = "";
-    let loadedSourceId = "";
-    let loadedSourceCacheKey = "";
-    let refreshResult: IptvRefreshResult | null = null;
+    function getInitialLiveTvState() {
+        const storedSelection = getStoredLiveTvSelection();
+        const storedSources = getStoredIptvSources();
+        const source =
+            storedSources.find((candidate) => candidate.id === storedSelection.sourceId) ??
+            storedSources[0] ??
+            null;
+        const cacheKey = source ? getLiveSourceCacheKey(source) : "";
+        const cachedResult = source ? getStoredIptvRefreshResult(source) : null;
+
+        return {
+            selectedSourceId: source?.id ?? storedSelection.sourceId,
+            loadedSourceId: source ? source.id : "",
+            loadedSourceCacheKey: source ? cacheKey : "",
+            refreshResult: cachedResult,
+            selectedGroup: source ? getStoredLiveTvGroup(source.id) || ALL_GROUPS : ALL_GROUPS,
+        };
+    }
+
+    const initialLiveTvState = getInitialLiveTvState();
+
+    let selectedSourceId = initialLiveTvState.selectedSourceId;
+    let loadedSourceId = initialLiveTvState.loadedSourceId;
+    let loadedSourceCacheKey = initialLiveTvState.loadedSourceCacheKey;
+    let refreshResult: IptvRefreshResult | null = initialLiveTvState.refreshResult;
     let refreshing = false;
     let refreshError = "";
-    let selectedGroup = ALL_GROUPS;
+    let selectedGroup = initialLiveTvState.selectedGroup;
     let searchQuery = "";
     let guideNow = new Date();
     let guideTimer: ReturnType<typeof setInterval> | null = null;
+    let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+    let lastAutoRefreshAttemptKey = "";
+    let lastAutoRefreshAttemptAt = 0;
     let showSourceManager = false;
     let sourceManagerResetRequest = 0;
     let showSettingsModal = false;
@@ -123,6 +157,9 @@
     ) {
         selectedSourceId = $iptvSources[0]?.id ?? "";
     }
+    $: if (selectedSource) {
+        setStoredLiveTvSourceId(selectedSource.id);
+    }
     $: if (
         selectedSource &&
         (loadedSourceId !== selectedSource.id ||
@@ -136,10 +173,14 @@
         refreshResult = null;
     }
     $: if (
+        currentResult &&
         selectedGroup !== ALL_GROUPS &&
         !availableGroups.some((group) => group.name === selectedGroup)
     ) {
         selectedGroup = ALL_GROUPS;
+    }
+    $: if (selectedSource && currentResult) {
+        setStoredLiveTvGroup(selectedSource.id, selectedGroup);
     }
 
     function showMoreGuideChannels() {
@@ -150,11 +191,16 @@
     }
 
     function hydrateStoredSource(source: IptvSource, cacheKey: string) {
-        refreshResult = getStoredIptvRefreshResult(source);
+        const cachedResult = getStoredIptvRefreshResult(source);
+        refreshResult = cachedResult;
         loadedSourceId = source.id;
         loadedSourceCacheKey = cacheKey;
-        selectedGroup = ALL_GROUPS;
+        selectedGroup = getStoredLiveTvGroup(source.id) || ALL_GROUPS;
+        searchQuery = "";
         refreshError = "";
+        queueMicrotask(() => {
+            maybeAutoRefreshSelectedSource();
+        });
     }
 
     function openSourceManager() {
@@ -174,7 +220,7 @@
         }
     }
 
-    async function refreshSelectedSource() {
+    async function refreshSelectedSource(refreshReason: "manual" | "auto" = "manual") {
         if (!selectedSource) {
             refreshError = "No IPTV source configured";
             return;
@@ -182,8 +228,11 @@
 
         const source = selectedSource;
         const sourceCacheKey = selectedSourceCacheKey;
+        const hadUsableResult = Boolean(currentResult);
         refreshing = true;
-        refreshError = "";
+        if (refreshReason === "manual" || !hadUsableResult) {
+            refreshError = "";
+        }
 
         try {
             const result = await refreshIptvSource(source);
@@ -191,21 +240,42 @@
             refreshResult = result;
             loadedSourceId = source.id;
             loadedSourceCacheKey = sourceCacheKey;
-            selectedGroup = ALL_GROUPS;
-            trackEvent("iptv_source_refreshed", {
+            lastAutoRefreshAttemptKey = "";
+            lastAutoRefreshAttemptAt = 0;
+            trackEvent(refreshReason === "auto" ? "iptv_source_auto_refreshed" : "iptv_source_refreshed", {
                 channel_count: result.stats.channelCount,
                 group_count: result.stats.groupCount,
                 programme_count: result.stats.programmeCount,
                 has_epg: Boolean(result.guide),
             });
         } catch (error) {
-            refreshError = error instanceof Error ? error.message : String(error);
-            trackEvent("iptv_source_refresh_failed", {
+            if (refreshReason === "manual" || !hadUsableResult) {
+                refreshError = error instanceof Error ? error.message : String(error);
+            }
+            trackEvent(refreshReason === "auto" ? "iptv_source_auto_refresh_failed" : "iptv_source_refresh_failed", {
                 error_name: error instanceof Error ? error.name : "unknown",
             });
         } finally {
             refreshing = false;
         }
+    }
+
+    function maybeAutoRefreshSelectedSource() {
+        if (!selectedSource || refreshing) return;
+        if (!shouldAutoRefreshLiveTvSource(selectedSource, currentResult)) return;
+
+        const now = Date.now();
+        const attemptKey = `${selectedSourceCacheKey}\n${currentResult?.loadedAt ?? "missing"}`;
+        if (
+            lastAutoRefreshAttemptKey === attemptKey &&
+            now - lastAutoRefreshAttemptAt < LIVE_TV_AUTO_REFRESH_RETRY_MS
+        ) {
+            return;
+        }
+
+        lastAutoRefreshAttemptKey = attemptKey;
+        lastAutoRefreshAttemptAt = now;
+        void refreshSelectedSource("auto");
     }
 
     function getChannelGuide(channel: IptvChannel) {
@@ -243,19 +313,27 @@
             guideNow = new Date();
         }, 60_000);
 
+        autoRefreshTimer = setInterval(() => {
+            maybeAutoRefreshSelectedSource();
+        }, LIVE_TV_REFRESH_CHECK_INTERVAL_MS);
+
         void tick().then(() => {
-            const source = selectedSource ?? $iptvSources[0] ?? null;
-            if (!source) return;
-            if (!selectedSourceId) {
-                selectedSourceId = source.id;
+            if (selectedSource) {
+                const sourceCacheKey = selectedSourceCacheKey;
+                if (loadedSourceId !== selectedSource.id || loadedSourceCacheKey !== sourceCacheKey) {
+                    hydrateStoredSource(selectedSource, sourceCacheKey);
+                }
             }
-            hydrateStoredSource(source, getLiveSourceCacheKey(source));
+            maybeAutoRefreshSelectedSource();
         });
     });
 
     onDestroy(() => {
         if (guideTimer) {
             clearInterval(guideTimer);
+        }
+        if (autoRefreshTimer) {
+            clearInterval(autoRefreshTimer);
         }
     });
 </script>
@@ -303,7 +381,7 @@
         </svelte:fragment>
     </SearchBar>
 
-    <main class="relative z-10 min-h-0 flex-1 px-5 pb-5 pt-2 lg:px-8 lg:pt-4">
+    <main class="relative z-10 min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-2 lg:px-8 lg:pt-4">
         <div class="mx-auto flex w-full max-w-[1760px] flex-col gap-4">
             {#if refreshError}
                 <div class="rounded-[20px] border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
@@ -311,7 +389,7 @@
                 </div>
             {/if}
 
-            {#if refreshing}
+            {#if refreshing && !currentResult}
                 <LiveEmptyState state="refreshing" />
             {:else if !selectedSource}
                 <LiveEmptyState state="no-source" onAddSource={openCreateSourceManager} />

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -42,6 +42,8 @@
     const ALL_GROUPS = "__all__";
     const GUIDE_VIEWPORT_HOURS = 2;
     const GUIDE_TIMELINE_MIN_WIDTH = 680;
+    const GUIDE_INITIAL_CHANNEL_LIMIT = 100;
+    const GUIDE_CHANNEL_PAGE_SIZE = 100;
     const IPTV_EXAMPLE_M3U_URL = (
         import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_M3U_URL as string | undefined
     )?.trim();
@@ -77,6 +79,8 @@
     let guideNow = new Date();
     let guideTimer: ReturnType<typeof setInterval> | null = null;
     let showSourceManager = false;
+    let guideChannelLimit = GUIDE_INITIAL_CHANNEL_LIMIT;
+    let guideChannelFilterKey = "";
 
     const isDev = import.meta.env.DEV;
 
@@ -100,10 +104,19 @@
         selectedGroup,
         searchQuery,
     );
+    $: currentGuideChannelFilterKey = `${selectedSourceId}\n${selectedGroup}\n${searchQuery.trim()}`;
+    $: if (guideChannelFilterKey !== currentGuideChannelFilterKey) {
+        guideChannelFilterKey = currentGuideChannelFilterKey;
+        guideChannelLimit = GUIDE_INITIAL_CHANNEL_LIMIT;
+    }
+    $: visibleGuideChannels = visibleChannels.slice(0, guideChannelLimit);
+    $: hasMoreGuideChannels = visibleGuideChannels.length < visibleChannels.length;
+    $: remainingGuideChannels = Math.max(visibleChannels.length - visibleGuideChannels.length, 0);
+    $: nextGuideChannelPageCount = Math.min(GUIDE_CHANNEL_PAGE_SIZE, remainingGuideChannels);
     $: guideTitle = selectedGroup === ALL_GROUPS ? "Live TV" : selectedGroup;
     $: guideViewport = getGuideViewport(guideNow);
     $: guideRows = currentResult
-        ? buildGuideRows(visibleChannels, currentResult.guide, guideViewport)
+        ? buildGuideRows(visibleGuideChannels, currentResult.guide, guideViewport)
         : [];
     $: guideNowLinePercent = getNowLinePercent(guideViewport);
     $: showGuideNowLine = guideNowLinePercent >= 0 && guideNowLinePercent <= 100;
@@ -154,6 +167,13 @@
 
     function getLiveSourceCacheKey(source: IptvSource) {
         return `${source.id}\n${getIptvSourceCacheFingerprint(source)}`;
+    }
+
+    function showMoreGuideChannels() {
+        guideChannelLimit = Math.min(
+            visibleChannels.length,
+            guideChannelLimit + GUIDE_CHANNEL_PAGE_SIZE,
+        );
     }
 
     function getGuideViewport(now: Date): GuideGridViewport {
@@ -217,6 +237,10 @@
 
     function guideFallbackLabel(hasGuide: boolean) {
         return hasGuide ? "No guide data" : "Live";
+    }
+
+    function focusOnMount(node: HTMLElement) {
+        void tick().then(() => node.focus());
     }
 
     function hydrateStoredSource(source: IptvSource, cacheKey: string) {
@@ -445,6 +469,12 @@
     });
 </script>
 
+<svelte:window
+    onkeydown={(event) => {
+        if (showSourceManager && event.key === "Escape") showSourceManager = false;
+    }}
+/>
+
 <div class="min-h-screen bg-[#090909] text-white">
     <main class="mx-auto flex min-h-screen w-full max-w-[1760px] flex-col gap-5 px-5 py-5 lg:px-8 lg:py-7">
         <header class="rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
@@ -645,6 +675,9 @@
                         </h2>
                         <p class="text-sm text-white/45">
                             Click a channel or programme to start live playback.
+                            {#if hasMoreGuideChannels}
+                                Showing {visibleGuideChannels.length} of {visibleChannels.length} matching channels.
+                            {/if}
                         </p>
                     </div>
                     <div class="text-sm tabular-nums text-white/46">
@@ -753,6 +786,20 @@
                         </div>
                     </div>
                 </div>
+
+                {#if hasMoreGuideChannels}
+                    <div class="flex flex-col gap-3 border-t border-white/10 bg-white/[0.03] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                        <p class="text-sm leading-6 text-white/48">
+                            Large playlists are paged to keep the guide responsive. Search or select a group to narrow the list.
+                        </p>
+                        <button
+                            class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
+                            onclick={showMoreGuideChannels}
+                        >
+                            Show {nextGuideChannelPageCount} more
+                        </button>
+                    </div>
+                {/if}
             </section>
         {/if}
     </main>
@@ -774,6 +821,7 @@
                 role="dialog"
                 aria-modal="true"
                 tabindex="-1"
+                use:focusOnMount
             >
                 <div class="mb-5 flex items-start justify-between gap-4">
                     <div>

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -1,0 +1,751 @@
+<script lang="ts">
+    import { onDestroy, onMount, tick } from "svelte";
+    import {
+        ChevronLeft,
+        Pencil,
+        Plus,
+        RefreshCw,
+        Search,
+        Trash2,
+        Tv,
+    } from "@lucide/svelte";
+    import LoadingSpinner from "../../components/common/LoadingSpinner.svelte";
+    import { trackEvent } from "../../lib/analytics";
+    import { router } from "../../lib/stores/router";
+    import {
+        addIptvSource,
+        iptvSources,
+        removeIptvSource,
+        updateIptvSource,
+    } from "../../lib/iptv/store";
+    import { refreshIptvSource } from "../../lib/iptv/refresh";
+    import {
+        getStoredIptvRefreshResult,
+        persistIptvRefreshResult,
+    } from "../../lib/iptv/cache";
+    import {
+        buildGuideRows,
+        getNowLinePercent,
+        type GuideGridViewport,
+        type GuideProgrammeState,
+    } from "../../lib/iptv/guideGrid";
+    import { getNowNext } from "../../lib/iptv/xmltv";
+    import type {
+        IptvChannel,
+        IptvRefreshResult,
+        IptvSource,
+    } from "../../lib/iptv/types";
+
+    const ALL_GROUPS = "__all__";
+    const GUIDE_VIEWPORT_HOURS = 2;
+    const GUIDE_TIMELINE_MIN_WIDTH = 680;
+    const IPTV_EXAMPLE_M3U_URL = (
+        import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_M3U_URL as string | undefined
+    )?.trim();
+    const IPTV_EXAMPLE_EPG_URL = (
+        import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_EPG_URL as string | undefined
+    )?.trim();
+    const IPTV_EXAMPLE =
+        IPTV_EXAMPLE_M3U_URL && IPTV_EXAMPLE_EPG_URL
+            ? {
+                  name: "IPTV Example",
+                  m3uUrl: IPTV_EXAMPLE_M3U_URL,
+                  epgUrl: IPTV_EXAMPLE_EPG_URL,
+              }
+            : null;
+
+    let selectedSourceId = "";
+    let loadedSourceId = "";
+    let loadedSourceCacheKey = "";
+    let refreshResult: IptvRefreshResult | null = null;
+    let refreshing = false;
+    let refreshError = "";
+    let formError = "";
+    let editingSourceId: string | null = null;
+    let formName = "";
+    let formM3uUrl = "";
+    let formEpgUrl = "";
+    let selectedGroup = ALL_GROUPS;
+    let searchQuery = "";
+    let guideNow = new Date();
+    let guideTimer: ReturnType<typeof setInterval> | null = null;
+    let showSourceManager = false;
+
+    const isDev = import.meta.env.DEV;
+
+    $: selectedSource =
+        $iptvSources.find((source) => source.id === selectedSourceId) ?? null;
+    $: selectedSourceCacheKey = selectedSource ? getLiveSourceCacheKey(selectedSource) : "";
+    $: currentResult =
+        refreshResult &&
+        loadedSourceId === selectedSourceId &&
+        loadedSourceCacheKey === selectedSourceCacheKey
+            ? refreshResult
+            : null;
+    $: showFullSourcePanel = !currentResult || showSourceManager;
+    $: availableGroups = currentResult?.groups ?? [];
+    $: sourceSummary = currentResult
+        ? `${currentResult.stats.channelCount} channels / ${currentResult.stats.groupCount} groups`
+        : "";
+    $: visibleChannels = getVisibleChannels(
+        currentResult?.channels ?? [],
+        selectedGroup,
+        searchQuery,
+    );
+    $: guideTitle = selectedGroup === ALL_GROUPS ? "Live TV" : selectedGroup;
+    $: guideViewport = getGuideViewport(guideNow);
+    $: guideRows = currentResult
+        ? buildGuideRows(visibleChannels, currentResult.guide, guideViewport)
+        : [];
+    $: guideNowLinePercent = getNowLinePercent(guideViewport);
+    $: showGuideNowLine = guideNowLinePercent >= 0 && guideNowLinePercent <= 100;
+    $: guideTimeTicks = buildGuideTimeTicks(guideViewport);
+    $: if (!selectedSourceId && $iptvSources.length > 0) {
+        selectedSourceId = $iptvSources[0].id;
+    }
+    $: if (selectedSourceId && !$iptvSources.some((source) => source.id === selectedSourceId)) {
+        selectedSourceId = $iptvSources[0]?.id ?? "";
+    }
+    $: if (
+        selectedSource &&
+        (loadedSourceId !== selectedSource.id ||
+            loadedSourceCacheKey !== selectedSourceCacheKey)
+    ) {
+        hydrateStoredSource(selectedSource, selectedSourceCacheKey);
+    }
+    $: if (!selectedSource && refreshResult) {
+        loadedSourceId = "";
+        loadedSourceCacheKey = "";
+        refreshResult = null;
+    }
+    $: if (
+        selectedGroup !== ALL_GROUPS &&
+        !availableGroups.some((group) => group.name === selectedGroup)
+    ) {
+        selectedGroup = ALL_GROUPS;
+    }
+
+    function getVisibleChannels(
+        channels: IptvChannel[],
+        group: string,
+        query: string,
+    ) {
+        const normalizedQuery = query.trim().toLowerCase();
+        return channels.filter((channel) => {
+            if (group !== ALL_GROUPS && channel.group !== group) return false;
+            if (!normalizedQuery) return true;
+
+            return (
+                channel.name.toLowerCase().includes(normalizedQuery) ||
+                channel.group.toLowerCase().includes(normalizedQuery) ||
+                (channel.tvgName ?? "").toLowerCase().includes(normalizedQuery) ||
+                (channel.tvgId ?? "").toLowerCase().includes(normalizedQuery)
+            );
+        });
+    }
+
+    function getLiveSourceCacheKey(source: IptvSource) {
+        return `${source.id}\n${source.m3uUrl.trim()}\n${source.epgUrl?.trim() ?? ""}`;
+    }
+
+    function getGuideViewport(now: Date): GuideGridViewport {
+        const viewportStart = new Date(now);
+        viewportStart.setMinutes(0, 0, 0);
+
+        return {
+            viewportStart,
+            viewportEnd: new Date(viewportStart.getTime() + GUIDE_VIEWPORT_HOURS * 60 * 60_000),
+            now,
+        };
+    }
+
+    function getTimePercent(value: Date, viewport: GuideGridViewport) {
+        const viewportStartMs = viewport.viewportStart.getTime();
+        const viewportDurationMs = viewport.viewportEnd.getTime() - viewportStartMs;
+
+        if (viewportDurationMs <= 0) return 0;
+
+        return ((value.getTime() - viewportStartMs) / viewportDurationMs) * 100;
+    }
+
+    function buildGuideTimeTicks(viewport: GuideGridViewport) {
+        const ticks: { value: Date; label: string; leftPercent: number }[] = [];
+        const tickMs = 30 * 60_000;
+
+        for (
+            let timestamp = viewport.viewportStart.getTime();
+            timestamp <= viewport.viewportEnd.getTime();
+            timestamp += tickMs
+        ) {
+            const value = new Date(timestamp);
+            ticks.push({
+                value,
+                label: formatTime(value),
+                leftPercent: getTimePercent(value, viewport),
+            });
+        }
+
+        return ticks;
+    }
+
+    function timeTickClass(leftPercent: number) {
+        const base = "absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-[11px] tabular-nums text-white/42";
+        if (leftPercent <= 1) return `${base} translate-x-0`;
+        if (leftPercent >= 99) return `${base} -translate-x-full`;
+        return `${base} -translate-x-1/2`;
+    }
+
+    function programmeBlockClass(state: GuideProgrammeState) {
+        if (state === "current") {
+            return "border-[#a8b99b]/35 bg-[#809278]/78 text-white shadow-[0_10px_24px_rgba(128,146,120,0.16)] hover:bg-[#8ea084]/86";
+        }
+
+        if (state === "future") {
+            return "border-white/[0.08] bg-[#20262b] text-white/84 hover:bg-[#293039]";
+        }
+
+        return "border-white/[0.06] bg-[#161b20] text-white/46 hover:bg-[#1d2329]";
+    }
+
+    function guideFallbackLabel(hasGuide: boolean) {
+        return hasGuide ? "No guide data" : "Live";
+    }
+
+    function hydrateStoredSource(source: IptvSource, cacheKey: string) {
+        refreshResult = getStoredIptvRefreshResult(source);
+        loadedSourceId = source.id;
+        loadedSourceCacheKey = cacheKey;
+        selectedGroup = ALL_GROUPS;
+        refreshError = "";
+    }
+
+    function resetForm() {
+        editingSourceId = null;
+        formName = "";
+        formM3uUrl = "";
+        formEpgUrl = "";
+        formError = "";
+    }
+
+    function editSource(source: IptvSource) {
+        editingSourceId = source.id;
+        formName = source.name;
+        formM3uUrl = source.m3uUrl;
+        formEpgUrl = source.epgUrl ?? "";
+        formError = "";
+    }
+
+    function fillDispatcharrExample() {
+        if (!IPTV_EXAMPLE) return;
+        formName = IPTV_EXAMPLE.name;
+        formM3uUrl = IPTV_EXAMPLE.m3uUrl;
+        formEpgUrl = IPTV_EXAMPLE.epgUrl;
+        formError = "";
+    }
+
+    function saveSource() {
+        try {
+            if (editingSourceId) {
+                const updated = updateIptvSource(editingSourceId, {
+                    name: formName,
+                    m3uUrl: formM3uUrl,
+                    epgUrl: formEpgUrl,
+                });
+                if (!updated) {
+                    throw new Error("The selected IPTV source no longer exists");
+                }
+                selectedSourceId = updated.id;
+                trackEvent("iptv_source_updated");
+            } else {
+                const source = addIptvSource({
+                    name: formName,
+                    m3uUrl: formM3uUrl,
+                    epgUrl: formEpgUrl,
+                });
+                selectedSourceId = source.id;
+                trackEvent("iptv_source_added");
+            }
+            resetForm();
+        } catch (error) {
+            formError = error instanceof Error ? error.message : String(error);
+        }
+    }
+
+    function deleteSource(source: IptvSource) {
+        const confirmed =
+            typeof window === "undefined" ||
+            window.confirm(`Remove IPTV source "${source.name}"?`);
+        if (!confirmed) return;
+
+        removeIptvSource(source.id);
+        if (loadedSourceId === source.id) {
+            loadedSourceId = "";
+            loadedSourceCacheKey = "";
+            refreshResult = null;
+        }
+        if (editingSourceId === source.id) {
+            resetForm();
+        }
+        trackEvent("iptv_source_removed");
+    }
+
+    async function refreshSelectedSource() {
+        if (!selectedSource) {
+            refreshError = "No IPTV source configured";
+            return;
+        }
+
+        const source = selectedSource;
+        const sourceCacheKey = selectedSourceCacheKey;
+        refreshing = true;
+        refreshError = "";
+
+        try {
+            const result = await refreshIptvSource(source);
+            persistIptvRefreshResult(source, result);
+            refreshResult = result;
+            loadedSourceId = source.id;
+            loadedSourceCacheKey = sourceCacheKey;
+            selectedGroup = ALL_GROUPS;
+            trackEvent("iptv_source_refreshed", {
+                channel_count: result.stats.channelCount,
+                group_count: result.stats.groupCount,
+                programme_count: result.stats.programmeCount,
+                has_epg: Boolean(result.guide),
+            });
+        } catch (error) {
+            refreshError = error instanceof Error ? error.message : String(error);
+            trackEvent("iptv_source_refresh_failed", {
+                error_name: error instanceof Error ? error.name : "unknown",
+            });
+        } finally {
+            refreshing = false;
+        }
+    }
+
+    function getChannelGuide(channel: IptvChannel) {
+        if (!currentResult?.guide) return { now: null, next: null };
+        return getNowNext(channel, currentResult.guide, guideNow);
+    }
+
+    function playChannel(channel: IptvChannel) {
+        const nowNext = getChannelGuide(channel);
+        trackEvent("live_channel_opened", {
+            group: channel.group,
+            has_logo: Boolean(channel.logo),
+            has_programme: Boolean(nowNext.now),
+        });
+        router.navigate("player", {
+            videoSrc: channel.url,
+            startTime: 0,
+            metaData: null,
+            fileIdx: null,
+            season: null,
+            episode: null,
+            liveMode: true,
+            liveChannel: {
+                name: channel.name,
+                group: channel.group,
+                logo: channel.logo ?? null,
+                tvgId: channel.tvgId ?? null,
+                programmeTitle: nowNext.now?.title ?? null,
+            },
+        });
+    }
+
+    function formatTime(value: Date) {
+        return new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+        }).format(value);
+    }
+
+    function formatLoadedAt(value: string) {
+        return new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+        }).format(new Date(value));
+    }
+
+    onMount(() => {
+        guideTimer = setInterval(() => {
+            guideNow = new Date();
+        }, 60_000);
+
+        void tick().then(() => {
+            const source = selectedSource ?? $iptvSources[0] ?? null;
+            if (!source) return;
+            if (!selectedSourceId) {
+                selectedSourceId = source.id;
+            }
+            hydrateStoredSource(source, getLiveSourceCacheKey(source));
+        });
+    });
+
+    onDestroy(() => {
+        if (guideTimer) {
+            clearInterval(guideTimer);
+        }
+    });
+</script>
+
+<div class="min-h-screen bg-[#090909] text-white">
+    <div class="sticky top-0 z-40 border-b border-white/10 bg-[#090909]/92 backdrop-blur-xl">
+        <div class="flex items-center justify-between gap-6 px-8 py-5">
+            <div class="flex items-center gap-4 min-w-0">
+                <button
+                    class="flex h-12 w-12 items-center justify-center rounded-full bg-white/8 text-white/80 transition-colors hover:bg-white/14"
+                    aria-label="Back"
+                    onclick={() => {
+                        if (!router.back()) router.navigate("home");
+                    }}
+                >
+                    <ChevronLeft size={26} strokeWidth={2} />
+                </button>
+                <div class="flex items-center gap-3 min-w-0">
+                    <Tv size={28} strokeWidth={2} class="text-white/70" />
+                    <div class="min-w-0">
+                        <h1 class="truncate font-poppins text-[28px] font-semibold leading-tight">
+                            {guideTitle}
+                        </h1>
+                        <p class="truncate text-sm text-white/48">
+                            {sourceSummary || "No channels loaded"}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex items-center gap-3">
+                {#if currentResult}
+                    <span class="hidden text-sm text-white/45 md:inline">
+                        Refreshed {formatLoadedAt(currentResult.loadedAt)}
+                    </span>
+                {/if}
+                <button
+                    class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88 disabled:cursor-not-allowed disabled:opacity-45"
+                    disabled={!selectedSource || refreshing}
+                    onclick={refreshSelectedSource}
+                >
+                    {#if refreshing}
+                        <LoadingSpinner size="16px" color="#111111" />
+                    {:else}
+                        <RefreshCw size={17} strokeWidth={2.4} />
+                    {/if}
+                    Refresh
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class={showFullSourcePanel
+        ? "grid min-h-[calc(100vh-89px)] grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]"
+        : "grid min-h-[calc(100vh-89px)] grid-cols-1"}>
+        {#if showFullSourcePanel}
+        <aside class="border-b border-white/10 bg-[#111111] p-6 lg:border-b-0 lg:border-r">
+            <section class="flex flex-col gap-4">
+                <div class="flex items-center justify-between gap-3">
+                    <h2 class="font-poppins text-lg font-semibold">
+                        Sources
+                    </h2>
+                    <button
+                        class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14"
+                        aria-label="Add source"
+                        onclick={resetForm}
+                    >
+                        <Plus size={18} strokeWidth={2.4} />
+                    </button>
+                </div>
+
+                {#if $iptvSources.length > 0}
+                    <select
+                        class="h-11 w-full rounded-lg border border-white/10 bg-black/35 px-3 text-sm text-white outline-none focus:border-white/35"
+                        bind:value={selectedSourceId}
+                    >
+                        {#each $iptvSources as source}
+                            <option value={source.id}>{source.name}</option>
+                        {/each}
+                    </select>
+                {:else}
+                    <div class="rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/56">
+                        No source configured
+                    </div>
+                {/if}
+
+                {#if selectedSource}
+                    <div class="flex gap-2">
+                        <button
+                            class="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-white/8 text-sm text-white/76 transition-colors hover:bg-white/14"
+                            onclick={() => editSource(selectedSource)}
+                        >
+                            <Pencil size={16} strokeWidth={2.2} />
+                            Edit
+                        </button>
+                        <button
+                            class="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-white/8 text-sm text-white/76 transition-colors hover:bg-white/14"
+                            onclick={() => deleteSource(selectedSource)}
+                        >
+                            <Trash2 size={16} strokeWidth={2.2} />
+                            Remove
+                        </button>
+                    </div>
+                {/if}
+            </section>
+
+            <section class="mt-8 flex flex-col gap-4">
+                <h2 class="font-poppins text-lg font-semibold">
+                    {editingSourceId ? "Edit Source" : "Add Source"}
+                </h2>
+                <label class="flex flex-col gap-2 text-sm text-white/62">
+                    Name
+                    <input
+                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                        bind:value={formName}
+                    />
+                </label>
+                <label class="flex flex-col gap-2 text-sm text-white/62">
+                    M3U URL
+                    <input
+                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                        bind:value={formM3uUrl}
+                        inputmode="url"
+                    />
+                </label>
+                <label class="flex flex-col gap-2 text-sm text-white/62">
+                    XMLTV URL
+                    <input
+                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                        bind:value={formEpgUrl}
+                        inputmode="url"
+                    />
+                </label>
+
+                {#if formError}
+                    <div class="rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                        {formError}
+                    </div>
+                {/if}
+
+                <div class="flex gap-2">
+                    <button
+                        class="h-11 flex-1 rounded-lg bg-white text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                        onclick={saveSource}
+                    >
+                        {editingSourceId ? "Save" : "Add"}
+                    </button>
+                    {#if editingSourceId}
+                        <button
+                            class="h-11 flex-1 rounded-lg bg-white/8 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14"
+                            onclick={resetForm}
+                        >
+                            Cancel
+                        </button>
+                    {/if}
+                </div>
+
+                {#if isDev && IPTV_EXAMPLE}
+                    <button
+                        class="h-10 rounded-lg border border-white/10 text-sm text-white/60 transition-colors hover:bg-white/8 hover:text-white/82"
+                        onclick={fillDispatcharrExample}
+                    >
+                        Use IPTV example
+                    </button>
+                {/if}
+            </section>
+        </aside>
+        {/if}
+
+        <main class="min-w-0 p-6 lg:p-8">
+            <div class="mb-5 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                <div class="flex min-w-0 flex-1 flex-col gap-3 md:flex-row">
+                    <div class="relative min-w-0 flex-1">
+                        <Search
+                            size={19}
+                            strokeWidth={2.1}
+                            class="absolute left-3 top-1/2 -translate-y-1/2 text-white/42"
+                        />
+                        <input
+                            class="h-12 w-full rounded-lg border border-white/10 bg-white/[0.04] pl-10 pr-3 text-white outline-none focus:border-white/35"
+                            placeholder="Search channels"
+                            bind:value={searchQuery}
+                        />
+                    </div>
+
+                    <select
+                        class="h-12 min-w-[220px] rounded-lg border border-white/10 bg-white/[0.04] px-3 text-white outline-none focus:border-white/35"
+                        bind:value={selectedGroup}
+                    >
+                        <option value={ALL_GROUPS}>All groups</option>
+                        {#each availableGroups as group}
+                            <option value={group.name}>
+                                {group.name} ({group.channelCount})
+                            </option>
+                        {/each}
+                    </select>
+                </div>
+
+                {#if currentResult}
+                    <div class="flex items-center gap-3 text-sm text-white/45">
+                        <button
+                            class="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white/70 transition-colors hover:bg-white/[0.09] hover:text-white"
+                            onclick={() => (showSourceManager = !showSourceManager)}
+                        >
+                            {showSourceManager ? "Hide Sources" : "Sources"}
+                        </button>
+                        <span>
+                            Showing {visibleChannels.length} of {currentResult.stats.channelCount}
+                        </span>
+                    </div>
+                {/if}
+            </div>
+
+            {#if refreshError}
+                <div class="mb-5 rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                    {refreshError}
+                </div>
+            {/if}
+
+            {#if refreshing}
+                <div class="flex h-[52vh] items-center justify-center">
+                    <div class="flex flex-col items-center gap-4 text-white/64">
+                        <LoadingSpinner size="46px" />
+                        <span>Refreshing channels</span>
+                    </div>
+                </div>
+            {:else if !selectedSource}
+                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
+                    No source configured
+                </div>
+            {:else if !currentResult}
+                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
+                    No channels loaded
+                </div>
+            {:else if visibleChannels.length === 0}
+                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
+                    No channels match
+                </div>
+            {:else}
+                <section class="overflow-hidden rounded-lg border border-white/10 bg-[#0b1116] shadow-2xl shadow-black/24">
+                    <div class="border-b border-white/10 bg-[#111a20] px-4 py-2 text-center">
+                        <div class="text-xs tabular-nums text-white/46">
+                            {formatTime(guideViewport.viewportStart)} – {formatTime(
+                                guideViewport.viewportEnd,
+                            )}
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
+                        <div class="border-r border-white/10 bg-[#101820]">
+                            <div class="h-10 border-b border-white/10"></div>
+                            {#each guideRows as row (row.channel.id)}
+                                <button
+                                    class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
+                                    title={row.channel.name}
+                                    aria-label={`Play ${row.channel.name}`}
+                                    onclick={() => playChannel(row.channel)}
+                                >
+                                    <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-md bg-black/42 ring-1 ring-white/[0.06]">
+                                        {#if row.channel.logo}
+                                            <img
+                                                src={row.channel.logo}
+                                                alt=""
+                                                class="max-h-full max-w-full object-contain"
+                                                loading="lazy"
+                                                onerror={(event) => {
+                                                    (event.currentTarget as HTMLImageElement).style.display = "none";
+                                                }}
+                                            />
+                                        {:else}
+                                            <Tv size={22} strokeWidth={2} class="text-white/34" />
+                                        {/if}
+                                    </div>
+                                    {#if row.channel.number}
+                                        <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                            {row.channel.number}
+                                        </span>
+                                    {:else}
+                                        <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+                                            {row.channel.name}
+                                        </span>
+                                    {/if}
+                                </button>
+                            {/each}
+                        </div>
+
+                        <div class="no-scrollbar min-w-0 overflow-x-auto bg-[#0b1116]">
+                            <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
+                                <div class="relative h-10 border-b border-white/10 bg-[#101820]">
+                                    {#each guideTimeTicks as tick (tick.value.getTime())}
+                                        <div
+                                            class={timeTickClass(tick.leftPercent)}
+                                            style={`left: ${tick.leftPercent}%;`}
+                                        >
+                                            {tick.label}
+                                        </div>
+                                    {/each}
+                                </div>
+
+                                <div class="relative">
+                                    {#if showGuideNowLine}
+                                        <div
+                                            class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
+                                            style={`left: ${guideNowLinePercent}%;`}
+                                        >
+                                            <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-[#a8b99b] shadow-[0_0_16px_rgba(168,185,155,0.75)]"></div>
+                                            <div class="h-full w-px bg-[#a8b99b]/90 shadow-[0_0_12px_rgba(168,185,155,0.45)]"></div>
+                                        </div>
+                                    {/if}
+
+                                    {#each guideRows as row (row.channel.id)}
+                                        <div class="relative h-[86px] border-b border-white/[0.06]">
+                                            {#if row.programmes.length > 0}
+                                                {#each row.programmes as programme (programme.id)}
+                                                    <button
+                                                        class={`absolute inset-y-2 overflow-hidden rounded-md border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
+                                                        style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
+                                                        title={`${programme.timeRange} ${programme.title}`}
+                                                        onclick={() => playChannel(row.channel)}
+                                                    >
+                                                        <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
+                                                            {programme.title}
+                                                        </span>
+                                                        <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
+                                                            {programme.timeRange}
+                                                        </span>
+                                                    </button>
+                                                {/each}
+                                            {:else}
+                                                <button
+                                                    class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-md border border-white/[0.08] bg-[#20262b] px-3 text-left text-white/78 transition-colors hover:bg-[#293039]"
+                                                    onclick={() => playChannel(row.channel)}
+                                                >
+                                                    <span class="font-poppins text-[13px] font-semibold">
+                                                        {guideFallbackLabel(Boolean(currentResult.guide))}
+                                                    </span>
+                                                    <span class="min-w-0 truncate text-[11px] text-white/42">
+                                                        {row.channel.name}
+                                                    </span>
+                                                </button>
+                                            {/if}
+                                        </div>
+                                    {/each}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            {/if}
+        </main>
+    </div>
+</div>
+
+<style>
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+
+    .no-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+</style>

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -1,49 +1,42 @@
 <script lang="ts">
     import { onDestroy, onMount, tick } from "svelte";
-    import {
-        ChevronLeft,
-        Pencil,
-        Plus,
-        RefreshCw,
-        Search,
-        Trash2,
-        Tv,
-        X,
-    } from "@lucide/svelte";
-    import LoadingSpinner from "../../components/common/LoadingSpinner.svelte";
+    import SearchBar from "../../components/home/SearchBar.svelte";
+    import SettingsModal from "../../components/home/modals/SettingsModal.svelte";
     import { trackEvent } from "../../lib/analytics";
-    import { router } from "../../lib/stores/router";
-    import {
-        addIptvSource,
-        iptvSources,
-        removeIptvSource,
-        updateIptvSource,
-    } from "../../lib/iptv/store";
-    import { refreshIptvSource } from "../../lib/iptv/refresh";
     import {
         getStoredIptvRefreshResult,
-        getIptvSourceCacheFingerprint,
         persistIptvRefreshResult,
     } from "../../lib/iptv/cache";
     import {
         buildGuideRows,
         getNowLinePercent,
-        type GuideGridViewport,
-        type GuideProgrammeState,
     } from "../../lib/iptv/guideGrid";
-    import { getNowNext } from "../../lib/iptv/xmltv";
+    import { refreshIptvSource } from "../../lib/iptv/refresh";
+    import { iptvSources } from "../../lib/iptv/store";
     import type {
         IptvChannel,
         IptvRefreshResult,
         IptvSource,
-        IptvSourceKind,
     } from "../../lib/iptv/types";
+    import { getNowNext } from "../../lib/iptv/xmltv";
+    import { router } from "../../lib/stores/router";
+    import LiveEmptyState from "./components/LiveEmptyState.svelte";
+    import LiveGroupFilter from "./components/LiveGroupFilter.svelte";
+    import LiveGuide from "./components/LiveGuide.svelte";
+    import LiveSourceManager from "./components/LiveSourceManager.svelte";
+    import LiveSourceSelector from "./components/LiveSourceSelector.svelte";
+    import {
+        ALL_GROUPS,
+        GUIDE_CHANNEL_PAGE_SIZE,
+        GUIDE_INITIAL_CHANNEL_LIMIT,
+        buildGuideTimeTicks,
+        formatLoadedAt,
+        getGuideViewport,
+        getLiveSourceCacheKey,
+        getLiveSourceSummary,
+        getVisibleChannels,
+    } from "./liveHelpers";
 
-    const ALL_GROUPS = "__all__";
-    const GUIDE_VIEWPORT_HOURS = 2;
-    const GUIDE_TIMELINE_MIN_WIDTH = 680;
-    const GUIDE_INITIAL_CHANNEL_LIMIT = 100;
-    const GUIDE_CHANNEL_PAGE_SIZE = 100;
     const IPTV_EXAMPLE_M3U_URL = (
         import.meta.env.VITE_RAFFI_IPTV_EXAMPLE_M3U_URL as string | undefined
     )?.trim();
@@ -59,34 +52,29 @@
               }
             : null;
 
+    const isDev = import.meta.env.DEV;
+
     let selectedSourceId = "";
     let loadedSourceId = "";
     let loadedSourceCacheKey = "";
     let refreshResult: IptvRefreshResult | null = null;
     let refreshing = false;
     let refreshError = "";
-    let formError = "";
-    let editingSourceId: string | null = null;
-    let formKind: IptvSourceKind = "m3u";
-    let formName = "";
-    let formM3uUrl = "";
-    let formEpgUrl = "";
-    let formXtreamServerUrl = "";
-    let formXtreamUsername = "";
-    let formXtreamCredential = "";
     let selectedGroup = ALL_GROUPS;
     let searchQuery = "";
     let guideNow = new Date();
     let guideTimer: ReturnType<typeof setInterval> | null = null;
     let showSourceManager = false;
+    let sourceManagerResetRequest = 0;
+    let showSettingsModal = false;
     let guideChannelLimit = GUIDE_INITIAL_CHANNEL_LIMIT;
     let guideChannelFilterKey = "";
 
-    const isDev = import.meta.env.DEV;
-
     $: selectedSource =
         $iptvSources.find((source) => source.id === selectedSourceId) ?? null;
-    $: selectedSourceCacheKey = selectedSource ? getLiveSourceCacheKey(selectedSource) : "";
+    $: selectedSourceCacheKey = selectedSource
+        ? getLiveSourceCacheKey(selectedSource)
+        : "";
     $: currentResult =
         refreshResult &&
         loadedSourceId === selectedSourceId &&
@@ -94,11 +82,10 @@
             ? refreshResult
             : null;
     $: availableGroups = currentResult?.groups ?? [];
-    $: sourceSummary = currentResult
-        ? `${currentResult.stats.channelCount} channels / ${currentResult.stats.groupCount} groups`
-        : selectedSource
-            ? "Refresh this source to load channels"
-            : "Add a source to start watching";
+    $: sourceSummary = getLiveSourceSummary(currentResult, selectedSource);
+    $: sourceRefreshedLabel = currentResult
+        ? `Refreshed ${formatLoadedAt(currentResult.loadedAt)}`
+        : "";
     $: visibleChannels = getVisibleChannels(
         currentResult?.channels ?? [],
         selectedGroup,
@@ -111,8 +98,14 @@
     }
     $: visibleGuideChannels = visibleChannels.slice(0, guideChannelLimit);
     $: hasMoreGuideChannels = visibleGuideChannels.length < visibleChannels.length;
-    $: remainingGuideChannels = Math.max(visibleChannels.length - visibleGuideChannels.length, 0);
-    $: nextGuideChannelPageCount = Math.min(GUIDE_CHANNEL_PAGE_SIZE, remainingGuideChannels);
+    $: remainingGuideChannels = Math.max(
+        visibleChannels.length - visibleGuideChannels.length,
+        0,
+    );
+    $: nextGuideChannelPageCount = Math.min(
+        GUIDE_CHANNEL_PAGE_SIZE,
+        remainingGuideChannels,
+    );
     $: guideTitle = selectedGroup === ALL_GROUPS ? "Live TV" : selectedGroup;
     $: guideViewport = getGuideViewport(guideNow);
     $: guideRows = currentResult
@@ -124,7 +117,10 @@
     $: if (!selectedSourceId && $iptvSources.length > 0) {
         selectedSourceId = $iptvSources[0].id;
     }
-    $: if (selectedSourceId && !$iptvSources.some((source) => source.id === selectedSourceId)) {
+    $: if (
+        selectedSourceId &&
+        !$iptvSources.some((source) => source.id === selectedSourceId)
+    ) {
         selectedSourceId = $iptvSources[0]?.id ?? "";
     }
     $: if (
@@ -146,101 +142,11 @@
         selectedGroup = ALL_GROUPS;
     }
 
-    function getVisibleChannels(
-        channels: IptvChannel[],
-        group: string,
-        query: string,
-    ) {
-        const normalizedQuery = query.trim().toLowerCase();
-        return channels.filter((channel) => {
-            if (group !== ALL_GROUPS && channel.group !== group) return false;
-            if (!normalizedQuery) return true;
-
-            return (
-                channel.name.toLowerCase().includes(normalizedQuery) ||
-                channel.group.toLowerCase().includes(normalizedQuery) ||
-                (channel.tvgName ?? "").toLowerCase().includes(normalizedQuery) ||
-                (channel.tvgId ?? "").toLowerCase().includes(normalizedQuery)
-            );
-        });
-    }
-
-    function getLiveSourceCacheKey(source: IptvSource) {
-        return `${source.id}\n${getIptvSourceCacheFingerprint(source)}`;
-    }
-
     function showMoreGuideChannels() {
         guideChannelLimit = Math.min(
             visibleChannels.length,
             guideChannelLimit + GUIDE_CHANNEL_PAGE_SIZE,
         );
-    }
-
-    function getGuideViewport(now: Date): GuideGridViewport {
-        const viewportStart = new Date(now);
-        viewportStart.setMinutes(0, 0, 0);
-
-        return {
-            viewportStart,
-            viewportEnd: new Date(viewportStart.getTime() + GUIDE_VIEWPORT_HOURS * 60 * 60_000),
-            now,
-        };
-    }
-
-    function getTimePercent(value: Date, viewport: GuideGridViewport) {
-        const viewportStartMs = viewport.viewportStart.getTime();
-        const viewportDurationMs = viewport.viewportEnd.getTime() - viewportStartMs;
-
-        if (viewportDurationMs <= 0) return 0;
-
-        return ((value.getTime() - viewportStartMs) / viewportDurationMs) * 100;
-    }
-
-    function buildGuideTimeTicks(viewport: GuideGridViewport) {
-        const ticks: { value: Date; label: string; leftPercent: number }[] = [];
-        const tickMs = 30 * 60_000;
-
-        for (
-            let timestamp = viewport.viewportStart.getTime();
-            timestamp <= viewport.viewportEnd.getTime();
-            timestamp += tickMs
-        ) {
-            const value = new Date(timestamp);
-            ticks.push({
-                value,
-                label: formatTime(value),
-                leftPercent: getTimePercent(value, viewport),
-            });
-        }
-
-        return ticks;
-    }
-
-    function timeTickClass(leftPercent: number) {
-        const base = "absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-[11px] tabular-nums text-white/42";
-        if (leftPercent <= 1) return `${base} translate-x-0`;
-        if (leftPercent >= 99) return `${base} -translate-x-full`;
-        return `${base} -translate-x-1/2`;
-    }
-
-    function programmeBlockClass(state: GuideProgrammeState) {
-        if (state === "current") {
-            return "border-white/18 bg-white/18 text-white shadow-[0_10px_24px_rgba(0,0,0,0.18)] hover:bg-white/24";
-        }
-
-        if (state === "future") {
-            return "border-white/[0.08] bg-white/[0.08] text-white/84 hover:bg-white/[0.12]";
-        }
-
-        return "border-white/[0.06] bg-white/[0.04] text-white/46 hover:bg-white/[0.07]";
-    }
-
-    function guideFallbackLabel(hasGuide: boolean) {
-        return hasGuide ? "No guide data" : "Live";
-    }
-
-    function focusOnMount(node: HTMLElement) {
-        void tick().then(() => node.focus());
     }
 
     function hydrateStoredSource(source: IptvSource, cacheKey: string) {
@@ -251,116 +157,21 @@
         refreshError = "";
     }
 
-    function resetForm() {
-        editingSourceId = null;
-        formKind = "m3u";
-        formName = "";
-        formM3uUrl = "";
-        formEpgUrl = "";
-        formXtreamServerUrl = "";
-        formXtreamUsername = "";
-        formXtreamCredential = "";
-        formError = "";
+    function openSourceManager() {
+        showSourceManager = true;
     }
 
-    function editSource(source: IptvSource) {
-        editingSourceId = source.id;
-        formKind = source.kind;
-        formName = source.name;
-        if (source.kind === "xtream") {
-            formM3uUrl = "";
-            formEpgUrl = "";
-            formXtreamServerUrl = source.serverUrl;
-            formXtreamUsername = source.username;
-            formXtreamCredential = source.credential;
-        } else {
-            formM3uUrl = source.m3uUrl;
-            formEpgUrl = source.epgUrl ?? "";
-            formXtreamServerUrl = "";
-            formXtreamUsername = "";
-            formXtreamCredential = "";
-        }
-        formError = "";
+    function openCreateSourceManager() {
+        sourceManagerResetRequest += 1;
+        showSourceManager = true;
     }
 
-    function setFormKind(kind: IptvSourceKind) {
-        formKind = kind;
-        formError = "";
-    }
-
-    function fillDispatcharrExample() {
-        if (!IPTV_EXAMPLE) return;
-        formKind = "m3u";
-        formName = IPTV_EXAMPLE.name;
-        formM3uUrl = IPTV_EXAMPLE.m3uUrl;
-        formEpgUrl = IPTV_EXAMPLE.epgUrl;
-        formError = "";
-    }
-
-    function saveSource() {
-        try {
-            if (editingSourceId) {
-                const updated =
-                    formKind === "xtream"
-                        ? updateIptvSource(editingSourceId, {
-                              kind: "xtream",
-                              name: formName,
-                              serverUrl: formXtreamServerUrl,
-                              username: formXtreamUsername,
-                              credential: formXtreamCredential,
-                          })
-                        : updateIptvSource(editingSourceId, {
-                              kind: "m3u",
-                              name: formName,
-                              m3uUrl: formM3uUrl,
-                              epgUrl: formEpgUrl,
-                          });
-                if (!updated) {
-                    throw new Error("The selected IPTV source no longer exists");
-                }
-                selectedSourceId = updated.id;
-                trackEvent("iptv_source_updated");
-            } else {
-                const source =
-                    formKind === "xtream"
-                        ? addIptvSource({
-                              kind: "xtream",
-                              name: formName,
-                              serverUrl: formXtreamServerUrl,
-                              username: formXtreamUsername,
-                              credential: formXtreamCredential,
-                          })
-                        : addIptvSource({
-                              kind: "m3u",
-                              name: formName,
-                              m3uUrl: formM3uUrl,
-                              epgUrl: formEpgUrl,
-                          });
-                selectedSourceId = source.id;
-                trackEvent("iptv_source_added");
-            }
-            resetForm();
-        } catch (error) {
-            formError = error instanceof Error ? error.message : String(error);
-        }
-    }
-
-    function deleteSource(source: IptvSource) {
-        const confirmed =
-            typeof window === "undefined" ||
-            window.confirm(`Remove IPTV source "${source.name}"?`);
-        if (!confirmed) return;
-
-        removeIptvSource(source.id);
+    function handleSourceRemoved(source: IptvSource) {
         if (loadedSourceId === source.id) {
             loadedSourceId = "";
             loadedSourceCacheKey = "";
             refreshResult = null;
         }
-        if (editingSourceId === source.id) {
-            resetForm();
-        }
-        trackEvent("iptv_source_removed");
     }
 
     async function refreshSelectedSource() {
@@ -427,26 +238,6 @@
         });
     }
 
-    function formatTime(value: Date) {
-        return new Intl.DateTimeFormat(undefined, {
-            hour: "numeric",
-            minute: "2-digit",
-        }).format(value);
-    }
-
-    function formatLoadedAt(value: string) {
-        const parsed = new Date(value);
-        if (Number.isNaN(parsed.getTime())) {
-            return "Unknown";
-        }
-
-        return new Intl.DateTimeFormat(undefined, {
-            hour: "numeric",
-            minute: "2-digit",
-            second: "2-digit",
-        }).format(parsed);
-    }
-
     onMount(() => {
         guideTimer = setInterval(() => {
             guideNow = new Date();
@@ -469,561 +260,87 @@
     });
 </script>
 
-<svelte:window
-    onkeydown={(event) => {
-        if (showSourceManager && event.key === "Escape") showSourceManager = false;
-    }}
+<SettingsModal bind:showSettings={showSettingsModal} />
+<LiveSourceManager
+    bind:show={showSourceManager}
+    bind:selectedSourceId
+    resetRequest={sourceManagerResetRequest}
+    {isDev}
+    iptvExample={IPTV_EXAMPLE}
+    onSourceRemoved={handleSourceRemoved}
 />
 
-<div class="min-h-screen bg-[#090909] text-white">
-    <main class="mx-auto flex min-h-screen w-full max-w-[1760px] flex-col gap-5 px-5 py-5 lg:px-8 lg:py-7">
-        <header class="rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
-            <div class="flex flex-col gap-5 xl:flex-row xl:items-center xl:justify-between">
-                <div class="flex min-w-0 items-center gap-4">
-                    <button
-                        class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/8 text-white/80 transition-colors hover:bg-white/14"
-                        aria-label="Back"
-                        onclick={() => {
-                            if (!router.back()) router.navigate("home");
-                        }}
-                    >
-                        <ChevronLeft size={26} strokeWidth={2} />
-                    </button>
-                    <div class="flex min-w-0 items-center gap-3">
-                        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white/8">
-                            <Tv size={25} strokeWidth={2} class="text-white/74" />
-                        </div>
-                        <div class="min-w-0">
-                            <h1 class="truncate font-poppins text-[28px] font-semibold leading-tight">
-                                Live TV
-                            </h1>
-                            <p class="truncate text-sm text-white/60">
-                                {sourceSummary}
-                            </p>
-                        </div>
-                    </div>
+<div class="flex h-full min-h-screen w-full flex-col overflow-hidden bg-[#090909] text-white">
+    <SearchBar
+        absolute={false}
+        controlledSearch={true}
+        bind:searchValue={searchQuery}
+        searchPlaceholder="search channels"
+        searchDisabled={!currentResult}
+        searchWidthClass="w-[420px] max-w-[32vw]"
+        showPlayButton={false}
+        showAddonsButton={false}
+        showLiveTvButton={false}
+        onOpenSettings={() => (showSettingsModal = true)}
+    >
+        <svelte:fragment slot="prefix">
+            <LiveSourceSelector
+                sources={$iptvSources}
+                bind:selectedSourceId
+                {sourceSummary}
+                refreshedLabel={sourceRefreshedLabel}
+                {refreshing}
+                onManage={openSourceManager}
+                onRefresh={refreshSelectedSource}
+            />
+            <LiveGroupFilter
+                groups={availableGroups}
+                bind:selectedGroup
+                allGroupsValue={ALL_GROUPS}
+                disabled={!currentResult}
+                totalChannels={currentResult?.stats.channelCount ?? 0}
+            />
+        </svelte:fragment>
+    </SearchBar>
+
+    <main class="relative z-10 min-h-0 flex-1 px-5 pb-5 pt-2 lg:px-8 lg:pt-4">
+        <div class="mx-auto flex w-full max-w-[1760px] flex-col gap-4">
+            {#if refreshError}
+                <div class="rounded-[20px] border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                    {refreshError}
                 </div>
+            {/if}
 
-                <div class="flex flex-wrap items-center gap-3">
-                    {#if currentResult}
-                        <span class="text-sm text-white/45">
-                            Refreshed {formatLoadedAt(currentResult.loadedAt)}
-                        </span>
-                    {/if}
-                    <button
-                        class="flex h-11 items-center gap-2 rounded-full border border-white/10 bg-white/8 px-4 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14 hover:text-white"
-                        onclick={() => (showSourceManager = true)}
-                    >
-                        <Plus size={17} strokeWidth={2.4} />
-                        Sources
-                    </button>
-                    <button
-                        class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88 disabled:cursor-not-allowed disabled:opacity-45"
-                        disabled={!selectedSource || refreshing}
-                        onclick={refreshSelectedSource}
-                    >
-                        {#if refreshing}
-                            <LoadingSpinner size="16px" color="#111111" />
-                        {:else}
-                            <RefreshCw size={17} strokeWidth={2.4} />
-                        {/if}
-                        Refresh
-                    </button>
-                </div>
-            </div>
-        </header>
-
-        {#if refreshError}
-            <div class="rounded-[20px] border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
-                {refreshError}
-            </div>
-        {/if}
-
-        {#if selectedSource}
-            <section class="rounded-[28px] border border-white/10 bg-white/4 p-4 backdrop-blur-md">
-                <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                    <div class="grid min-w-0 flex-1 gap-3 md:grid-cols-[minmax(180px,0.8fr)_minmax(180px,0.8fr)_minmax(220px,1.2fr)]">
-                        <label class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-white/38">
-                            Source
-                            <select
-                                class="h-12 rounded-2xl border border-white/10 bg-black/24 px-4 text-sm normal-case tracking-normal text-white outline-none focus:border-white/35"
-                                bind:value={selectedSourceId}
-                            >
-                                {#each $iptvSources as source}
-                                    <option value={source.id}>{source.name}</option>
-                                {/each}
-                            </select>
-                        </label>
-
-                        <label class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-white/38">
-                            Group
-                            <select
-                                class="h-12 rounded-2xl border border-white/10 bg-black/24 px-4 text-sm normal-case tracking-normal text-white outline-none focus:border-white/35 disabled:opacity-45"
-                                bind:value={selectedGroup}
-                                disabled={!currentResult}
-                            >
-                                <option value={ALL_GROUPS}>All groups</option>
-                                {#each availableGroups as group}
-                                    <option value={group.name}>
-                                        {group.name} ({group.channelCount})
-                                    </option>
-                                {/each}
-                            </select>
-                        </label>
-
-                        <label class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-white/38">
-                            Search
-                            <div class="relative">
-                                <Search
-                                    size={19}
-                                    strokeWidth={2.1}
-                                    class="absolute left-4 top-1/2 -translate-y-1/2 text-white/42"
-                                />
-                                <input
-                                    class="h-12 w-full rounded-2xl border border-white/10 bg-black/24 pl-11 pr-4 text-sm normal-case tracking-normal text-white outline-none focus:border-white/35 disabled:opacity-45"
-                                    placeholder="Search channels"
-                                    bind:value={searchQuery}
-                                    disabled={!currentResult}
-                                />
-                            </div>
-                        </label>
-                    </div>
-
-                    {#if currentResult}
-                        <span class="text-sm text-white/45">
-                            Showing {visibleChannels.length} of {currentResult.stats.channelCount}
-                        </span>
-                    {/if}
-                </div>
-            </section>
-        {/if}
-
-        {#if refreshing}
-            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 backdrop-blur-xl">
-                <div class="flex flex-col items-center gap-4 text-white/64">
-                    <LoadingSpinner size="46px" />
-                    <span>Refreshing channels</span>
-                </div>
-            </section>
-        {:else if !selectedSource}
-            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center backdrop-blur-xl">
-                <div class="flex max-w-xl flex-col items-center gap-4">
-                    <div class="flex h-16 w-16 items-center justify-center rounded-[24px] bg-white/8">
-                        <Tv size={30} strokeWidth={2} class="text-white/70" />
-                    </div>
-                    <div>
-                        <h2 class="font-poppins text-2xl font-semibold">
-                            Add a Live TV Source
-                        </h2>
-                        <p class="mt-2 text-sm leading-6 text-white/60">
-                            Connect an M3U playlist or Xtream account to load channels and guide data.
-                        </p>
-                    </div>
-                    <button
-                        class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
-                        onclick={() => {
-                            resetForm();
-                            showSourceManager = true;
-                        }}
-                    >
-                        <Plus size={17} strokeWidth={2.4} />
-                        Add Source
-                    </button>
-                </div>
-            </section>
-        {:else if !currentResult}
-            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center backdrop-blur-xl">
-                <div class="flex max-w-xl flex-col items-center gap-4">
-                    <div class="flex h-16 w-16 items-center justify-center rounded-[24px] bg-white/8">
-                        <RefreshCw size={28} strokeWidth={2} class="text-white/70" />
-                    </div>
-                    <div>
-                        <h2 class="font-poppins text-2xl font-semibold">
-                            Load Channels
-                        </h2>
-                        <p class="mt-2 text-sm leading-6 text-white/60">
-                            Refresh {selectedSource.name} to cache channels and guide data for this device.
-                        </p>
-                    </div>
-                    <div class="flex flex-wrap justify-center gap-3">
-                        <button
-                            class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
-                            onclick={refreshSelectedSource}
-                        >
-                            <RefreshCw size={17} strokeWidth={2.4} />
-                            Refresh Source
-                        </button>
-                        <button
-                            class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
-                            onclick={() => (showSourceManager = true)}
-                        >
-                            Manage Sources
-                        </button>
-                    </div>
-                </div>
-            </section>
-        {:else if visibleChannels.length === 0}
-            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center text-white/60 backdrop-blur-xl">
-                No channels match the current filters.
-            </section>
-        {:else}
-            <section class="overflow-hidden rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
-                <div class="flex flex-col gap-2 border-b border-white/10 bg-white/[0.04] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h2 class="font-poppins text-lg font-semibold">
-                            {guideTitle}
-                        </h2>
-                        <p class="text-sm text-white/45">
-                            Click a channel or programme to start live playback.
-                            {#if hasMoreGuideChannels}
-                                Showing {visibleGuideChannels.length} of {visibleChannels.length} matching channels.
-                            {/if}
-                        </p>
-                    </div>
-                    <div class="text-sm tabular-nums text-white/46">
-                        {formatTime(guideViewport.viewportStart)} to {formatTime(
-                            guideViewport.viewportEnd,
-                        )}
-                    </div>
-                </div>
-
-                <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
-                    <div class="border-r border-white/10 bg-black/18">
-                        <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
-                        {#each guideRows as row (row.channel.id)}
-                            <button
-                                class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
-                                title={row.channel.name}
-                                aria-label={`Play ${row.channel.name}`}
-                                onclick={() => playChannel(row.channel)}
-                            >
-                                <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-black/32 ring-1 ring-white/[0.06]">
-                                    {#if row.channel.logo}
-                                        <img
-                                            src={row.channel.logo}
-                                            alt=""
-                                            class="max-h-full max-w-full object-contain"
-                                            loading="lazy"
-                                            onerror={(event) => {
-                                                (event.currentTarget as HTMLImageElement).style.display = "none";
-                                            }}
-                                        />
-                                    {:else}
-                                        <Tv size={22} strokeWidth={2} class="text-white/34" />
-                                    {/if}
-                                </div>
-                                {#if row.channel.number}
-                                    <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
-                                        {row.channel.number}
-                                    </span>
-                                {:else}
-                                    <span class="max-w-full truncate text-[10px] leading-none text-white/48">
-                                        {row.channel.name}
-                                    </span>
-                                {/if}
-                            </button>
-                        {/each}
-                    </div>
-
-                    <div class="no-scrollbar min-w-0 overflow-x-auto bg-black/12">
-                        <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
-                            <div class="relative h-10 border-b border-white/10 bg-white/[0.03]">
-                                {#each guideTimeTicks as tick (tick.value.getTime())}
-                                    <div
-                                        class={timeTickClass(tick.leftPercent)}
-                                        style={`left: ${tick.leftPercent}%;`}
-                                    >
-                                        {tick.label}
-                                    </div>
-                                {/each}
-                            </div>
-
-                            <div class="relative">
-                                {#if showGuideNowLine}
-                                    <div
-                                        class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
-                                        style={`left: ${guideNowLinePercent}%;`}
-                                    >
-                                        <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-white shadow-[0_0_16px_rgba(255,255,255,0.55)]"></div>
-                                        <div class="h-full w-px bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.28)]"></div>
-                                    </div>
-                                {/if}
-
-                                {#each guideRows as row (row.channel.id)}
-                                    <div class="relative h-[86px] border-b border-white/[0.06]">
-                                        {#if row.programmes.length > 0}
-                                            {#each row.programmes as programme (programme.id)}
-                                                <button
-                                                    class={`absolute inset-y-2 overflow-hidden rounded-xl border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
-                                                    style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
-                                                    title={`${programme.timeRange} ${programme.title}`}
-                                                    onclick={() => playChannel(row.channel)}
-                                                >
-                                                    <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
-                                                        {programme.title}
-                                                    </span>
-                                                    <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
-                                                        {programme.timeRange}
-                                                    </span>
-                                                </button>
-                                            {/each}
-                                        {:else}
-                                            <button
-                                                class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.08] px-3 text-left text-white/78 transition-colors hover:bg-white/[0.12]"
-                                                onclick={() => playChannel(row.channel)}
-                                            >
-                                                <span class="font-poppins text-[13px] font-semibold">
-                                                    {guideFallbackLabel(Boolean(currentResult.guide))}
-                                                </span>
-                                                <span class="min-w-0 truncate text-[11px] text-white/42">
-                                                    {row.channel.name}
-                                                </span>
-                                            </button>
-                                        {/if}
-                                    </div>
-                                {/each}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                {#if hasMoreGuideChannels}
-                    <div class="flex flex-col gap-3 border-t border-white/10 bg-white/[0.03] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-                        <p class="text-sm leading-6 text-white/48">
-                            Large playlists are paged to keep the guide responsive. Search or select a group to narrow the list.
-                        </p>
-                        <button
-                            class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
-                            onclick={showMoreGuideChannels}
-                        >
-                            Show {nextGuideChannelPageCount} more
-                        </button>
-                    </div>
-                {/if}
-            </section>
-        {/if}
-    </main>
-
-    {#if showSourceManager}
-        <div
-            class="fixed inset-0 z-[220] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
-            onclick={(event) => {
-                if (event.currentTarget === event.target) showSourceManager = false;
-            }}
-            onkeydown={(event) => {
-                if (event.key === "Escape") showSourceManager = false;
-            }}
-            role="button"
-            tabindex="0"
-        >
-            <section
-                class="max-h-[92vh] w-full max-w-[1040px] overflow-y-auto rounded-[28px] border border-white/10 bg-[#2b2b2b]/95 p-5 shadow-[0_32px_100px_rgba(0,0,0,0.48)] backdrop-blur-xl"
-                role="dialog"
-                aria-modal="true"
-                tabindex="-1"
-                use:focusOnMount
-            >
-                <div class="mb-5 flex items-start justify-between gap-4">
-                    <div>
-                        <h2 class="font-poppins text-2xl font-semibold">
-                            Live TV Sources
-                        </h2>
-                        <p class="mt-1 text-sm text-white/60">
-                            Add M3U playlists, Xtream accounts, and guide data.
-                        </p>
-                    </div>
-                    <button
-                        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/8 text-white/72 transition-colors hover:bg-white/14 hover:text-white"
-                        aria-label="Close source manager"
-                        onclick={() => (showSourceManager = false)}
-                    >
-                        <X size={20} strokeWidth={2.2} />
-                    </button>
-                </div>
-
-                <div class="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(360px,1.1fr)]">
-                    <section class="rounded-[24px] bg-white/4 p-4">
-                        <div class="mb-4 flex items-center justify-between gap-3">
-                            <h3 class="font-poppins text-lg font-semibold">
-                                Sources
-                            </h3>
-                            <button
-                                class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
-                                aria-label="Add source"
-                                onclick={resetForm}
-                            >
-                                <Plus size={18} strokeWidth={2.4} />
-                            </button>
-                        </div>
-
-                        {#if $iptvSources.length > 0}
-                            <div class="flex max-h-[420px] flex-col gap-2 overflow-y-auto pr-1">
-                                {#each $iptvSources as source}
-                                    <div
-                                        class={`flex flex-col gap-3 rounded-2xl border p-3 transition-colors sm:flex-row sm:items-center sm:justify-between ${
-                                            selectedSourceId === source.id
-                                                ? "border-white/18 bg-white/[0.10]"
-                                                : "border-white/8 bg-white/[0.04]"
-                                        }`}
-                                    >
-                                        <button
-                                            class="min-w-0 flex-1 text-left"
-                                            onclick={() => (selectedSourceId = source.id)}
-                                        >
-                                            <p class="truncate font-medium text-white">
-                                                {source.name}
-                                            </p>
-                                            <p class="mt-1 text-xs uppercase tracking-[0.12em] text-white/42">
-                                                {source.kind === "xtream" ? "Xtream" : "M3U"}
-                                            </p>
-                                        </button>
-                                        <div class="flex shrink-0 gap-2">
-                                            <button
-                                                class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
-                                                aria-label={`Edit ${source.name}`}
-                                                onclick={() => editSource(source)}
-                                            >
-                                                <Pencil size={16} strokeWidth={2.2} />
-                                            </button>
-                                            <button
-                                                class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-red-500/20 hover:text-red-100"
-                                                aria-label={`Remove ${source.name}`}
-                                                onclick={() => deleteSource(source)}
-                                            >
-                                                <Trash2 size={16} strokeWidth={2.2} />
-                                            </button>
-                                        </div>
-                                    </div>
-                                {/each}
-                            </div>
-                        {:else}
-                            <div class="rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-5 text-sm text-white/56">
-                                No source configured yet.
-                            </div>
-                        {/if}
-                    </section>
-
-                    <section class="rounded-[24px] bg-white/4 p-4">
-                        <h3 class="font-poppins text-lg font-semibold">
-                            {editingSourceId ? "Edit Source" : "Add Source"}
-                        </h3>
-                        <div class="mt-4 flex flex-col gap-4">
-                            <label class="flex flex-col gap-2 text-sm text-white/62">
-                                Name
-                                <input
-                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
-                                    bind:value={formName}
-                                />
-                            </label>
-
-                            <div class="grid grid-cols-2 gap-1 rounded-full border border-white/10 bg-black/24 p-1">
-                                <button
-                                    class={`h-9 rounded-full text-sm font-semibold transition-colors ${formKind === "m3u" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
-                                    aria-pressed={formKind === "m3u"}
-                                    onclick={() => setFormKind("m3u")}
-                                >
-                                    M3U URL
-                                </button>
-                                <button
-                                    class={`h-9 rounded-full text-sm font-semibold transition-colors ${formKind === "xtream" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
-                                    aria-pressed={formKind === "xtream"}
-                                    onclick={() => setFormKind("xtream")}
-                                >
-                                    Xtream
-                                </button>
-                            </div>
-
-                            {#if formKind === "m3u"}
-                                <label class="flex flex-col gap-2 text-sm text-white/62">
-                                    M3U URL
-                                    <input
-                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
-                                        bind:value={formM3uUrl}
-                                        inputmode="url"
-                                    />
-                                </label>
-                                <label class="flex flex-col gap-2 text-sm text-white/62">
-                                    XMLTV URL
-                                    <input
-                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
-                                        bind:value={formEpgUrl}
-                                        inputmode="url"
-                                    />
-                                </label>
-                            {:else}
-                                <label class="flex flex-col gap-2 text-sm text-white/62">
-                                    Server URL
-                                    <input
-                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
-                                        bind:value={formXtreamServerUrl}
-                                        inputmode="url"
-                                    />
-                                </label>
-                                <label class="flex flex-col gap-2 text-sm text-white/62">
-                                    Username
-                                    <input
-                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
-                                        bind:value={formXtreamUsername}
-                                        autocomplete="off"
-                                    />
-                                </label>
-                                <label class="flex flex-col gap-2 text-sm text-white/62">
-                                    Password
-                                    <input
-                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
-                                        bind:value={formXtreamCredential}
-                                        type="password"
-                                        autocomplete="off"
-                                    />
-                                </label>
-                            {/if}
-
-                            {#if formError}
-                                <div class="rounded-2xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
-                                    {formError}
-                                </div>
-                            {/if}
-
-                            <div class="flex flex-wrap gap-2">
-                                <button
-                                    class="h-11 flex-1 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
-                                    onclick={saveSource}
-                                >
-                                    {editingSourceId ? "Save Source" : "Add Source"}
-                                </button>
-                                {#if editingSourceId}
-                                    <button
-                                        class="h-11 flex-1 rounded-full bg-white/8 px-5 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14"
-                                        onclick={resetForm}
-                                    >
-                                        Cancel
-                                    </button>
-                                {/if}
-                            </div>
-
-                            {#if isDev && IPTV_EXAMPLE}
-                                <button
-                                    class="h-10 rounded-full border border-white/10 text-sm text-white/60 transition-colors hover:bg-white/8 hover:text-white/82"
-                                    onclick={fillDispatcharrExample}
-                                >
-                                    Use IPTV example
-                                </button>
-                            {/if}
-                        </div>
-                    </section>
-                </div>
-            </section>
+            {#if refreshing}
+                <LiveEmptyState state="refreshing" />
+            {:else if !selectedSource}
+                <LiveEmptyState state="no-source" onAddSource={openCreateSourceManager} />
+            {:else if !currentResult}
+                <LiveEmptyState
+                    state="needs-refresh"
+                    sourceName={selectedSource.name}
+                    onRefreshSource={refreshSelectedSource}
+                    onManageSources={openSourceManager}
+                />
+            {:else if visibleChannels.length === 0}
+                <LiveEmptyState state="no-results" />
+            {:else}
+                <LiveGuide
+                    {guideTitle}
+                    {guideViewport}
+                    {guideRows}
+                    {guideTimeTicks}
+                    {guideNowLinePercent}
+                    {showGuideNowLine}
+                    hasGuide={Boolean(currentResult.guide)}
+                    {hasMoreGuideChannels}
+                    visibleGuideChannelsCount={visibleGuideChannels.length}
+                    visibleChannelsCount={visibleChannels.length}
+                    {nextGuideChannelPageCount}
+                    onPlayChannel={playChannel}
+                    onShowMoreGuideChannels={showMoreGuideChannels}
+                />
+            {/if}
         </div>
-    {/if}
+    </main>
 </div>
-
-<style>
-    .no-scrollbar::-webkit-scrollbar {
-        display: none;
-    }
-
-    .no-scrollbar {
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-    }
-</style>

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -21,6 +21,7 @@
     import { refreshIptvSource } from "../../lib/iptv/refresh";
     import {
         getStoredIptvRefreshResult,
+        getIptvSourceCacheFingerprint,
         persistIptvRefreshResult,
     } from "../../lib/iptv/cache";
     import {
@@ -34,6 +35,7 @@
         IptvChannel,
         IptvRefreshResult,
         IptvSource,
+        IptvSourceKind,
     } from "../../lib/iptv/types";
 
     const ALL_GROUPS = "__all__";
@@ -62,9 +64,13 @@
     let refreshError = "";
     let formError = "";
     let editingSourceId: string | null = null;
+    let formKind: IptvSourceKind = "m3u";
     let formName = "";
     let formM3uUrl = "";
     let formEpgUrl = "";
+    let formXtreamServerUrl = "";
+    let formXtreamUsername = "";
+    let formXtreamCredential = "";
     let selectedGroup = ALL_GROUPS;
     let searchQuery = "";
     let guideNow = new Date();
@@ -145,7 +151,7 @@
     }
 
     function getLiveSourceCacheKey(source: IptvSource) {
-        return `${source.id}\n${source.m3uUrl.trim()}\n${source.epgUrl?.trim() ?? ""}`;
+        return `${source.id}\n${getIptvSourceCacheFingerprint(source)}`;
     }
 
     function getGuideViewport(now: Date): GuideGridViewport {
@@ -221,22 +227,44 @@
 
     function resetForm() {
         editingSourceId = null;
+        formKind = "m3u";
         formName = "";
         formM3uUrl = "";
         formEpgUrl = "";
+        formXtreamServerUrl = "";
+        formXtreamUsername = "";
+        formXtreamCredential = "";
         formError = "";
     }
 
     function editSource(source: IptvSource) {
         editingSourceId = source.id;
+        formKind = source.kind;
         formName = source.name;
-        formM3uUrl = source.m3uUrl;
-        formEpgUrl = source.epgUrl ?? "";
+        if (source.kind === "xtream") {
+            formM3uUrl = "";
+            formEpgUrl = "";
+            formXtreamServerUrl = source.serverUrl;
+            formXtreamUsername = source.username;
+            formXtreamCredential = source.credential;
+        } else {
+            formM3uUrl = source.m3uUrl;
+            formEpgUrl = source.epgUrl ?? "";
+            formXtreamServerUrl = "";
+            formXtreamUsername = "";
+            formXtreamCredential = "";
+        }
+        formError = "";
+    }
+
+    function setFormKind(kind: IptvSourceKind) {
+        formKind = kind;
         formError = "";
     }
 
     function fillDispatcharrExample() {
         if (!IPTV_EXAMPLE) return;
+        formKind = "m3u";
         formName = IPTV_EXAMPLE.name;
         formM3uUrl = IPTV_EXAMPLE.m3uUrl;
         formEpgUrl = IPTV_EXAMPLE.epgUrl;
@@ -246,22 +274,42 @@
     function saveSource() {
         try {
             if (editingSourceId) {
-                const updated = updateIptvSource(editingSourceId, {
-                    name: formName,
-                    m3uUrl: formM3uUrl,
-                    epgUrl: formEpgUrl,
-                });
+                const updated =
+                    formKind === "xtream"
+                        ? updateIptvSource(editingSourceId, {
+                              kind: "xtream",
+                              name: formName,
+                              serverUrl: formXtreamServerUrl,
+                              username: formXtreamUsername,
+                              credential: formXtreamCredential,
+                          })
+                        : updateIptvSource(editingSourceId, {
+                              kind: "m3u",
+                              name: formName,
+                              m3uUrl: formM3uUrl,
+                              epgUrl: formEpgUrl,
+                          });
                 if (!updated) {
                     throw new Error("The selected IPTV source no longer exists");
                 }
                 selectedSourceId = updated.id;
                 trackEvent("iptv_source_updated");
             } else {
-                const source = addIptvSource({
-                    name: formName,
-                    m3uUrl: formM3uUrl,
-                    epgUrl: formEpgUrl,
-                });
+                const source =
+                    formKind === "xtream"
+                        ? addIptvSource({
+                              kind: "xtream",
+                              name: formName,
+                              serverUrl: formXtreamServerUrl,
+                              username: formXtreamUsername,
+                              credential: formXtreamCredential,
+                          })
+                        : addIptvSource({
+                              kind: "m3u",
+                              name: formName,
+                              m3uUrl: formM3uUrl,
+                              epgUrl: formEpgUrl,
+                          });
                 selectedSourceId = source.id;
                 trackEvent("iptv_source_added");
             }
@@ -503,22 +551,67 @@
                         bind:value={formName}
                     />
                 </label>
-                <label class="flex flex-col gap-2 text-sm text-white/62">
-                    M3U URL
-                    <input
-                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                        bind:value={formM3uUrl}
-                        inputmode="url"
-                    />
-                </label>
-                <label class="flex flex-col gap-2 text-sm text-white/62">
-                    XMLTV URL
-                    <input
-                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                        bind:value={formEpgUrl}
-                        inputmode="url"
-                    />
-                </label>
+                <div class="grid grid-cols-2 gap-1 rounded-lg border border-white/10 bg-black/35 p-1">
+                    <button
+                        class={`h-9 rounded-md text-sm font-semibold transition-colors ${formKind === "m3u" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
+                        aria-pressed={formKind === "m3u"}
+                        onclick={() => setFormKind("m3u")}
+                    >
+                        M3U URL
+                    </button>
+                    <button
+                        class={`h-9 rounded-md text-sm font-semibold transition-colors ${formKind === "xtream" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
+                        aria-pressed={formKind === "xtream"}
+                        onclick={() => setFormKind("xtream")}
+                    >
+                        Xtream
+                    </button>
+                </div>
+
+                {#if formKind === "m3u"}
+                    <label class="flex flex-col gap-2 text-sm text-white/62">
+                        M3U URL
+                        <input
+                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                            bind:value={formM3uUrl}
+                            inputmode="url"
+                        />
+                    </label>
+                    <label class="flex flex-col gap-2 text-sm text-white/62">
+                        XMLTV URL
+                        <input
+                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                            bind:value={formEpgUrl}
+                            inputmode="url"
+                        />
+                    </label>
+                {:else}
+                    <label class="flex flex-col gap-2 text-sm text-white/62">
+                        Server URL
+                        <input
+                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                            bind:value={formXtreamServerUrl}
+                            inputmode="url"
+                        />
+                    </label>
+                    <label class="flex flex-col gap-2 text-sm text-white/62">
+                        Username
+                        <input
+                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                            bind:value={formXtreamUsername}
+                            autocomplete="off"
+                        />
+                    </label>
+                    <label class="flex flex-col gap-2 text-sm text-white/62">
+                        Password
+                        <input
+                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
+                            bind:value={formXtreamCredential}
+                            type="password"
+                            autocomplete="off"
+                        />
+                    </label>
+                {/if}
 
                 {#if formError}
                     <div class="rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -30,6 +30,8 @@
     import LiveSourceSelector from "./components/LiveSourceSelector.svelte";
     import {
         ALL_GROUPS,
+        FAVORITES_GROUP,
+        FAVORITES_GROUP_LABEL,
         GUIDE_CHANNEL_PAGE_SIZE,
         GUIDE_INITIAL_CHANNEL_LIMIT,
         LIVE_TV_AUTO_REFRESH_RETRY_MS,
@@ -39,12 +41,14 @@
         getGuideViewport,
         getLiveSourceCacheKey,
         getLiveSourceSummary,
+        getStoredLiveTvFavoriteChannelIds,
         getStoredLiveTvGroup,
         getStoredLiveTvSelection,
         getVisibleChannels,
         setStoredLiveTvGroup,
         setStoredLiveTvSourceId,
         shouldAutoRefreshLiveTvSource,
+        toggleStoredLiveTvFavoriteChannelId,
     } from "./liveHelpers";
 
     const IPTV_EXAMPLE_M3U_URL = (
@@ -80,6 +84,7 @@
             loadedSourceCacheKey: source ? cacheKey : "",
             refreshResult: cachedResult,
             selectedGroup: source ? getStoredLiveTvGroup(source.id) || ALL_GROUPS : ALL_GROUPS,
+            favoriteChannelIds: source ? getStoredLiveTvFavoriteChannelIds(source.id) : [],
         };
     }
 
@@ -92,6 +97,7 @@
     let refreshing = false;
     let refreshError = "";
     let selectedGroup = initialLiveTvState.selectedGroup;
+    let favoriteChannelIds = initialLiveTvState.favoriteChannelIds;
     let searchQuery = "";
     let guideNow = new Date();
     let guideTimer: ReturnType<typeof setInterval> | null = null;
@@ -116,6 +122,10 @@
             ? refreshResult
             : null;
     $: availableGroups = currentResult?.groups ?? [];
+    $: favoriteChannelIdSet = new Set(favoriteChannelIds);
+    $: favoriteChannelsCount = currentResult
+        ? currentResult.channels.filter((channel) => favoriteChannelIdSet.has(channel.id)).length
+        : 0;
     $: sourceSummary = getLiveSourceSummary(currentResult, selectedSource);
     $: sourceRefreshedLabel = currentResult
         ? `Refreshed ${formatLoadedAt(currentResult.loadedAt)}`
@@ -124,6 +134,7 @@
         currentResult?.channels ?? [],
         selectedGroup,
         searchQuery,
+        favoriteChannelIds,
     );
     $: currentGuideChannelFilterKey = `${selectedSourceId}\n${selectedGroup}\n${searchQuery.trim()}`;
     $: if (guideChannelFilterKey !== currentGuideChannelFilterKey) {
@@ -140,7 +151,12 @@
         GUIDE_CHANNEL_PAGE_SIZE,
         remainingGuideChannels,
     );
-    $: guideTitle = selectedGroup === ALL_GROUPS ? "Live TV" : selectedGroup;
+    $: guideTitle =
+        selectedGroup === ALL_GROUPS
+            ? "Live TV"
+            : selectedGroup === FAVORITES_GROUP
+              ? FAVORITES_GROUP_LABEL
+              : selectedGroup;
     $: guideViewport = getGuideViewport(guideNow);
     $: guideRows = currentResult
         ? buildGuideRows(visibleGuideChannels, currentResult.guide, guideViewport)
@@ -175,6 +191,7 @@
     $: if (
         currentResult &&
         selectedGroup !== ALL_GROUPS &&
+        selectedGroup !== FAVORITES_GROUP &&
         !availableGroups.some((group) => group.name === selectedGroup)
     ) {
         selectedGroup = ALL_GROUPS;
@@ -196,6 +213,7 @@
         loadedSourceId = source.id;
         loadedSourceCacheKey = cacheKey;
         selectedGroup = getStoredLiveTvGroup(source.id) || ALL_GROUPS;
+        favoriteChannelIds = getStoredLiveTvFavoriteChannelIds(source.id);
         searchQuery = "";
         refreshError = "";
         queueMicrotask(() => {
@@ -217,6 +235,7 @@
             loadedSourceId = "";
             loadedSourceCacheKey = "";
             refreshResult = null;
+            favoriteChannelIds = [];
         }
     }
 
@@ -308,6 +327,15 @@
         });
     }
 
+    function toggleFavoriteChannel(channel: IptvChannel) {
+        if (!selectedSource) return;
+        favoriteChannelIds = toggleStoredLiveTvFavoriteChannelId(selectedSource.id, channel.id);
+        trackEvent("live_channel_favorite_toggled", {
+            group: channel.group,
+            is_favorite: favoriteChannelIds.includes(channel.id),
+        });
+    }
+
     onMount(() => {
         guideTimer = setInterval(() => {
             guideNow = new Date();
@@ -375,6 +403,9 @@
                 groups={availableGroups}
                 bind:selectedGroup
                 allGroupsValue={ALL_GROUPS}
+                favoritesGroupValue={FAVORITES_GROUP}
+                favoritesGroupLabel={FAVORITES_GROUP_LABEL}
+                favoritesCount={favoriteChannelsCount}
                 disabled={!currentResult}
                 totalChannels={currentResult?.stats.channelCount ?? 0}
             />
@@ -411,11 +442,13 @@
                     {guideNowLinePercent}
                     {showGuideNowLine}
                     hasGuide={Boolean(currentResult.guide)}
+                    favoriteChannelIds={favoriteChannelIds}
                     {hasMoreGuideChannels}
                     visibleGuideChannelsCount={visibleGuideChannels.length}
                     visibleChannelsCount={visibleChannels.length}
                     {nextGuideChannelPageCount}
                     onPlayChannel={playChannel}
+                    onToggleFavoriteChannel={toggleFavoriteChannel}
                     onShowMoreGuideChannels={showMoreGuideChannels}
                 />
             {/if}

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -8,6 +8,7 @@
         Search,
         Trash2,
         Tv,
+        X,
     } from "@lucide/svelte";
     import LoadingSpinner from "../../components/common/LoadingSpinner.svelte";
     import { trackEvent } from "../../lib/analytics";
@@ -88,11 +89,12 @@
         loadedSourceCacheKey === selectedSourceCacheKey
             ? refreshResult
             : null;
-    $: showFullSourcePanel = !currentResult || showSourceManager;
     $: availableGroups = currentResult?.groups ?? [];
     $: sourceSummary = currentResult
         ? `${currentResult.stats.channelCount} channels / ${currentResult.stats.groupCount} groups`
-        : "";
+        : selectedSource
+            ? "Refresh this source to load channels"
+            : "Add a source to start watching";
     $: visibleChannels = getVisibleChannels(
         currentResult?.channels ?? [],
         selectedGroup,
@@ -203,14 +205,14 @@
 
     function programmeBlockClass(state: GuideProgrammeState) {
         if (state === "current") {
-            return "border-[#a8b99b]/35 bg-[#809278]/78 text-white shadow-[0_10px_24px_rgba(128,146,120,0.16)] hover:bg-[#8ea084]/86";
+            return "border-white/18 bg-white/18 text-white shadow-[0_10px_24px_rgba(0,0,0,0.18)] hover:bg-white/24";
         }
 
         if (state === "future") {
-            return "border-white/[0.08] bg-[#20262b] text-white/84 hover:bg-[#293039]";
+            return "border-white/[0.08] bg-white/[0.08] text-white/84 hover:bg-white/[0.12]";
         }
 
-        return "border-white/[0.06] bg-[#161b20] text-white/46 hover:bg-[#1d2329]";
+        return "border-white/[0.06] bg-white/[0.04] text-white/46 hover:bg-white/[0.07]";
     }
 
     function guideFallbackLabel(hasGuide: boolean) {
@@ -444,397 +446,527 @@
 </script>
 
 <div class="min-h-screen bg-[#090909] text-white">
-    <div class="sticky top-0 z-40 border-b border-white/10 bg-[#090909]/92 backdrop-blur-xl">
-        <div class="flex items-center justify-between gap-6 px-8 py-5">
-            <div class="flex items-center gap-4 min-w-0">
-                <button
-                    class="flex h-12 w-12 items-center justify-center rounded-full bg-white/8 text-white/80 transition-colors hover:bg-white/14"
-                    aria-label="Back"
-                    onclick={() => {
-                        if (!router.back()) router.navigate("home");
-                    }}
-                >
-                    <ChevronLeft size={26} strokeWidth={2} />
-                </button>
-                <div class="flex items-center gap-3 min-w-0">
-                    <Tv size={28} strokeWidth={2} class="text-white/70" />
-                    <div class="min-w-0">
-                        <h1 class="truncate font-poppins text-[28px] font-semibold leading-tight">
-                            {guideTitle}
-                        </h1>
-                        <p class="truncate text-sm text-white/48">
-                            {sourceSummary || "No channels loaded"}
-                        </p>
+    <main class="mx-auto flex min-h-screen w-full max-w-[1760px] flex-col gap-5 px-5 py-5 lg:px-8 lg:py-7">
+        <header class="rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
+            <div class="flex flex-col gap-5 xl:flex-row xl:items-center xl:justify-between">
+                <div class="flex min-w-0 items-center gap-4">
+                    <button
+                        class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/8 text-white/80 transition-colors hover:bg-white/14"
+                        aria-label="Back"
+                        onclick={() => {
+                            if (!router.back()) router.navigate("home");
+                        }}
+                    >
+                        <ChevronLeft size={26} strokeWidth={2} />
+                    </button>
+                    <div class="flex min-w-0 items-center gap-3">
+                        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white/8">
+                            <Tv size={25} strokeWidth={2} class="text-white/74" />
+                        </div>
+                        <div class="min-w-0">
+                            <h1 class="truncate font-poppins text-[28px] font-semibold leading-tight">
+                                Live TV
+                            </h1>
+                            <p class="truncate text-sm text-white/60">
+                                {sourceSummary}
+                            </p>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="flex items-center gap-3">
-                {#if currentResult}
-                    <span class="hidden text-sm text-white/45 md:inline">
-                        Refreshed {formatLoadedAt(currentResult.loadedAt)}
-                    </span>
-                {/if}
-                <button
-                    class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88 disabled:cursor-not-allowed disabled:opacity-45"
-                    disabled={!selectedSource || refreshing}
-                    onclick={refreshSelectedSource}
-                >
-                    {#if refreshing}
-                        <LoadingSpinner size="16px" color="#111111" />
-                    {:else}
-                        <RefreshCw size={17} strokeWidth={2.4} />
+                <div class="flex flex-wrap items-center gap-3">
+                    {#if currentResult}
+                        <span class="text-sm text-white/45">
+                            Refreshed {formatLoadedAt(currentResult.loadedAt)}
+                        </span>
                     {/if}
-                    Refresh
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <div class={showFullSourcePanel
-        ? "grid min-h-[calc(100vh-89px)] grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]"
-        : "grid min-h-[calc(100vh-89px)] grid-cols-1"}>
-        {#if showFullSourcePanel}
-        <aside class="border-b border-white/10 bg-[#111111] p-6 lg:border-b-0 lg:border-r">
-            <section class="flex flex-col gap-4">
-                <div class="flex items-center justify-between gap-3">
-                    <h2 class="font-poppins text-lg font-semibold">
+                    <button
+                        class="flex h-11 items-center gap-2 rounded-full border border-white/10 bg-white/8 px-4 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14 hover:text-white"
+                        onclick={() => (showSourceManager = true)}
+                    >
+                        <Plus size={17} strokeWidth={2.4} />
                         Sources
-                    </h2>
+                    </button>
                     <button
-                        class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14"
-                        aria-label="Add source"
-                        onclick={resetForm}
+                        class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88 disabled:cursor-not-allowed disabled:opacity-45"
+                        disabled={!selectedSource || refreshing}
+                        onclick={refreshSelectedSource}
                     >
-                        <Plus size={18} strokeWidth={2.4} />
+                        {#if refreshing}
+                            <LoadingSpinner size="16px" color="#111111" />
+                        {:else}
+                            <RefreshCw size={17} strokeWidth={2.4} />
+                        {/if}
+                        Refresh
                     </button>
                 </div>
+            </div>
+        </header>
 
-                {#if $iptvSources.length > 0}
-                    <select
-                        class="h-11 w-full rounded-lg border border-white/10 bg-black/35 px-3 text-sm text-white outline-none focus:border-white/35"
-                        bind:value={selectedSourceId}
-                    >
-                        {#each $iptvSources as source}
-                            <option value={source.id}>{source.name}</option>
-                        {/each}
-                    </select>
-                {:else}
-                    <div class="rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/56">
-                        No source configured
-                    </div>
-                {/if}
-
-                {#if selectedSource}
-                    <div class="flex gap-2">
-                        <button
-                            class="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-white/8 text-sm text-white/76 transition-colors hover:bg-white/14"
-                            onclick={() => editSource(selectedSource)}
-                        >
-                            <Pencil size={16} strokeWidth={2.2} />
-                            Edit
-                        </button>
-                        <button
-                            class="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-white/8 text-sm text-white/76 transition-colors hover:bg-white/14"
-                            onclick={() => deleteSource(selectedSource)}
-                        >
-                            <Trash2 size={16} strokeWidth={2.2} />
-                            Remove
-                        </button>
-                    </div>
-                {/if}
-            </section>
-
-            <section class="mt-8 flex flex-col gap-4">
-                <h2 class="font-poppins text-lg font-semibold">
-                    {editingSourceId ? "Edit Source" : "Add Source"}
-                </h2>
-                <label class="flex flex-col gap-2 text-sm text-white/62">
-                    Name
-                    <input
-                        class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                        bind:value={formName}
-                    />
-                </label>
-                <div class="grid grid-cols-2 gap-1 rounded-lg border border-white/10 bg-black/35 p-1">
-                    <button
-                        class={`h-9 rounded-md text-sm font-semibold transition-colors ${formKind === "m3u" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
-                        aria-pressed={formKind === "m3u"}
-                        onclick={() => setFormKind("m3u")}
-                    >
-                        M3U URL
-                    </button>
-                    <button
-                        class={`h-9 rounded-md text-sm font-semibold transition-colors ${formKind === "xtream" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
-                        aria-pressed={formKind === "xtream"}
-                        onclick={() => setFormKind("xtream")}
-                    >
-                        Xtream
-                    </button>
-                </div>
-
-                {#if formKind === "m3u"}
-                    <label class="flex flex-col gap-2 text-sm text-white/62">
-                        M3U URL
-                        <input
-                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                            bind:value={formM3uUrl}
-                            inputmode="url"
-                        />
-                    </label>
-                    <label class="flex flex-col gap-2 text-sm text-white/62">
-                        XMLTV URL
-                        <input
-                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                            bind:value={formEpgUrl}
-                            inputmode="url"
-                        />
-                    </label>
-                {:else}
-                    <label class="flex flex-col gap-2 text-sm text-white/62">
-                        Server URL
-                        <input
-                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                            bind:value={formXtreamServerUrl}
-                            inputmode="url"
-                        />
-                    </label>
-                    <label class="flex flex-col gap-2 text-sm text-white/62">
-                        Username
-                        <input
-                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                            bind:value={formXtreamUsername}
-                            autocomplete="off"
-                        />
-                    </label>
-                    <label class="flex flex-col gap-2 text-sm text-white/62">
-                        Password
-                        <input
-                            class="h-11 rounded-lg border border-white/10 bg-black/35 px-3 text-white outline-none focus:border-white/35"
-                            bind:value={formXtreamCredential}
-                            type="password"
-                            autocomplete="off"
-                        />
-                    </label>
-                {/if}
-
-                {#if formError}
-                    <div class="rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
-                        {formError}
-                    </div>
-                {/if}
-
-                <div class="flex gap-2">
-                    <button
-                        class="h-11 flex-1 rounded-lg bg-white text-sm font-semibold text-black transition-opacity hover:opacity-88"
-                        onclick={saveSource}
-                    >
-                        {editingSourceId ? "Save" : "Add"}
-                    </button>
-                    {#if editingSourceId}
-                        <button
-                            class="h-11 flex-1 rounded-lg bg-white/8 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14"
-                            onclick={resetForm}
-                        >
-                            Cancel
-                        </button>
-                    {/if}
-                </div>
-
-                {#if isDev && IPTV_EXAMPLE}
-                    <button
-                        class="h-10 rounded-lg border border-white/10 text-sm text-white/60 transition-colors hover:bg-white/8 hover:text-white/82"
-                        onclick={fillDispatcharrExample}
-                    >
-                        Use IPTV example
-                    </button>
-                {/if}
-            </section>
-        </aside>
+        {#if refreshError}
+            <div class="rounded-[20px] border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                {refreshError}
+            </div>
         {/if}
 
-        <main class="min-w-0 p-6 lg:p-8">
-            <div class="mb-5 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                <div class="flex min-w-0 flex-1 flex-col gap-3 md:flex-row">
-                    <div class="relative min-w-0 flex-1">
-                        <Search
-                            size={19}
-                            strokeWidth={2.1}
-                            class="absolute left-3 top-1/2 -translate-y-1/2 text-white/42"
-                        />
-                        <input
-                            class="h-12 w-full rounded-lg border border-white/10 bg-white/[0.04] pl-10 pr-3 text-white outline-none focus:border-white/35"
-                            placeholder="Search channels"
-                            bind:value={searchQuery}
-                        />
+        {#if selectedSource}
+            <section class="rounded-[28px] border border-white/10 bg-white/4 p-4 backdrop-blur-md">
+                <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                    <div class="grid min-w-0 flex-1 gap-3 md:grid-cols-[minmax(180px,0.8fr)_minmax(180px,0.8fr)_minmax(220px,1.2fr)]">
+                        <label class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-white/38">
+                            Source
+                            <select
+                                class="h-12 rounded-2xl border border-white/10 bg-black/24 px-4 text-sm normal-case tracking-normal text-white outline-none focus:border-white/35"
+                                bind:value={selectedSourceId}
+                            >
+                                {#each $iptvSources as source}
+                                    <option value={source.id}>{source.name}</option>
+                                {/each}
+                            </select>
+                        </label>
+
+                        <label class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-white/38">
+                            Group
+                            <select
+                                class="h-12 rounded-2xl border border-white/10 bg-black/24 px-4 text-sm normal-case tracking-normal text-white outline-none focus:border-white/35 disabled:opacity-45"
+                                bind:value={selectedGroup}
+                                disabled={!currentResult}
+                            >
+                                <option value={ALL_GROUPS}>All groups</option>
+                                {#each availableGroups as group}
+                                    <option value={group.name}>
+                                        {group.name} ({group.channelCount})
+                                    </option>
+                                {/each}
+                            </select>
+                        </label>
+
+                        <label class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-white/38">
+                            Search
+                            <div class="relative">
+                                <Search
+                                    size={19}
+                                    strokeWidth={2.1}
+                                    class="absolute left-4 top-1/2 -translate-y-1/2 text-white/42"
+                                />
+                                <input
+                                    class="h-12 w-full rounded-2xl border border-white/10 bg-black/24 pl-11 pr-4 text-sm normal-case tracking-normal text-white outline-none focus:border-white/35 disabled:opacity-45"
+                                    placeholder="Search channels"
+                                    bind:value={searchQuery}
+                                    disabled={!currentResult}
+                                />
+                            </div>
+                        </label>
                     </div>
 
-                    <select
-                        class="h-12 min-w-[220px] rounded-lg border border-white/10 bg-white/[0.04] px-3 text-white outline-none focus:border-white/35"
-                        bind:value={selectedGroup}
-                    >
-                        <option value={ALL_GROUPS}>All groups</option>
-                        {#each availableGroups as group}
-                            <option value={group.name}>
-                                {group.name} ({group.channelCount})
-                            </option>
-                        {/each}
-                    </select>
-                </div>
-
-                {#if currentResult}
-                    <div class="flex items-center gap-3 text-sm text-white/45">
-                        <button
-                            class="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white/70 transition-colors hover:bg-white/[0.09] hover:text-white"
-                            onclick={() => (showSourceManager = !showSourceManager)}
-                        >
-                            {showSourceManager ? "Hide Sources" : "Sources"}
-                        </button>
-                        <span>
+                    {#if currentResult}
+                        <span class="text-sm text-white/45">
                             Showing {visibleChannels.length} of {currentResult.stats.channelCount}
                         </span>
-                    </div>
-                {/if}
-            </div>
+                    {/if}
+                </div>
+            </section>
+        {/if}
 
-            {#if refreshError}
-                <div class="mb-5 rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
-                    {refreshError}
+        {#if refreshing}
+            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 backdrop-blur-xl">
+                <div class="flex flex-col items-center gap-4 text-white/64">
+                    <LoadingSpinner size="46px" />
+                    <span>Refreshing channels</span>
                 </div>
-            {/if}
-
-            {#if refreshing}
-                <div class="flex h-[52vh] items-center justify-center">
-                    <div class="flex flex-col items-center gap-4 text-white/64">
-                        <LoadingSpinner size="46px" />
-                        <span>Refreshing channels</span>
+            </section>
+        {:else if !selectedSource}
+            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center backdrop-blur-xl">
+                <div class="flex max-w-xl flex-col items-center gap-4">
+                    <div class="flex h-16 w-16 items-center justify-center rounded-[24px] bg-white/8">
+                        <Tv size={30} strokeWidth={2} class="text-white/70" />
+                    </div>
+                    <div>
+                        <h2 class="font-poppins text-2xl font-semibold">
+                            Add a Live TV Source
+                        </h2>
+                        <p class="mt-2 text-sm leading-6 text-white/60">
+                            Connect an M3U playlist or Xtream account to load channels and guide data.
+                        </p>
+                    </div>
+                    <button
+                        class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                        onclick={() => {
+                            resetForm();
+                            showSourceManager = true;
+                        }}
+                    >
+                        <Plus size={17} strokeWidth={2.4} />
+                        Add Source
+                    </button>
+                </div>
+            </section>
+        {:else if !currentResult}
+            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center backdrop-blur-xl">
+                <div class="flex max-w-xl flex-col items-center gap-4">
+                    <div class="flex h-16 w-16 items-center justify-center rounded-[24px] bg-white/8">
+                        <RefreshCw size={28} strokeWidth={2} class="text-white/70" />
+                    </div>
+                    <div>
+                        <h2 class="font-poppins text-2xl font-semibold">
+                            Load Channels
+                        </h2>
+                        <p class="mt-2 text-sm leading-6 text-white/60">
+                            Refresh {selectedSource.name} to cache channels and guide data for this device.
+                        </p>
+                    </div>
+                    <div class="flex flex-wrap justify-center gap-3">
+                        <button
+                            class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                            onclick={refreshSelectedSource}
+                        >
+                            <RefreshCw size={17} strokeWidth={2.4} />
+                            Refresh Source
+                        </button>
+                        <button
+                            class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
+                            onclick={() => (showSourceManager = true)}
+                        >
+                            Manage Sources
+                        </button>
                     </div>
                 </div>
-            {:else if !selectedSource}
-                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
-                    No source configured
-                </div>
-            {:else if !currentResult}
-                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
-                    No channels loaded
-                </div>
-            {:else if visibleChannels.length === 0}
-                <div class="flex h-[52vh] items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/56">
-                    No channels match
-                </div>
-            {:else}
-                <section class="overflow-hidden rounded-lg border border-white/10 bg-[#0b1116] shadow-2xl shadow-black/24">
-                    <div class="border-b border-white/10 bg-[#111a20] px-4 py-2 text-center">
-                        <div class="text-xs tabular-nums text-white/46">
-                            {formatTime(guideViewport.viewportStart)} – {formatTime(
-                                guideViewport.viewportEnd,
-                            )}
-                        </div>
+            </section>
+        {:else if visibleChannels.length === 0}
+            <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center text-white/60 backdrop-blur-xl">
+                No channels match the current filters.
+            </section>
+        {:else}
+            <section class="overflow-hidden rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
+                <div class="flex flex-col gap-2 border-b border-white/10 bg-white/[0.04] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 class="font-poppins text-lg font-semibold">
+                            {guideTitle}
+                        </h2>
+                        <p class="text-sm text-white/45">
+                            Click a channel or programme to start live playback.
+                        </p>
                     </div>
+                    <div class="text-sm tabular-nums text-white/46">
+                        {formatTime(guideViewport.viewportStart)} to {formatTime(
+                            guideViewport.viewportEnd,
+                        )}
+                    </div>
+                </div>
 
-                    <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
-                        <div class="border-r border-white/10 bg-[#101820]">
-                            <div class="h-10 border-b border-white/10"></div>
-                            {#each guideRows as row (row.channel.id)}
-                                <button
-                                    class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
-                                    title={row.channel.name}
-                                    aria-label={`Play ${row.channel.name}`}
-                                    onclick={() => playChannel(row.channel)}
-                                >
-                                    <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-md bg-black/42 ring-1 ring-white/[0.06]">
-                                        {#if row.channel.logo}
-                                            <img
-                                                src={row.channel.logo}
-                                                alt=""
-                                                class="max-h-full max-w-full object-contain"
-                                                loading="lazy"
-                                                onerror={(event) => {
-                                                    (event.currentTarget as HTMLImageElement).style.display = "none";
-                                                }}
-                                            />
-                                        {:else}
-                                            <Tv size={22} strokeWidth={2} class="text-white/34" />
-                                        {/if}
-                                    </div>
-                                    {#if row.channel.number}
-                                        <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
-                                            {row.channel.number}
-                                        </span>
+                <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
+                    <div class="border-r border-white/10 bg-black/18">
+                        <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
+                        {#each guideRows as row (row.channel.id)}
+                            <button
+                                class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
+                                title={row.channel.name}
+                                aria-label={`Play ${row.channel.name}`}
+                                onclick={() => playChannel(row.channel)}
+                            >
+                                <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-black/32 ring-1 ring-white/[0.06]">
+                                    {#if row.channel.logo}
+                                        <img
+                                            src={row.channel.logo}
+                                            alt=""
+                                            class="max-h-full max-w-full object-contain"
+                                            loading="lazy"
+                                            onerror={(event) => {
+                                                (event.currentTarget as HTMLImageElement).style.display = "none";
+                                            }}
+                                        />
                                     {:else}
-                                        <span class="max-w-full truncate text-[10px] leading-none text-white/48">
-                                            {row.channel.name}
-                                        </span>
+                                        <Tv size={22} strokeWidth={2} class="text-white/34" />
                                     {/if}
-                                </button>
-                            {/each}
-                        </div>
-
-                        <div class="no-scrollbar min-w-0 overflow-x-auto bg-[#0b1116]">
-                            <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
-                                <div class="relative h-10 border-b border-white/10 bg-[#101820]">
-                                    {#each guideTimeTicks as tick (tick.value.getTime())}
-                                        <div
-                                            class={timeTickClass(tick.leftPercent)}
-                                            style={`left: ${tick.leftPercent}%;`}
-                                        >
-                                            {tick.label}
-                                        </div>
-                                    {/each}
                                 </div>
+                                {#if row.channel.number}
+                                    <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                        {row.channel.number}
+                                    </span>
+                                {:else}
+                                    <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+                                        {row.channel.name}
+                                    </span>
+                                {/if}
+                            </button>
+                        {/each}
+                    </div>
 
-                                <div class="relative">
-                                    {#if showGuideNowLine}
-                                        <div
-                                            class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
-                                            style={`left: ${guideNowLinePercent}%;`}
-                                        >
-                                            <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-[#a8b99b] shadow-[0_0_16px_rgba(168,185,155,0.75)]"></div>
-                                            <div class="h-full w-px bg-[#a8b99b]/90 shadow-[0_0_12px_rgba(168,185,155,0.45)]"></div>
-                                        </div>
-                                    {/if}
+                    <div class="no-scrollbar min-w-0 overflow-x-auto bg-black/12">
+                        <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
+                            <div class="relative h-10 border-b border-white/10 bg-white/[0.03]">
+                                {#each guideTimeTicks as tick (tick.value.getTime())}
+                                    <div
+                                        class={timeTickClass(tick.leftPercent)}
+                                        style={`left: ${tick.leftPercent}%;`}
+                                    >
+                                        {tick.label}
+                                    </div>
+                                {/each}
+                            </div>
 
-                                    {#each guideRows as row (row.channel.id)}
-                                        <div class="relative h-[86px] border-b border-white/[0.06]">
-                                            {#if row.programmes.length > 0}
-                                                {#each row.programmes as programme (programme.id)}
-                                                    <button
-                                                        class={`absolute inset-y-2 overflow-hidden rounded-md border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
-                                                        style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
-                                                        title={`${programme.timeRange} ${programme.title}`}
-                                                        onclick={() => playChannel(row.channel)}
-                                                    >
-                                                        <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
-                                                            {programme.title}
-                                                        </span>
-                                                        <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
-                                                            {programme.timeRange}
-                                                        </span>
-                                                    </button>
-                                                {/each}
-                                            {:else}
+                            <div class="relative">
+                                {#if showGuideNowLine}
+                                    <div
+                                        class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
+                                        style={`left: ${guideNowLinePercent}%;`}
+                                    >
+                                        <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-white shadow-[0_0_16px_rgba(255,255,255,0.55)]"></div>
+                                        <div class="h-full w-px bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.28)]"></div>
+                                    </div>
+                                {/if}
+
+                                {#each guideRows as row (row.channel.id)}
+                                    <div class="relative h-[86px] border-b border-white/[0.06]">
+                                        {#if row.programmes.length > 0}
+                                            {#each row.programmes as programme (programme.id)}
                                                 <button
-                                                    class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-md border border-white/[0.08] bg-[#20262b] px-3 text-left text-white/78 transition-colors hover:bg-[#293039]"
+                                                    class={`absolute inset-y-2 overflow-hidden rounded-xl border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
+                                                    style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
+                                                    title={`${programme.timeRange} ${programme.title}`}
                                                     onclick={() => playChannel(row.channel)}
                                                 >
-                                                    <span class="font-poppins text-[13px] font-semibold">
-                                                        {guideFallbackLabel(Boolean(currentResult.guide))}
+                                                    <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
+                                                        {programme.title}
                                                     </span>
-                                                    <span class="min-w-0 truncate text-[11px] text-white/42">
-                                                        {row.channel.name}
+                                                    <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
+                                                        {programme.timeRange}
                                                     </span>
                                                 </button>
-                                            {/if}
-                                        </div>
-                                    {/each}
-                                </div>
+                                            {/each}
+                                        {:else}
+                                            <button
+                                                class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.08] px-3 text-left text-white/78 transition-colors hover:bg-white/[0.12]"
+                                                onclick={() => playChannel(row.channel)}
+                                            >
+                                                <span class="font-poppins text-[13px] font-semibold">
+                                                    {guideFallbackLabel(Boolean(currentResult.guide))}
+                                                </span>
+                                                <span class="min-w-0 truncate text-[11px] text-white/42">
+                                                    {row.channel.name}
+                                                </span>
+                                            </button>
+                                        {/if}
+                                    </div>
+                                {/each}
                             </div>
                         </div>
                     </div>
-                </section>
-            {/if}
-        </main>
-    </div>
+                </div>
+            </section>
+        {/if}
+    </main>
+
+    {#if showSourceManager}
+        <div
+            class="fixed inset-0 z-[220] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+            onclick={(event) => {
+                if (event.currentTarget === event.target) showSourceManager = false;
+            }}
+            onkeydown={(event) => {
+                if (event.key === "Escape") showSourceManager = false;
+            }}
+            role="button"
+            tabindex="0"
+        >
+            <section
+                class="max-h-[92vh] w-full max-w-[1040px] overflow-y-auto rounded-[28px] border border-white/10 bg-[#2b2b2b]/95 p-5 shadow-[0_32px_100px_rgba(0,0,0,0.48)] backdrop-blur-xl"
+                role="dialog"
+                aria-modal="true"
+                tabindex="-1"
+            >
+                <div class="mb-5 flex items-start justify-between gap-4">
+                    <div>
+                        <h2 class="font-poppins text-2xl font-semibold">
+                            Live TV Sources
+                        </h2>
+                        <p class="mt-1 text-sm text-white/60">
+                            Add M3U playlists, Xtream accounts, and guide data.
+                        </p>
+                    </div>
+                    <button
+                        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/8 text-white/72 transition-colors hover:bg-white/14 hover:text-white"
+                        aria-label="Close source manager"
+                        onclick={() => (showSourceManager = false)}
+                    >
+                        <X size={20} strokeWidth={2.2} />
+                    </button>
+                </div>
+
+                <div class="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(360px,1.1fr)]">
+                    <section class="rounded-[24px] bg-white/4 p-4">
+                        <div class="mb-4 flex items-center justify-between gap-3">
+                            <h3 class="font-poppins text-lg font-semibold">
+                                Sources
+                            </h3>
+                            <button
+                                class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
+                                aria-label="Add source"
+                                onclick={resetForm}
+                            >
+                                <Plus size={18} strokeWidth={2.4} />
+                            </button>
+                        </div>
+
+                        {#if $iptvSources.length > 0}
+                            <div class="flex max-h-[420px] flex-col gap-2 overflow-y-auto pr-1">
+                                {#each $iptvSources as source}
+                                    <div
+                                        class={`flex flex-col gap-3 rounded-2xl border p-3 transition-colors sm:flex-row sm:items-center sm:justify-between ${
+                                            selectedSourceId === source.id
+                                                ? "border-white/18 bg-white/[0.10]"
+                                                : "border-white/8 bg-white/[0.04]"
+                                        }`}
+                                    >
+                                        <button
+                                            class="min-w-0 flex-1 text-left"
+                                            onclick={() => (selectedSourceId = source.id)}
+                                        >
+                                            <p class="truncate font-medium text-white">
+                                                {source.name}
+                                            </p>
+                                            <p class="mt-1 text-xs uppercase tracking-[0.12em] text-white/42">
+                                                {source.kind === "xtream" ? "Xtream" : "M3U"}
+                                            </p>
+                                        </button>
+                                        <div class="flex shrink-0 gap-2">
+                                            <button
+                                                class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
+                                                aria-label={`Edit ${source.name}`}
+                                                onclick={() => editSource(source)}
+                                            >
+                                                <Pencil size={16} strokeWidth={2.2} />
+                                            </button>
+                                            <button
+                                                class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-red-500/20 hover:text-red-100"
+                                                aria-label={`Remove ${source.name}`}
+                                                onclick={() => deleteSource(source)}
+                                            >
+                                                <Trash2 size={16} strokeWidth={2.2} />
+                                            </button>
+                                        </div>
+                                    </div>
+                                {/each}
+                            </div>
+                        {:else}
+                            <div class="rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-5 text-sm text-white/56">
+                                No source configured yet.
+                            </div>
+                        {/if}
+                    </section>
+
+                    <section class="rounded-[24px] bg-white/4 p-4">
+                        <h3 class="font-poppins text-lg font-semibold">
+                            {editingSourceId ? "Edit Source" : "Add Source"}
+                        </h3>
+                        <div class="mt-4 flex flex-col gap-4">
+                            <label class="flex flex-col gap-2 text-sm text-white/62">
+                                Name
+                                <input
+                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                    bind:value={formName}
+                                />
+                            </label>
+
+                            <div class="grid grid-cols-2 gap-1 rounded-full border border-white/10 bg-black/24 p-1">
+                                <button
+                                    class={`h-9 rounded-full text-sm font-semibold transition-colors ${formKind === "m3u" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
+                                    aria-pressed={formKind === "m3u"}
+                                    onclick={() => setFormKind("m3u")}
+                                >
+                                    M3U URL
+                                </button>
+                                <button
+                                    class={`h-9 rounded-full text-sm font-semibold transition-colors ${formKind === "xtream" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
+                                    aria-pressed={formKind === "xtream"}
+                                    onclick={() => setFormKind("xtream")}
+                                >
+                                    Xtream
+                                </button>
+                            </div>
+
+                            {#if formKind === "m3u"}
+                                <label class="flex flex-col gap-2 text-sm text-white/62">
+                                    M3U URL
+                                    <input
+                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                        bind:value={formM3uUrl}
+                                        inputmode="url"
+                                    />
+                                </label>
+                                <label class="flex flex-col gap-2 text-sm text-white/62">
+                                    XMLTV URL
+                                    <input
+                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                        bind:value={formEpgUrl}
+                                        inputmode="url"
+                                    />
+                                </label>
+                            {:else}
+                                <label class="flex flex-col gap-2 text-sm text-white/62">
+                                    Server URL
+                                    <input
+                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                        bind:value={formXtreamServerUrl}
+                                        inputmode="url"
+                                    />
+                                </label>
+                                <label class="flex flex-col gap-2 text-sm text-white/62">
+                                    Username
+                                    <input
+                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                        bind:value={formXtreamUsername}
+                                        autocomplete="off"
+                                    />
+                                </label>
+                                <label class="flex flex-col gap-2 text-sm text-white/62">
+                                    Password
+                                    <input
+                                        class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                        bind:value={formXtreamCredential}
+                                        type="password"
+                                        autocomplete="off"
+                                    />
+                                </label>
+                            {/if}
+
+                            {#if formError}
+                                <div class="rounded-2xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                                    {formError}
+                                </div>
+                            {/if}
+
+                            <div class="flex flex-wrap gap-2">
+                                <button
+                                    class="h-11 flex-1 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                                    onclick={saveSource}
+                                >
+                                    {editingSourceId ? "Save Source" : "Add Source"}
+                                </button>
+                                {#if editingSourceId}
+                                    <button
+                                        class="h-11 flex-1 rounded-full bg-white/8 px-5 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14"
+                                        onclick={resetForm}
+                                    >
+                                        Cancel
+                                    </button>
+                                {/if}
+                            </div>
+
+                            {#if isDev && IPTV_EXAMPLE}
+                                <button
+                                    class="h-10 rounded-full border border-white/10 text-sm text-white/60 transition-colors hover:bg-white/8 hover:text-white/82"
+                                    onclick={fillDispatcharrExample}
+                                >
+                                    Use IPTV example
+                                </button>
+                            {/if}
+                        </div>
+                    </section>
+                </div>
+            </section>
+        </div>
+    {/if}
 </div>
 
 <style>

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -409,11 +409,16 @@
     }
 
     function formatLoadedAt(value: string) {
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return "Unknown";
+        }
+
         return new Intl.DateTimeFormat(undefined, {
             hour: "numeric",
             minute: "2-digit",
             second: "2-digit",
-        }).format(new Date(value));
+        }).format(parsed);
     }
 
     onMount(() => {

--- a/packages/app/src/pages/live/LiveTV.svelte
+++ b/packages/app/src/pages/live/LiveTV.svelte
@@ -43,9 +43,12 @@
         getLiveSourceSummary,
         getStoredLiveTvFavoriteChannelIds,
         getStoredLiveTvGroup,
+        getStoredLiveTvLastChannelId,
         getStoredLiveTvSelection,
         getVisibleChannels,
+        normalizeLiveTvGroup,
         setStoredLiveTvGroup,
+        setStoredLiveTvLastChannelId,
         setStoredLiveTvSourceId,
         shouldAutoRefreshLiveTvSource,
         toggleStoredLiveTvFavoriteChannelId,
@@ -85,6 +88,7 @@
             refreshResult: cachedResult,
             selectedGroup: source ? getStoredLiveTvGroup(source.id) || ALL_GROUPS : ALL_GROUPS,
             favoriteChannelIds: source ? getStoredLiveTvFavoriteChannelIds(source.id) : [],
+            lastChannelId: source ? getStoredLiveTvLastChannelId(source.id) : "",
         };
     }
 
@@ -98,6 +102,7 @@
     let refreshError = "";
     let selectedGroup = initialLiveTvState.selectedGroup;
     let favoriteChannelIds = initialLiveTvState.favoriteChannelIds;
+    let lastChannelId = initialLiveTvState.lastChannelId;
     let searchQuery = "";
     let guideNow = new Date();
     let guideTimer: ReturnType<typeof setInterval> | null = null;
@@ -143,20 +148,6 @@
     }
     $: visibleGuideChannels = visibleChannels.slice(0, guideChannelLimit);
     $: hasMoreGuideChannels = visibleGuideChannels.length < visibleChannels.length;
-    $: remainingGuideChannels = Math.max(
-        visibleChannels.length - visibleGuideChannels.length,
-        0,
-    );
-    $: nextGuideChannelPageCount = Math.min(
-        GUIDE_CHANNEL_PAGE_SIZE,
-        remainingGuideChannels,
-    );
-    $: guideTitle =
-        selectedGroup === ALL_GROUPS
-            ? "Live TV"
-            : selectedGroup === FAVORITES_GROUP
-              ? FAVORITES_GROUP_LABEL
-              : selectedGroup;
     $: guideViewport = getGuideViewport(guideNow);
     $: guideRows = currentResult
         ? buildGuideRows(visibleGuideChannels, currentResult.guide, guideViewport)
@@ -190,9 +181,7 @@
     }
     $: if (
         currentResult &&
-        selectedGroup !== ALL_GROUPS &&
-        selectedGroup !== FAVORITES_GROUP &&
-        !availableGroups.some((group) => group.name === selectedGroup)
+        normalizeLiveTvGroup(selectedGroup, availableGroups) !== selectedGroup
     ) {
         selectedGroup = ALL_GROUPS;
     }
@@ -214,6 +203,7 @@
         loadedSourceCacheKey = cacheKey;
         selectedGroup = getStoredLiveTvGroup(source.id) || ALL_GROUPS;
         favoriteChannelIds = getStoredLiveTvFavoriteChannelIds(source.id);
+        lastChannelId = getStoredLiveTvLastChannelId(source.id);
         searchQuery = "";
         refreshError = "";
         queueMicrotask(() => {
@@ -304,6 +294,10 @@
 
     function playChannel(channel: IptvChannel) {
         const nowNext = getChannelGuide(channel);
+        lastChannelId = channel.id;
+        if (selectedSource) {
+            setStoredLiveTvLastChannelId(selectedSource.id, channel.id);
+        }
         trackEvent("live_channel_opened", {
             group: channel.group,
             has_logo: Boolean(channel.logo),
@@ -435,18 +429,14 @@
                 <LiveEmptyState state="no-results" />
             {:else}
                 <LiveGuide
-                    {guideTitle}
-                    {guideViewport}
                     {guideRows}
                     {guideTimeTicks}
                     {guideNowLinePercent}
                     {showGuideNowLine}
                     hasGuide={Boolean(currentResult.guide)}
                     favoriteChannelIds={favoriteChannelIds}
+                    activeChannelId={lastChannelId}
                     {hasMoreGuideChannels}
-                    visibleGuideChannelsCount={visibleGuideChannels.length}
-                    visibleChannelsCount={visibleChannels.length}
-                    {nextGuideChannelPageCount}
                     onPlayChannel={playChannel}
                     onToggleFavoriteChannel={toggleFavoriteChannel}
                     onShowMoreGuideChannels={showMoreGuideChannels}

--- a/packages/app/src/pages/live/components/LiveChannelContextMenu.svelte
+++ b/packages/app/src/pages/live/components/LiveChannelContextMenu.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { fade } from "svelte/transition";
+    import { Star } from "@lucide/svelte";
+
+    export let x = 0;
+    export let y = 0;
+    export let isFavorite = false;
+    export let onClose: () => void = () => {};
+    export let onToggleFavorite: () => void = () => {};
+
+    const portal = (node: HTMLElement) => {
+        if (typeof document === "undefined") {
+            return { destroy() {} };
+        }
+        document.body.appendChild(node);
+        return {
+            destroy() {
+                if (node.parentNode) {
+                    node.parentNode.removeChild(node);
+                }
+            },
+        };
+    };
+
+    function close() {
+        onClose();
+    }
+
+    function toggleFavorite() {
+        onToggleFavorite();
+        close();
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+        const target = event.target as HTMLElement;
+        if (!target.closest(".live-channel-context-menu")) {
+            close();
+        }
+    }
+
+    onMount(() => {
+        document.addEventListener("pointerdown", handlePointerDown);
+        return () => {
+            document.removeEventListener("pointerdown", handlePointerDown);
+        };
+    });
+</script>
+
+<svelte:window onkeydown={(event) => {
+    if (event.key === "Escape") close();
+}} />
+
+<div
+    use:portal
+    class="live-channel-context-menu fixed z-[300] flex min-w-[190px] flex-col rounded-xl bg-[#181818] py-2 shadow-[0_18px_48px_rgba(0,0,0,0.36)]"
+    style="top: {y}px; left: {x}px;"
+    transition:fade={{ duration: 100 }}
+    oncontextmenu={(event) => event.preventDefault()}
+    role="menu"
+    tabindex="-1"
+>
+    <button
+        class="flex cursor-pointer flex-row items-center gap-2 px-4 py-2 text-left font-poppins text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+        onclick={toggleFavorite}
+        role="menuitem"
+    >
+        <Star size={16} strokeWidth={2} />
+        {isFavorite ? "Remove from Favorites" : "Add to Favorites"}
+    </button>
+</div>

--- a/packages/app/src/pages/live/components/LiveChannelContextMenu.svelte
+++ b/packages/app/src/pages/live/components/LiveChannelContextMenu.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
-    import { onMount } from "svelte";
+    import { onMount, tick } from "svelte";
     import { fade } from "svelte/transition";
     import { Star } from "@lucide/svelte";
 
     export let x = 0;
     export let y = 0;
     export let isFavorite = false;
+    export let ariaLabel = "Channel actions";
+    export let returnFocusTo: HTMLElement | null = null;
     export let onClose: () => void = () => {};
     export let onToggleFavorite: () => void = () => {};
+
+    const VIEWPORT_PADDING = 8;
+    const hiddenMenuStyle = "position: fixed; top: 0; left: 0; visibility: hidden;";
+    const capturedScrollOptions = { capture: true } as const;
+    const capturedPassiveOptions = { capture: true, passive: true } as const;
+
+    let menuEl: HTMLDivElement | null = null;
+    let favoriteButtonEl: HTMLButtonElement | null = null;
+    let menuStyle = hiddenMenuStyle;
+    let menuReady = false;
+    let positionKey = "";
 
     const portal = (node: HTMLElement) => {
         if (typeof document === "undefined") {
@@ -23,7 +36,53 @@
         };
     };
 
+    function getEffectiveZoom() {
+        if (typeof document === "undefined") return 1;
+        const zoom = Number.parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue("--raffi-effective-zoom") || "1",
+        );
+        return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+    }
+
+    function clamp(value: number, min: number, max: number) {
+        if (max < min) return min;
+        return Math.max(min, Math.min(value, max));
+    }
+
+    async function updatePosition() {
+        if (!menuEl || typeof window === "undefined") return;
+
+        menuReady = false;
+        menuStyle = hiddenMenuStyle;
+        await tick();
+
+        if (!menuEl || typeof window === "undefined") return;
+
+        const zoom = getEffectiveZoom();
+        const naturalMenuWidth = menuEl.offsetWidth;
+        const naturalMenuHeight = menuEl.offsetHeight;
+        const visualMenuWidth = naturalMenuWidth * zoom;
+        const visualMenuHeight = naturalMenuHeight * zoom;
+        const maxLeft = window.innerWidth - visualMenuWidth - VIEWPORT_PADDING;
+        const maxTop = window.innerHeight - visualMenuHeight - VIEWPORT_PADDING;
+        const left = clamp(x, VIEWPORT_PADDING, maxLeft);
+        const top = clamp(y, VIEWPORT_PADDING, maxTop);
+
+        menuStyle = `position: fixed; top: ${top}px; left: ${left}px; transform: scale(${zoom}); transform-origin: top left;`;
+        menuReady = true;
+    }
+
+    function restoreTriggerFocus() {
+        if (!returnFocusTo?.isConnected) return;
+        try {
+            returnFocusTo.focus({ preventScroll: true });
+        } catch {
+            returnFocusTo.focus();
+        }
+    }
+
     function close() {
+        restoreTriggerFocus();
         onClose();
     }
 
@@ -39,10 +98,38 @@
         }
     }
 
+    function handleResize() {
+        void updatePosition();
+    }
+
+    function handleViewportDismiss() {
+        close();
+    }
+
+    $: if (menuEl) {
+        const nextPositionKey = `${x}:${y}:${isFavorite}`;
+        if (positionKey !== nextPositionKey) {
+            positionKey = nextPositionKey;
+            void updatePosition();
+        }
+    }
+
     onMount(() => {
         document.addEventListener("pointerdown", handlePointerDown);
+        window.addEventListener("resize", handleResize);
+        window.addEventListener("scroll", handleViewportDismiss, capturedScrollOptions);
+        window.addEventListener("wheel", handleViewportDismiss, capturedPassiveOptions);
+
+        void (async () => {
+            await updatePosition();
+            favoriteButtonEl?.focus({ preventScroll: true });
+        })();
+
         return () => {
             document.removeEventListener("pointerdown", handlePointerDown);
+            window.removeEventListener("resize", handleResize);
+            window.removeEventListener("scroll", handleViewportDismiss, capturedScrollOptions);
+            window.removeEventListener("wheel", handleViewportDismiss, capturedPassiveOptions);
         };
     });
 </script>
@@ -53,15 +140,19 @@
 
 <div
     use:portal
-    class="live-channel-context-menu fixed z-[300] flex min-w-[190px] flex-col rounded-xl bg-[#181818] py-2 shadow-[0_18px_48px_rgba(0,0,0,0.36)]"
-    style="top: {y}px; left: {x}px;"
+    bind:this={menuEl}
+    class={`live-channel-context-menu fixed z-[300] flex min-w-[190px] flex-col rounded-xl bg-[#181818] py-2 shadow-[0_18px_48px_rgba(0,0,0,0.36)] ${menuReady ? "opacity-100" : "opacity-0"}`}
+    style={menuStyle}
     transition:fade={{ duration: 100 }}
     oncontextmenu={(event) => event.preventDefault()}
     role="menu"
+    aria-label={ariaLabel}
     tabindex="-1"
 >
     <button
-        class="flex cursor-pointer flex-row items-center gap-2 px-4 py-2 text-left font-poppins text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+        bind:this={favoriteButtonEl}
+        type="button"
+        class="flex cursor-pointer flex-row items-center gap-2 px-4 py-2 text-left font-poppins text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-white/70"
         onclick={toggleFavorite}
         role="menuitem"
     >

--- a/packages/app/src/pages/live/components/LiveChannelLogo.svelte
+++ b/packages/app/src/pages/live/components/LiveChannelLogo.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import { Tv } from "@lucide/svelte";
+    import type { IptvChannel } from "../../../lib/iptv/types";
+
+    export let channel: IptvChannel;
+    export let shouldShowLogo: (channel: IptvChannel) => boolean = () => false;
+    export let markLogoFailed: (logo: string | undefined) => void = () => {};
+</script>
+
+<div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-black/32 ring-1 ring-white/[0.06]">
+    {#if shouldShowLogo(channel)}
+        <img
+            src={channel.logo}
+            alt=""
+            class="max-h-full max-w-full object-contain"
+            loading="lazy"
+            onerror={() => markLogoFailed(channel.logo)}
+        />
+    {:else}
+        <Tv size={22} strokeWidth={2} class="text-white/34" />
+    {/if}
+</div>

--- a/packages/app/src/pages/live/components/LiveEmptyState.svelte
+++ b/packages/app/src/pages/live/components/LiveEmptyState.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+    import { Plus, RefreshCw, Tv } from "@lucide/svelte";
+    import LoadingSpinner from "../../../components/common/LoadingSpinner.svelte";
+
+    export let state:
+        | "refreshing"
+        | "no-source"
+        | "needs-refresh"
+        | "no-results" = "no-results";
+    export let sourceName = "";
+    export let onAddSource: () => void = () => {};
+    export let onRefreshSource: () => void = () => {};
+    export let onManageSources: () => void = () => {};
+</script>
+
+{#if state === "refreshing"}
+    <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 backdrop-blur-xl">
+        <div class="flex flex-col items-center gap-4 text-white/64">
+            <LoadingSpinner size="46px" />
+            <span>Refreshing channels</span>
+        </div>
+    </section>
+{:else if state === "no-source"}
+    <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center backdrop-blur-xl">
+        <div class="flex max-w-xl flex-col items-center gap-4">
+            <div class="flex h-16 w-16 items-center justify-center rounded-[24px] bg-white/8">
+                <Tv size={30} strokeWidth={2} class="text-white/70" />
+            </div>
+            <div>
+                <h2 class="font-poppins text-2xl font-semibold">
+                    Add a Live TV Source
+                </h2>
+                <p class="mt-2 text-sm leading-6 text-white/60">
+                    Connect an M3U playlist or Xtream account to load channels and guide data.
+                </p>
+            </div>
+            <button
+                class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                onclick={onAddSource}
+            >
+                <Plus size={17} strokeWidth={2.4} />
+                Add Source
+            </button>
+        </div>
+    </section>
+{:else if state === "needs-refresh"}
+    <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center backdrop-blur-xl">
+        <div class="flex max-w-xl flex-col items-center gap-4">
+            <div class="flex h-16 w-16 items-center justify-center rounded-[24px] bg-white/8">
+                <RefreshCw size={28} strokeWidth={2} class="text-white/70" />
+            </div>
+            <div>
+                <h2 class="font-poppins text-2xl font-semibold">
+                    Load Channels
+                </h2>
+                <p class="mt-2 text-sm leading-6 text-white/60">
+                    Refresh {sourceName} to cache channels and guide data for this device.
+                </p>
+            </div>
+            <div class="flex flex-wrap justify-center gap-3">
+                <button
+                    class="flex h-11 items-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                    onclick={onRefreshSource}
+                >
+                    <RefreshCw size={17} strokeWidth={2.4} />
+                    Refresh Source
+                </button>
+                <button
+                    class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
+                    onclick={onManageSources}
+                >
+                    Manage Sources
+                </button>
+            </div>
+        </div>
+    </section>
+{:else}
+    <section class="flex min-h-[52vh] items-center justify-center rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 p-6 text-center text-white/60 backdrop-blur-xl">
+        No channels match the current filters.
+    </section>
+{/if}

--- a/packages/app/src/pages/live/components/LiveGroupFilter.svelte
+++ b/packages/app/src/pages/live/components/LiveGroupFilter.svelte
@@ -6,6 +6,9 @@
     export let groups: IptvGroup[] = [];
     export let selectedGroup = "__all__";
     export let allGroupsValue = "__all__";
+    export let favoritesGroupValue = "__favorites__";
+    export let favoritesGroupLabel = "Favorites";
+    export let favoritesCount = 0;
     export let disabled = false;
     export let totalChannels = 0;
 
@@ -15,11 +18,17 @@
     $: selectedGroupRow =
         groups.find((group) => group.name === selectedGroup) ?? null;
     $: selectedLabel =
-        selectedGroup === allGroupsValue ? "All groups" : selectedGroup;
+        selectedGroup === allGroupsValue
+            ? "All groups"
+            : selectedGroup === favoritesGroupValue
+              ? favoritesGroupLabel
+              : selectedGroup;
     $: selectedCount =
         selectedGroup === allGroupsValue
             ? totalChannels
-            : selectedGroupRow?.channelCount ?? 0;
+            : selectedGroup === favoritesGroupValue
+              ? favoritesCount
+              : selectedGroupRow?.channelCount ?? 0;
 
     function toggleMenu(event: MouseEvent) {
         event.stopPropagation();
@@ -107,6 +116,33 @@
                         </span>
                     </span>
                     {#if selectedGroup === allGroupsValue}
+                        <Check size={18} strokeWidth={2.4} class="shrink-0" />
+                    {/if}
+                </button>
+
+                <button
+                    type="button"
+                    class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
+                        selectedGroup === favoritesGroupValue
+                            ? "bg-white/[0.12] text-white"
+                            : "text-white/76 hover:bg-white/[0.07] hover:text-white"
+                    }`}
+                    role="option"
+                    aria-selected={selectedGroup === favoritesGroupValue}
+                    onclick={() => selectGroup(favoritesGroupValue)}
+                >
+                    <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.08] text-sm text-amber-200">
+                        ★
+                    </span>
+                    <span class="min-w-0 flex-1">
+                        <span class="block truncate text-sm font-semibold">
+                            {favoritesGroupLabel}
+                        </span>
+                        <span class="mt-0.5 block text-xs text-white/42">
+                            {favoritesCount} channels
+                        </span>
+                    </span>
+                    {#if selectedGroup === favoritesGroupValue}
                         <Check size={18} strokeWidth={2.4} class="shrink-0" />
                     {/if}
                 </button>

--- a/packages/app/src/pages/live/components/LiveGroupFilter.svelte
+++ b/packages/app/src/pages/live/components/LiveGroupFilter.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { Check, ChevronDown, ListFilter } from "@lucide/svelte";
+    import type { IptvGroup } from "../../../lib/iptv/types";
+
+    export let groups: IptvGroup[] = [];
+    export let selectedGroup = "__all__";
+    export let allGroupsValue = "__all__";
+    export let disabled = false;
+    export let totalChannels = 0;
+
+    let open = false;
+    let root: HTMLDivElement;
+
+    $: selectedGroupRow =
+        groups.find((group) => group.name === selectedGroup) ?? null;
+    $: selectedLabel =
+        selectedGroup === allGroupsValue ? "All groups" : selectedGroup;
+    $: selectedCount =
+        selectedGroup === allGroupsValue
+            ? totalChannels
+            : selectedGroupRow?.channelCount ?? 0;
+
+    function toggleMenu(event: MouseEvent) {
+        event.stopPropagation();
+        if (disabled) return;
+        open = !open;
+    }
+
+    function closeMenu() {
+        open = false;
+    }
+
+    function selectGroup(groupName: string) {
+        selectedGroup = groupName;
+        closeMenu();
+    }
+
+    function handleDocumentPointerDown(event: PointerEvent) {
+        if (root && !root.contains(event.target as Node)) {
+            closeMenu();
+        }
+    }
+
+    onMount(() => {
+        document.addEventListener("pointerdown", handleDocumentPointerDown);
+        return () => {
+            document.removeEventListener("pointerdown", handleDocumentPointerDown);
+        };
+    });
+</script>
+
+<svelte:window onkeydown={(event) => {
+    if (event.key === "Escape") closeMenu();
+}} />
+
+<div class="relative" bind:this={root}>
+    <button
+        type="button"
+        class="flex h-[80px] w-[202px] items-center gap-3 rounded-[24px] bg-[#2C2C2C]/80 px-4 text-left backdrop-blur-md transition-colors hover:bg-[#2C2C2C]/60 disabled:cursor-not-allowed disabled:opacity-45"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        {disabled}
+        onclick={toggleMenu}
+    >
+        <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-white/8 text-white/72">
+            <ListFilter size={22} strokeWidth={2.2} />
+        </span>
+        <span class="min-w-0 flex-1">
+            <span class="block truncate font-poppins text-base font-semibold text-white">
+                {selectedLabel}
+            </span>
+            <span class="mt-0.5 block truncate text-xs text-white/48">
+                {selectedCount} channels
+            </span>
+        </span>
+        <ChevronDown
+            size={19}
+            strokeWidth={2.2}
+            class={`shrink-0 text-white/54 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+    </button>
+
+    {#if open}
+        <div
+            class="absolute left-0 top-[calc(100%+10px)] z-[260] w-[300px] overflow-hidden rounded-[24px] border border-white/10 bg-[#181818]/96 p-2 shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur-xl"
+            role="listbox"
+        >
+            <div class="max-h-[360px] overflow-y-auto pr-1">
+                <button
+                    type="button"
+                    class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
+                        selectedGroup === allGroupsValue
+                            ? "bg-white/[0.12] text-white"
+                            : "text-white/76 hover:bg-white/[0.07] hover:text-white"
+                    }`}
+                    role="option"
+                    aria-selected={selectedGroup === allGroupsValue}
+                    onclick={() => selectGroup(allGroupsValue)}
+                >
+                    <span class="min-w-0 flex-1">
+                        <span class="block truncate text-sm font-semibold">
+                            All groups
+                        </span>
+                        <span class="mt-0.5 block text-xs text-white/42">
+                            {totalChannels} channels
+                        </span>
+                    </span>
+                    {#if selectedGroup === allGroupsValue}
+                        <Check size={18} strokeWidth={2.4} class="shrink-0" />
+                    {/if}
+                </button>
+
+                {#each groups as group}
+                    <button
+                        type="button"
+                        class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
+                            selectedGroup === group.name
+                                ? "bg-white/[0.12] text-white"
+                                : "text-white/76 hover:bg-white/[0.07] hover:text-white"
+                        }`}
+                        role="option"
+                        aria-selected={selectedGroup === group.name}
+                        onclick={() => selectGroup(group.name)}
+                    >
+                        <span class="min-w-0 flex-1">
+                            <span class="block truncate text-sm font-semibold">
+                                {group.name}
+                            </span>
+                            <span class="mt-0.5 block text-xs text-white/42">
+                                {group.channelCount} channels
+                            </span>
+                        </span>
+                        {#if selectedGroup === group.name}
+                            <Check size={18} strokeWidth={2.4} class="shrink-0" />
+                        {/if}
+                    </button>
+                {/each}
+            </div>
+        </div>
+    {/if}
+</div>

--- a/packages/app/src/pages/live/components/LiveGroupFilter.svelte
+++ b/packages/app/src/pages/live/components/LiveGroupFilter.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import { onMount } from "svelte";
-    import { Check, ChevronDown, ListFilter } from "@lucide/svelte";
+    import { onMount, tick } from "svelte";
+    import { Check, ChevronDown, ListFilter, Search } from "@lucide/svelte";
     import type { IptvGroup } from "../../../lib/iptv/types";
+    import { getVisibleLiveTvGroups } from "../liveHelpers";
 
     export let groups: IptvGroup[] = [];
     export let selectedGroup = "__all__";
@@ -12,14 +13,18 @@
     export let disabled = false;
     export let totalChannels = 0;
 
+    const allGroupsLabel = "All groups";
+
     let open = false;
     let root: HTMLDivElement;
+    let groupQuery = "";
+    let searchInput: HTMLInputElement;
 
     $: selectedGroupRow =
         groups.find((group) => group.name === selectedGroup) ?? null;
     $: selectedLabel =
         selectedGroup === allGroupsValue
-            ? "All groups"
+            ? allGroupsLabel
             : selectedGroup === favoritesGroupValue
               ? favoritesGroupLabel
               : selectedGroup;
@@ -29,15 +34,32 @@
             : selectedGroup === favoritesGroupValue
               ? favoritesCount
               : selectedGroupRow?.channelCount ?? 0;
+    $: visibleGroups = getVisibleLiveTvGroups(groups, groupQuery);
+    $: normalizedGroupQuery = groupQuery.trim().toLowerCase();
+    $: showAllGroupOption =
+        !normalizedGroupQuery || allGroupsLabel.toLowerCase().includes(normalizedGroupQuery);
+    $: showFavoritesGroupOption =
+        !normalizedGroupQuery ||
+        favoritesGroupLabel.toLowerCase().includes(normalizedGroupQuery);
+    $: hasVisibleOptions =
+        showAllGroupOption || showFavoritesGroupOption || visibleGroups.length > 0;
 
     function toggleMenu(event: MouseEvent) {
         event.stopPropagation();
         if (disabled) return;
-        open = !open;
+        if (open) {
+            closeMenu();
+            return;
+        }
+
+        groupQuery = "";
+        open = true;
+        void tick().then(() => searchInput?.focus());
     }
 
     function closeMenu() {
         open = false;
+        groupQuery = "";
     }
 
     function selectGroup(groupName: string) {
@@ -93,61 +115,73 @@
     {#if open}
         <div
             class="absolute left-0 top-[calc(100%+10px)] z-[260] w-[300px] overflow-hidden rounded-[24px] border border-white/10 bg-[#181818]/96 p-2 shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur-xl"
-            role="listbox"
         >
-            <div class="max-h-[360px] overflow-y-auto pr-1">
-                <button
-                    type="button"
-                    class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
-                        selectedGroup === allGroupsValue
-                            ? "bg-white/[0.12] text-white"
-                            : "text-white/76 hover:bg-white/[0.07] hover:text-white"
-                    }`}
-                    role="option"
-                    aria-selected={selectedGroup === allGroupsValue}
-                    onclick={() => selectGroup(allGroupsValue)}
-                >
-                    <span class="min-w-0 flex-1">
-                        <span class="block truncate text-sm font-semibold">
-                            All groups
-                        </span>
-                        <span class="mt-0.5 block text-xs text-white/42">
-                            {totalChannels} channels
-                        </span>
-                    </span>
-                    {#if selectedGroup === allGroupsValue}
-                        <Check size={18} strokeWidth={2.4} class="shrink-0" />
-                    {/if}
-                </button>
+            <label class="mb-2 flex h-10 items-center gap-2 rounded-[16px] border border-white/10 bg-black/24 px-3 text-white/62 focus-within:border-white/30 focus-within:text-white">
+                <Search size={16} strokeWidth={2.2} class="shrink-0" />
+                <input
+                    bind:this={searchInput}
+                    bind:value={groupQuery}
+                    class="h-full min-w-0 flex-1 bg-transparent text-sm text-white outline-none placeholder:text-white/32"
+                    placeholder="Search groups"
+                    autocomplete="off"
+                    aria-label="Search groups"
+                />
+            </label>
 
-                <button
-                    type="button"
-                    class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
-                        selectedGroup === favoritesGroupValue
-                            ? "bg-white/[0.12] text-white"
-                            : "text-white/76 hover:bg-white/[0.07] hover:text-white"
-                    }`}
-                    role="option"
-                    aria-selected={selectedGroup === favoritesGroupValue}
-                    onclick={() => selectGroup(favoritesGroupValue)}
-                >
-                    <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.08] text-sm text-amber-200">
-                        ★
-                    </span>
-                    <span class="min-w-0 flex-1">
-                        <span class="block truncate text-sm font-semibold">
-                            {favoritesGroupLabel}
+            <div class="max-h-[360px] overflow-y-auto pr-1" role="listbox">
+                {#if showAllGroupOption}
+                    <button
+                        type="button"
+                        class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
+                            selectedGroup === allGroupsValue
+                                ? "bg-white/[0.12] text-white"
+                                : "text-white/76 hover:bg-white/[0.07] hover:text-white"
+                        }`}
+                        role="option"
+                        aria-selected={selectedGroup === allGroupsValue}
+                        onclick={() => selectGroup(allGroupsValue)}
+                    >
+                        <span class="min-w-0 flex-1">
+                            <span class="block truncate text-sm font-semibold">
+                                {allGroupsLabel}
+                            </span>
+                            <span class="mt-0.5 block text-xs text-white/42">
+                                {totalChannels} channels
+                            </span>
                         </span>
-                        <span class="mt-0.5 block text-xs text-white/42">
-                            {favoritesCount} channels
-                        </span>
-                    </span>
-                    {#if selectedGroup === favoritesGroupValue}
-                        <Check size={18} strokeWidth={2.4} class="shrink-0" />
-                    {/if}
-                </button>
+                        {#if selectedGroup === allGroupsValue}
+                            <Check size={18} strokeWidth={2.4} class="shrink-0" />
+                        {/if}
+                    </button>
+                {/if}
 
-                {#each groups as group}
+                {#if showFavoritesGroupOption}
+                    <button
+                        type="button"
+                        class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
+                            selectedGroup === favoritesGroupValue
+                                ? "bg-white/[0.12] text-white"
+                                : "text-white/76 hover:bg-white/[0.07] hover:text-white"
+                        }`}
+                        role="option"
+                        aria-selected={selectedGroup === favoritesGroupValue}
+                        onclick={() => selectGroup(favoritesGroupValue)}
+                    >
+                        <span class="min-w-0 flex-1">
+                            <span class="block truncate text-sm font-semibold">
+                                {favoritesGroupLabel}
+                            </span>
+                            <span class="mt-0.5 block text-xs text-white/42">
+                                {favoritesCount} channels
+                            </span>
+                        </span>
+                        {#if selectedGroup === favoritesGroupValue}
+                            <Check size={18} strokeWidth={2.4} class="shrink-0" />
+                        {/if}
+                    </button>
+                {/if}
+
+                {#each visibleGroups as group}
                     <button
                         type="button"
                         class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
@@ -172,6 +206,12 @@
                         {/if}
                     </button>
                 {/each}
+
+                {#if !hasVisibleOptions}
+                    <div class="px-3 py-5 text-sm text-white/42">
+                        No groups found
+                    </div>
+                {/if}
             </div>
         </div>
     {/if}

--- a/packages/app/src/pages/live/components/LiveGuide.svelte
+++ b/packages/app/src/pages/live/components/LiveGuide.svelte
@@ -17,14 +17,34 @@
     export let guideNowLinePercent = 0;
     export let showGuideNowLine = false;
     export let hasGuide = false;
+    export let favoriteChannelIds: string[] = [];
     export let hasMoreGuideChannels = false;
     export let visibleGuideChannelsCount = 0;
     export let visibleChannelsCount = 0;
     export let nextGuideChannelPageCount = 0;
     export let onPlayChannel: (channel: IptvChannel) => void = () => {};
+    export let onToggleFavoriteChannel: (channel: IptvChannel) => void = () => {};
     export let onShowMoreGuideChannels: () => void = () => {};
 
     let failedLogoUrls = new Set<string>();
+
+    $: favoriteChannelIdSet = new Set(favoriteChannelIds);
+
+    function isFavoriteChannel(channel: IptvChannel) {
+        return favoriteChannelIdSet.has(channel.id);
+    }
+
+    function favoriteButtonLabel(channel: IptvChannel) {
+        return `${isFavoriteChannel(channel) ? "Remove" : "Add"} ${channel.name} ${isFavoriteChannel(channel) ? "from" : "to"} Favorites`;
+    }
+
+    function favoriteButtonClass(channel: IptvChannel) {
+        return `flex h-8 w-8 items-center justify-center rounded-full border text-sm transition-colors ${
+            isFavoriteChannel(channel)
+                ? "border-amber-300/50 bg-amber-300/18 text-amber-200"
+                : "border-white/10 bg-black/36 text-white/48 hover:bg-white/12 hover:text-white"
+        }`;
+    }
 
     function shouldShowLogo(channel: IptvChannel) {
         return Boolean(channel.logo && !failedLogoUrls.has(channel.logo));
@@ -88,26 +108,38 @@
         <div class="p-4">
             <div class="grid grid-cols-[repeat(auto-fill,minmax(86px,1fr))] gap-2 sm:grid-cols-[repeat(auto-fill,minmax(104px,1fr))]">
                 {#each guideRows as row (row.channel.id)}
-                    <button
-                        class="flex h-[104px] min-w-0 flex-col items-center justify-center gap-2 rounded-2xl bg-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.11]"
-                        title={row.channel.name}
-                        aria-label={`Play ${row.channel.name}`}
-                        onclick={() => onPlayChannel(row.channel)}
-                    >
-                        <LiveChannelLogo
-                            channel={row.channel}
-                            {shouldShowLogo}
-                            {markLogoFailed}
-                        />
-                        <span class="line-clamp-2 max-w-full text-[11px] font-medium leading-tight text-white/72">
-                            {row.channel.name}
-                        </span>
-                        {#if row.channel.number}
-                            <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
-                                {row.channel.number}
+                    <div class="relative">
+                        <button
+                            class="flex h-[104px] w-full min-w-0 flex-col items-center justify-center gap-2 rounded-2xl bg-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.11]"
+                            title={row.channel.name}
+                            aria-label={`Play ${row.channel.name}`}
+                            onclick={() => onPlayChannel(row.channel)}
+                        >
+                            <LiveChannelLogo
+                                channel={row.channel}
+                                {shouldShowLogo}
+                                {markLogoFailed}
+                            />
+                            <span class="line-clamp-2 max-w-full text-[11px] font-medium leading-tight text-white/72">
+                                {row.channel.name}
                             </span>
-                        {/if}
-                    </button>
+                            {#if row.channel.number}
+                                <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                    {row.channel.number}
+                                </span>
+                            {/if}
+                        </button>
+                        <button
+                            type="button"
+                            class={`absolute right-2 top-2 ${favoriteButtonClass(row.channel)}`}
+                            aria-label={favoriteButtonLabel(row.channel)}
+                            aria-pressed={isFavoriteChannel(row.channel)}
+                            title={favoriteButtonLabel(row.channel)}
+                            onclick={() => onToggleFavoriteChannel(row.channel)}
+                        >
+                            {isFavoriteChannel(row.channel) ? "★" : "☆"}
+                        </button>
+                    </div>
                 {/each}
             </div>
         </div>
@@ -116,27 +148,39 @@
             <div class="border-r border-white/10 bg-black/18">
                 <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
                 {#each guideRows as row (row.channel.id)}
-                    <button
-                        class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
-                        title={row.channel.name}
-                        aria-label={`Play ${row.channel.name}`}
-                        onclick={() => onPlayChannel(row.channel)}
-                    >
-                        <LiveChannelLogo
-                            channel={row.channel}
-                            {shouldShowLogo}
-                            {markLogoFailed}
-                        />
-                        {#if row.channel.number}
-                            <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
-                                {row.channel.number}
-                            </span>
-                        {:else}
-                            <span class="max-w-full truncate text-[10px] leading-none text-white/48">
-                                {row.channel.name}
-                            </span>
-                        {/if}
-                    </button>
+                    <div class="relative h-[86px] border-b border-white/[0.06]">
+                        <button
+                            class="flex h-full w-full flex-col items-center justify-center gap-1 px-2 text-center transition-colors hover:bg-white/[0.06]"
+                            title={row.channel.name}
+                            aria-label={`Play ${row.channel.name}`}
+                            onclick={() => onPlayChannel(row.channel)}
+                        >
+                            <LiveChannelLogo
+                                channel={row.channel}
+                                {shouldShowLogo}
+                                {markLogoFailed}
+                            />
+                            {#if row.channel.number}
+                                <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                    {row.channel.number}
+                                </span>
+                            {:else}
+                                <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+                                    {row.channel.name}
+                                </span>
+                            {/if}
+                        </button>
+                        <button
+                            type="button"
+                            class={`absolute right-1 top-1 ${favoriteButtonClass(row.channel)}`}
+                            aria-label={favoriteButtonLabel(row.channel)}
+                            aria-pressed={isFavoriteChannel(row.channel)}
+                            title={favoriteButtonLabel(row.channel)}
+                            onclick={() => onToggleFavoriteChannel(row.channel)}
+                        >
+                            {isFavoriteChannel(row.channel) ? "★" : "☆"}
+                        </button>
+                    </div>
                 {/each}
             </div>
 

--- a/packages/app/src/pages/live/components/LiveGuide.svelte
+++ b/packages/app/src/pages/live/components/LiveGuide.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+    import { Tv } from "@lucide/svelte";
+    import type {
+        GuideGridRow,
+        GuideGridViewport,
+        GuideProgrammeState,
+    } from "../../../lib/iptv/guideGrid";
+    import type { IptvChannel } from "../../../lib/iptv/types";
+    import { formatTime, type GuideTimeTick } from "../liveHelpers";
+
+    const GUIDE_TIMELINE_MIN_WIDTH = 680;
+
+    export let guideTitle = "Live TV";
+    export let guideViewport: GuideGridViewport;
+    export let guideRows: GuideGridRow[] = [];
+    export let guideTimeTicks: GuideTimeTick[] = [];
+    export let guideNowLinePercent = 0;
+    export let showGuideNowLine = false;
+    export let hasGuide = false;
+    export let hasMoreGuideChannels = false;
+    export let visibleGuideChannelsCount = 0;
+    export let visibleChannelsCount = 0;
+    export let nextGuideChannelPageCount = 0;
+    export let onPlayChannel: (channel: IptvChannel) => void = () => {};
+    export let onShowMoreGuideChannels: () => void = () => {};
+
+    function timeTickClass(leftPercent: number) {
+        const base =
+            "absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-[11px] tabular-nums text-white/42";
+        if (leftPercent <= 1) return `${base} translate-x-0`;
+        if (leftPercent >= 99) return `${base} -translate-x-full`;
+        return `${base} -translate-x-1/2`;
+    }
+
+    function programmeBlockClass(state: GuideProgrammeState) {
+        if (state === "current") {
+            return "border-white/18 bg-white/18 text-white shadow-[0_10px_24px_rgba(0,0,0,0.18)] hover:bg-white/24";
+        }
+
+        if (state === "future") {
+            return "border-white/[0.08] bg-white/[0.08] text-white/84 hover:bg-white/[0.12]";
+        }
+
+        return "border-white/[0.06] bg-white/[0.04] text-white/46 hover:bg-white/[0.07]";
+    }
+
+    function guideFallbackLabel() {
+        return hasGuide ? "No guide data" : "Live";
+    }
+</script>
+
+<section class="overflow-hidden rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
+    <div class="flex flex-col gap-2 border-b border-white/10 bg-white/[0.04] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <h2 class="font-poppins text-lg font-semibold">
+                {guideTitle}
+            </h2>
+            <p class="text-sm text-white/45">
+                Click a channel or programme to start live playback.
+                {#if hasMoreGuideChannels}
+                    Showing {visibleGuideChannelsCount} of {visibleChannelsCount} matching channels.
+                {/if}
+            </p>
+        </div>
+        <div class="text-sm tabular-nums text-white/46">
+            {formatTime(guideViewport.viewportStart)} to {formatTime(
+                guideViewport.viewportEnd,
+            )}
+        </div>
+    </div>
+
+    <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
+        <div class="border-r border-white/10 bg-black/18">
+            <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
+            {#each guideRows as row (row.channel.id)}
+                <button
+                    class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
+                    title={row.channel.name}
+                    aria-label={`Play ${row.channel.name}`}
+                    onclick={() => onPlayChannel(row.channel)}
+                >
+                    <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-black/32 ring-1 ring-white/[0.06]">
+                        {#if row.channel.logo}
+                            <img
+                                src={row.channel.logo}
+                                alt=""
+                                class="max-h-full max-w-full object-contain"
+                                loading="lazy"
+                                onerror={(event) => {
+                                    (event.currentTarget as HTMLImageElement).style.display = "none";
+                                }}
+                            />
+                        {:else}
+                            <Tv size={22} strokeWidth={2} class="text-white/34" />
+                        {/if}
+                    </div>
+                    {#if row.channel.number}
+                        <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                            {row.channel.number}
+                        </span>
+                    {:else}
+                        <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+                            {row.channel.name}
+                        </span>
+                    {/if}
+                </button>
+            {/each}
+        </div>
+
+        <div class="no-scrollbar min-w-0 overflow-x-auto bg-black/12">
+            <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
+                <div class="relative h-10 border-b border-white/10 bg-white/[0.03]">
+                    {#each guideTimeTicks as tick (tick.value.getTime())}
+                        <div
+                            class={timeTickClass(tick.leftPercent)}
+                            style={`left: ${tick.leftPercent}%;`}
+                        >
+                            {tick.label}
+                        </div>
+                    {/each}
+                </div>
+
+                <div class="relative">
+                    {#if showGuideNowLine}
+                        <div
+                            class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
+                            style={`left: ${guideNowLinePercent}%;`}
+                        >
+                            <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-white shadow-[0_0_16px_rgba(255,255,255,0.55)]"></div>
+                            <div class="h-full w-px bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.28)]"></div>
+                        </div>
+                    {/if}
+
+                    {#each guideRows as row (row.channel.id)}
+                        <div class="relative h-[86px] border-b border-white/[0.06]">
+                            {#if row.programmes.length > 0}
+                                {#each row.programmes as programme (programme.id)}
+                                    <button
+                                        class={`absolute inset-y-2 overflow-hidden rounded-xl border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
+                                        style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
+                                        title={`${programme.timeRange} ${programme.title}`}
+                                        onclick={() => onPlayChannel(row.channel)}
+                                    >
+                                        <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
+                                            {programme.title}
+                                        </span>
+                                        <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
+                                            {programme.timeRange}
+                                        </span>
+                                    </button>
+                                {/each}
+                            {:else}
+                                <button
+                                    class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.08] px-3 text-left text-white/78 transition-colors hover:bg-white/[0.12]"
+                                    onclick={() => onPlayChannel(row.channel)}
+                                >
+                                    <span class="font-poppins text-[13px] font-semibold">
+                                        {guideFallbackLabel()}
+                                    </span>
+                                    <span class="min-w-0 truncate text-[11px] text-white/42">
+                                        {row.channel.name}
+                                    </span>
+                                </button>
+                            {/if}
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {#if hasMoreGuideChannels}
+        <div class="flex flex-col gap-3 border-t border-white/10 bg-white/[0.03] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <p class="text-sm leading-6 text-white/48">
+                Large playlists are paged to keep the guide responsive. Search or select a group to narrow the list.
+            </p>
+            <button
+                class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
+                onclick={onShowMoreGuideChannels}
+            >
+                Show {nextGuideChannelPageCount} more
+            </button>
+        </div>
+    {/if}
+</section>
+
+<style>
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+
+    .no-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+</style>

--- a/packages/app/src/pages/live/components/LiveGuide.svelte
+++ b/packages/app/src/pages/live/components/LiveGuide.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { Tv } from "@lucide/svelte";
     import type {
         GuideGridRow,
         GuideGridViewport,
@@ -7,6 +6,7 @@
     } from "../../../lib/iptv/guideGrid";
     import type { IptvChannel } from "../../../lib/iptv/types";
     import { formatTime, type GuideTimeTick } from "../liveHelpers";
+    import LiveChannelLogo from "./LiveChannelLogo.svelte";
 
     const GUIDE_TIMELINE_MIN_WIDTH = 680;
 
@@ -24,9 +24,20 @@
     export let onPlayChannel: (channel: IptvChannel) => void = () => {};
     export let onShowMoreGuideChannels: () => void = () => {};
 
+    let failedLogoUrls = new Set<string>();
+
+    function shouldShowLogo(channel: IptvChannel) {
+        return Boolean(channel.logo && !failedLogoUrls.has(channel.logo));
+    }
+
+    function markLogoFailed(logo: string | undefined) {
+        if (!logo) return;
+        failedLogoUrls = new Set(failedLogoUrls).add(logo);
+    }
+
     function timeTickClass(leftPercent: number) {
         const base =
-            "absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-[11px] tabular-nums text-white/42";
+            "absolute top-1/2 -translate-y-1/2 whitespace-nowrap px-2 text-[11px] tabular-nums text-white/42";
         if (leftPercent <= 1) return `${base} translate-x-0`;
         if (leftPercent >= 99) return `${base} -translate-x-full`;
         return `${base} -translate-x-1/2`;
@@ -45,7 +56,7 @@
     }
 
     function guideFallbackLabel() {
-        return hasGuide ? "No guide data" : "Live";
+        return "No guide data";
     }
 </script>
 
@@ -56,118 +67,141 @@
                 {guideTitle}
             </h2>
             <p class="text-sm text-white/45">
-                Click a channel or programme to start live playback.
+                Click a channel{#if hasGuide} or programme{/if} to start live playback.
                 {#if hasMoreGuideChannels}
                     Showing {visibleGuideChannelsCount} of {visibleChannelsCount} matching channels.
                 {/if}
             </p>
         </div>
         <div class="text-sm tabular-nums text-white/46">
-            {formatTime(guideViewport.viewportStart)} to {formatTime(
-                guideViewport.viewportEnd,
-            )}
+            {#if hasGuide}
+                {formatTime(guideViewport.viewportStart)} to {formatTime(
+                    guideViewport.viewportEnd,
+                )}
+            {:else}
+                {visibleChannelsCount} channels
+            {/if}
         </div>
     </div>
 
-    <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
-        <div class="border-r border-white/10 bg-black/18">
-            <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
-            {#each guideRows as row (row.channel.id)}
-                <button
-                    class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
-                    title={row.channel.name}
-                    aria-label={`Play ${row.channel.name}`}
-                    onclick={() => onPlayChannel(row.channel)}
-                >
-                    <div class="flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-black/32 ring-1 ring-white/[0.06]">
-                        {#if row.channel.logo}
-                            <img
-                                src={row.channel.logo}
-                                alt=""
-                                class="max-h-full max-w-full object-contain"
-                                loading="lazy"
-                                onerror={(event) => {
-                                    (event.currentTarget as HTMLImageElement).style.display = "none";
-                                }}
-                            />
-                        {:else}
-                            <Tv size={22} strokeWidth={2} class="text-white/34" />
-                        {/if}
-                    </div>
-                    {#if row.channel.number}
-                        <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
-                            {row.channel.number}
-                        </span>
-                    {:else}
-                        <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+    {#if !hasGuide}
+        <div class="p-4">
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(86px,1fr))] gap-2 sm:grid-cols-[repeat(auto-fill,minmax(104px,1fr))]">
+                {#each guideRows as row (row.channel.id)}
+                    <button
+                        class="flex h-[104px] min-w-0 flex-col items-center justify-center gap-2 rounded-2xl bg-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.11]"
+                        title={row.channel.name}
+                        aria-label={`Play ${row.channel.name}`}
+                        onclick={() => onPlayChannel(row.channel)}
+                    >
+                        <LiveChannelLogo
+                            channel={row.channel}
+                            {shouldShowLogo}
+                            {markLogoFailed}
+                        />
+                        <span class="line-clamp-2 max-w-full text-[11px] font-medium leading-tight text-white/72">
                             {row.channel.name}
                         </span>
-                    {/if}
-                </button>
-            {/each}
+                        {#if row.channel.number}
+                            <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                {row.channel.number}
+                            </span>
+                        {/if}
+                    </button>
+                {/each}
+            </div>
         </div>
+    {:else}
+        <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
+            <div class="border-r border-white/10 bg-black/18">
+                <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
+                {#each guideRows as row (row.channel.id)}
+                    <button
+                        class="flex h-[86px] w-full flex-col items-center justify-center gap-1 border-b border-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.06]"
+                        title={row.channel.name}
+                        aria-label={`Play ${row.channel.name}`}
+                        onclick={() => onPlayChannel(row.channel)}
+                    >
+                        <LiveChannelLogo
+                            channel={row.channel}
+                            {shouldShowLogo}
+                            {markLogoFailed}
+                        />
+                        {#if row.channel.number}
+                            <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                {row.channel.number}
+                            </span>
+                        {:else}
+                            <span class="max-w-full truncate text-[10px] leading-none text-white/48">
+                                {row.channel.name}
+                            </span>
+                        {/if}
+                    </button>
+                {/each}
+            </div>
 
-        <div class="no-scrollbar min-w-0 overflow-x-auto bg-black/12">
-            <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
-                <div class="relative h-10 border-b border-white/10 bg-white/[0.03]">
-                    {#each guideTimeTicks as tick (tick.value.getTime())}
-                        <div
-                            class={timeTickClass(tick.leftPercent)}
-                            style={`left: ${tick.leftPercent}%;`}
-                        >
-                            {tick.label}
-                        </div>
-                    {/each}
-                </div>
+            <div class="no-scrollbar min-w-0 overflow-x-auto bg-black/12">
+                <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
+                    <div class="relative h-10 border-b border-white/10 bg-white/[0.03]">
+                        {#each guideTimeTicks as tick (tick.value.getTime())}
+                            <div
+                                class={timeTickClass(tick.leftPercent)}
+                                style={`left: ${tick.leftPercent}%;`}
+                            >
+                                {tick.label}
+                            </div>
+                        {/each}
+                    </div>
 
-                <div class="relative">
-                    {#if showGuideNowLine}
-                        <div
-                            class="pointer-events-none absolute bottom-0 top-0 z-30 -translate-x-1/2"
-                            style={`left: ${guideNowLinePercent}%;`}
-                        >
-                            <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-white shadow-[0_0_16px_rgba(255,255,255,0.55)]"></div>
-                            <div class="h-full w-px bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.28)]"></div>
-                        </div>
-                    {/if}
+                    <div class="relative">
+                        {#if showGuideNowLine}
+                            <div
+                                class="pointer-events-none absolute bottom-0 top-0 z-30 w-px -translate-x-1/2"
+                                style={`left: ${guideNowLinePercent}%;`}
+                            >
+                                <div class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-white shadow-[0_0_16px_rgba(255,255,255,0.55)]"></div>
+                                <div class="h-full w-px bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.28)]"></div>
+                            </div>
+                        {/if}
 
-                    {#each guideRows as row (row.channel.id)}
-                        <div class="relative h-[86px] border-b border-white/[0.06]">
-                            {#if row.programmes.length > 0}
-                                {#each row.programmes as programme (programme.id)}
+                        {#each guideRows as row (row.channel.id)}
+                            <div class="relative h-[86px] border-b border-white/[0.06]">
+                                {#if row.programmes.length > 0}
+                                    {#each row.programmes as programme (programme.id)}
+                                        <button
+                                            class={`absolute inset-y-2 overflow-hidden rounded-xl border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
+                                            style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
+                                            title={`${programme.timeRange} ${programme.title}`}
+                                            onclick={() => onPlayChannel(row.channel)}
+                                        >
+                                            <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
+                                                {programme.title}
+                                            </span>
+                                            <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
+                                                {programme.timeRange}
+                                            </span>
+                                        </button>
+                                    {/each}
+                                {:else}
                                     <button
-                                        class={`absolute inset-y-2 overflow-hidden rounded-xl border px-3 py-2 text-left transition-colors ${programmeBlockClass(programme.state)}`}
-                                        style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
-                                        title={`${programme.timeRange} ${programme.title}`}
+                                        class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.08] px-3 text-left text-white/78 transition-colors hover:bg-white/[0.12]"
                                         onclick={() => onPlayChannel(row.channel)}
                                     >
-                                        <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
-                                            {programme.title}
+                                        <span class="font-poppins text-[13px] font-semibold">
+                                            {guideFallbackLabel()}
                                         </span>
-                                        <span class="mt-1 block truncate text-[11px] tabular-nums opacity-68">
-                                            {programme.timeRange}
+                                        <span class="min-w-0 truncate text-[11px] text-white/42">
+                                            {row.channel.name}
                                         </span>
                                     </button>
-                                {/each}
-                            {:else}
-                                <button
-                                    class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.08] px-3 text-left text-white/78 transition-colors hover:bg-white/[0.12]"
-                                    onclick={() => onPlayChannel(row.channel)}
-                                >
-                                    <span class="font-poppins text-[13px] font-semibold">
-                                        {guideFallbackLabel()}
-                                    </span>
-                                    <span class="min-w-0 truncate text-[11px] text-white/42">
-                                        {row.channel.name}
-                                    </span>
-                                </button>
-                            {/if}
-                        </div>
-                    {/each}
+                                {/if}
+                            </div>
+                        {/each}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {/if}
 
     {#if hasMoreGuideChannels}
         <div class="flex flex-col gap-3 border-t border-white/10 bg-white/[0.03] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">

--- a/packages/app/src/pages/live/components/LiveGuide.svelte
+++ b/packages/app/src/pages/live/components/LiveGuide.svelte
@@ -24,6 +24,7 @@
 
     let failedLogoUrls = new Set<string>();
     let contextMenuChannel: IptvChannel | null = null;
+    let contextMenuTrigger: HTMLElement | null = null;
     let contextMenuX = 0;
     let contextMenuY = 0;
 
@@ -45,10 +46,12 @@
             ? event.clientY
             : (rect?.top ?? 0) + Math.min(rect?.height ?? 0, 28);
         contextMenuChannel = channel;
+        contextMenuTrigger = event.currentTarget as HTMLElement | null;
     }
 
     function closeChannelContextMenu() {
         contextMenuChannel = null;
+        contextMenuTrigger = null;
     }
 
     function toggleContextMenuFavorite() {
@@ -56,7 +59,7 @@
         onToggleFavoriteChannel(contextMenuChannel);
     }
 
-    function loadMoreSentinel(node: HTMLElement, _pageKey = 0) {
+    function loadMoreSentinel(node: HTMLElement, _pageKey: number = 0) {
         let disposed = false;
         const loadNextPage = () => {
             if (!disposed) onShowMoreGuideChannels();
@@ -290,6 +293,8 @@
             x={contextMenuX}
             y={contextMenuY}
             isFavorite={isFavoriteChannel(contextMenuChannel)}
+            ariaLabel={`Channel actions for ${contextMenuChannel.name}`}
+            returnFocusTo={contextMenuTrigger}
             onClose={closeChannelContextMenu}
             onToggleFavorite={toggleContextMenuFavorite}
         />

--- a/packages/app/src/pages/live/components/LiveGuide.svelte
+++ b/packages/app/src/pages/live/components/LiveGuide.svelte
@@ -1,32 +1,31 @@
 <script lang="ts">
     import type {
         GuideGridRow,
-        GuideGridViewport,
         GuideProgrammeState,
     } from "../../../lib/iptv/guideGrid";
     import type { IptvChannel } from "../../../lib/iptv/types";
-    import { formatTime, type GuideTimeTick } from "../liveHelpers";
+    import type { GuideTimeTick } from "../liveHelpers";
+    import LiveChannelContextMenu from "./LiveChannelContextMenu.svelte";
     import LiveChannelLogo from "./LiveChannelLogo.svelte";
 
     const GUIDE_TIMELINE_MIN_WIDTH = 680;
 
-    export let guideTitle = "Live TV";
-    export let guideViewport: GuideGridViewport;
     export let guideRows: GuideGridRow[] = [];
     export let guideTimeTicks: GuideTimeTick[] = [];
     export let guideNowLinePercent = 0;
     export let showGuideNowLine = false;
     export let hasGuide = false;
     export let favoriteChannelIds: string[] = [];
+    export let activeChannelId = "";
     export let hasMoreGuideChannels = false;
-    export let visibleGuideChannelsCount = 0;
-    export let visibleChannelsCount = 0;
-    export let nextGuideChannelPageCount = 0;
     export let onPlayChannel: (channel: IptvChannel) => void = () => {};
     export let onToggleFavoriteChannel: (channel: IptvChannel) => void = () => {};
     export let onShowMoreGuideChannels: () => void = () => {};
 
     let failedLogoUrls = new Set<string>();
+    let contextMenuChannel: IptvChannel | null = null;
+    let contextMenuX = 0;
+    let contextMenuY = 0;
 
     $: favoriteChannelIdSet = new Set(favoriteChannelIds);
 
@@ -34,16 +33,81 @@
         return favoriteChannelIdSet.has(channel.id);
     }
 
-    function favoriteButtonLabel(channel: IptvChannel) {
-        return `${isFavoriteChannel(channel) ? "Remove" : "Add"} ${channel.name} ${isFavoriteChannel(channel) ? "from" : "to"} Favorites`;
+    function openChannelContextMenu(event: MouseEvent, channel: IptvChannel) {
+        event.preventDefault();
+        event.stopPropagation();
+        const rect = (event.currentTarget as HTMLElement | null)?.getBoundingClientRect();
+        const hasPointerCoordinates = event.clientX !== 0 || event.clientY !== 0;
+        contextMenuX = hasPointerCoordinates
+            ? event.clientX
+            : (rect?.left ?? 0) + Math.min(rect?.width ?? 0, 28);
+        contextMenuY = hasPointerCoordinates
+            ? event.clientY
+            : (rect?.top ?? 0) + Math.min(rect?.height ?? 0, 28);
+        contextMenuChannel = channel;
     }
 
-    function favoriteButtonClass(channel: IptvChannel) {
-        return `flex h-8 w-8 items-center justify-center rounded-full border text-sm transition-colors ${
-            isFavoriteChannel(channel)
-                ? "border-amber-300/50 bg-amber-300/18 text-amber-200"
-                : "border-white/10 bg-black/36 text-white/48 hover:bg-white/12 hover:text-white"
-        }`;
+    function closeChannelContextMenu() {
+        contextMenuChannel = null;
+    }
+
+    function toggleContextMenuFavorite() {
+        if (!contextMenuChannel) return;
+        onToggleFavoriteChannel(contextMenuChannel);
+    }
+
+    function loadMoreSentinel(node: HTMLElement, _pageKey = 0) {
+        let disposed = false;
+        const loadNextPage = () => {
+            if (!disposed) onShowMoreGuideChannels();
+        };
+
+        if (typeof IntersectionObserver === "undefined") {
+            queueMicrotask(loadNextPage);
+            return {
+                update() {
+                    queueMicrotask(loadNextPage);
+                },
+                destroy() {
+                    disposed = true;
+                },
+            };
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    loadNextPage();
+                }
+            },
+            { rootMargin: "520px 0px" },
+        );
+        const observe = () => {
+            observer.unobserve(node);
+            observer.observe(node);
+        };
+        observe();
+
+        return {
+            update() {
+                observe();
+            },
+            destroy() {
+                disposed = true;
+                observer.disconnect();
+            },
+        };
+    }
+
+    function channelButtonClass(channel: IptvChannel, variant: "grid" | "guide") {
+        const active = channel.id === activeChannelId;
+        const base =
+            variant === "grid"
+                ? "flex h-[88px] w-full min-w-0 items-center gap-3 rounded-[14px] border px-3 text-left transition-colors"
+                : "flex h-full w-full flex-col items-center justify-center gap-1 px-2 text-center transition-colors";
+        return active
+            ? `${base} border-white/22 bg-white/[0.14] ring-1 ring-white/22`
+            : `${base} border-white/[0.08] bg-white/[0.045] hover:border-white/14 hover:bg-white/[0.08]`;
     }
 
     function shouldShowLogo(channel: IptvChannel) {
@@ -80,80 +144,54 @@
     }
 </script>
 
-<section class="overflow-hidden rounded-[28px] border border-white/10 bg-[#2b2b2b]/56 shadow-[0_24px_80px_rgba(0,0,0,0.32)] backdrop-blur-xl">
-    <div class="flex flex-col gap-2 border-b border-white/10 bg-white/[0.04] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-            <h2 class="font-poppins text-lg font-semibold">
-                {guideTitle}
-            </h2>
-            <p class="text-sm text-white/45">
-                Click a channel{#if hasGuide} or programme{/if} to start live playback.
-                {#if hasMoreGuideChannels}
-                    Showing {visibleGuideChannelsCount} of {visibleChannelsCount} matching channels.
-                {/if}
-            </p>
-        </div>
-        <div class="text-sm tabular-nums text-white/46">
-            {#if hasGuide}
-                {formatTime(guideViewport.viewportStart)} to {formatTime(
-                    guideViewport.viewportEnd,
-                )}
-            {:else}
-                {visibleChannelsCount} channels
-            {/if}
-        </div>
-    </div>
-
+<section class="min-w-0">
     {#if !hasGuide}
-        <div class="p-4">
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(86px,1fr))] gap-2 sm:grid-cols-[repeat(auto-fill,minmax(104px,1fr))]">
-                {#each guideRows as row (row.channel.id)}
-                    <div class="relative">
-                        <button
-                            class="flex h-[104px] w-full min-w-0 flex-col items-center justify-center gap-2 rounded-2xl bg-white/[0.06] px-2 text-center transition-colors hover:bg-white/[0.11]"
-                            title={row.channel.name}
-                            aria-label={`Play ${row.channel.name}`}
-                            onclick={() => onPlayChannel(row.channel)}
-                        >
-                            <LiveChannelLogo
-                                channel={row.channel}
-                                {shouldShowLogo}
-                                {markLogoFailed}
-                            />
-                            <span class="line-clamp-2 max-w-full text-[11px] font-medium leading-tight text-white/72">
-                                {row.channel.name}
-                            </span>
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3 sm:grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">
+            {#each guideRows as row (row.channel.id)}
+                <button
+                    class={channelButtonClass(row.channel, "grid")}
+                    title={row.channel.name}
+                    aria-label={`Play ${row.channel.name}`}
+                    onclick={() => onPlayChannel(row.channel)}
+                    oncontextmenu={(event) => openChannelContextMenu(event, row.channel)}
+                >
+                    <LiveChannelLogo
+                        channel={row.channel}
+                        {shouldShowLogo}
+                        {markLogoFailed}
+                    />
+                    <span class="min-w-0 flex-1">
+                        <span class="block truncate font-poppins text-sm font-semibold text-white/86">
+                            {row.channel.name}
+                        </span>
+                        <span class="mt-1 flex min-w-0 items-center gap-2 text-xs text-white/48">
                             {#if row.channel.number}
-                                <span class="max-w-full truncate rounded bg-white/[0.07] px-1.5 py-0.5 text-[10px] tabular-nums text-white/54">
+                                <span class="shrink-0 rounded bg-white/[0.07] px-2 py-0.5 tabular-nums text-white/58">
                                     {row.channel.number}
                                 </span>
                             {/if}
-                        </button>
-                        <button
-                            type="button"
-                            class={`absolute right-2 top-2 ${favoriteButtonClass(row.channel)}`}
-                            aria-label={favoriteButtonLabel(row.channel)}
-                            aria-pressed={isFavoriteChannel(row.channel)}
-                            title={favoriteButtonLabel(row.channel)}
-                            onclick={() => onToggleFavoriteChannel(row.channel)}
-                        >
-                            {isFavoriteChannel(row.channel) ? "★" : "☆"}
-                        </button>
-                    </div>
-                {/each}
-            </div>
+                            {#if row.channel.group || !row.channel.number}
+                                <span class="truncate">
+                                    {row.channel.group || "Live TV"}
+                                </span>
+                            {/if}
+                        </span>
+                    </span>
+                </button>
+            {/each}
         </div>
     {:else}
-        <div class="grid grid-cols-[88px_minmax(0,1fr)] sm:grid-cols-[108px_minmax(0,1fr)]">
-            <div class="border-r border-white/10 bg-black/18">
-                <div class="h-10 border-b border-white/10 bg-white/[0.03]"></div>
+        <div class="grid grid-cols-[88px_minmax(0,1fr)] border-t border-white/10 sm:grid-cols-[108px_minmax(0,1fr)]">
+            <div class="border-r border-white/10">
+                <div class="h-10 border-b border-white/10 bg-white/[0.025]"></div>
                 {#each guideRows as row (row.channel.id)}
-                    <div class="relative h-[86px] border-b border-white/[0.06]">
+                    <div class="h-[86px] border-b border-white/[0.06]">
                         <button
-                            class="flex h-full w-full flex-col items-center justify-center gap-1 px-2 text-center transition-colors hover:bg-white/[0.06]"
+                            class={channelButtonClass(row.channel, "guide")}
                             title={row.channel.name}
                             aria-label={`Play ${row.channel.name}`}
                             onclick={() => onPlayChannel(row.channel)}
+                            oncontextmenu={(event) => openChannelContextMenu(event, row.channel)}
                         >
                             <LiveChannelLogo
                                 channel={row.channel}
@@ -170,23 +208,13 @@
                                 </span>
                             {/if}
                         </button>
-                        <button
-                            type="button"
-                            class={`absolute right-1 top-1 ${favoriteButtonClass(row.channel)}`}
-                            aria-label={favoriteButtonLabel(row.channel)}
-                            aria-pressed={isFavoriteChannel(row.channel)}
-                            title={favoriteButtonLabel(row.channel)}
-                            onclick={() => onToggleFavoriteChannel(row.channel)}
-                        >
-                            {isFavoriteChannel(row.channel) ? "★" : "☆"}
-                        </button>
                     </div>
                 {/each}
             </div>
 
-            <div class="no-scrollbar min-w-0 overflow-x-auto bg-black/12">
+            <div class="no-scrollbar min-w-0 overflow-x-auto">
                 <div class="relative" style={`min-width: ${GUIDE_TIMELINE_MIN_WIDTH}px;`}>
-                    <div class="relative h-10 border-b border-white/10 bg-white/[0.03]">
+                    <div class="relative h-10 border-b border-white/10 bg-white/[0.025]">
                         {#each guideTimeTicks as tick (tick.value.getTime())}
                             <div
                                 class={timeTickClass(tick.leftPercent)}
@@ -209,7 +237,11 @@
                         {/if}
 
                         {#each guideRows as row (row.channel.id)}
-                            <div class="relative h-[86px] border-b border-white/[0.06]">
+                            <div
+                                class="relative h-[86px] border-b border-white/[0.06]"
+                                role="presentation"
+                                oncontextmenu={(event) => openChannelContextMenu(event, row.channel)}
+                            >
                                 {#if row.programmes.length > 0}
                                     {#each row.programmes as programme (programme.id)}
                                         <button
@@ -217,6 +249,7 @@
                                             style={`left: ${programme.leftPercent}%; width: ${programme.widthPercent}%;`}
                                             title={`${programme.timeRange} ${programme.title}`}
                                             onclick={() => onPlayChannel(row.channel)}
+                                            oncontextmenu={(event) => openChannelContextMenu(event, row.channel)}
                                         >
                                             <span class="line-clamp-2 font-poppins text-[13px] font-semibold leading-tight">
                                                 {programme.title}
@@ -230,6 +263,7 @@
                                     <button
                                         class="absolute inset-y-2 left-2 right-2 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.08] px-3 text-left text-white/78 transition-colors hover:bg-white/[0.12]"
                                         onclick={() => onPlayChannel(row.channel)}
+                                        oncontextmenu={(event) => openChannelContextMenu(event, row.channel)}
                                     >
                                         <span class="font-poppins text-[13px] font-semibold">
                                             {guideFallbackLabel()}
@@ -248,17 +282,17 @@
     {/if}
 
     {#if hasMoreGuideChannels}
-        <div class="flex flex-col gap-3 border-t border-white/10 bg-white/[0.03] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-            <p class="text-sm leading-6 text-white/48">
-                Large playlists are paged to keep the guide responsive. Search or select a group to narrow the list.
-            </p>
-            <button
-                class="h-11 rounded-full border border-white/10 bg-white/8 px-5 text-sm font-semibold text-white/76 transition-colors hover:bg-white/14 hover:text-white"
-                onclick={onShowMoreGuideChannels}
-            >
-                Show {nextGuideChannelPageCount} more
-            </button>
-        </div>
+        <div use:loadMoreSentinel={guideRows.length} class="h-px w-full" aria-hidden="true"></div>
+    {/if}
+
+    {#if contextMenuChannel}
+        <LiveChannelContextMenu
+            x={contextMenuX}
+            y={contextMenuY}
+            isFavorite={isFavoriteChannel(contextMenuChannel)}
+            onClose={closeChannelContextMenu}
+            onToggleFavorite={toggleContextMenuFavorite}
+        />
     {/if}
 </section>
 

--- a/packages/app/src/pages/live/components/LiveSourceManager.svelte
+++ b/packages/app/src/pages/live/components/LiveSourceManager.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { tick } from "svelte";
-    import { Pencil, Plus, Trash2, X } from "@lucide/svelte";
+    import { Pencil, Trash2, X } from "@lucide/svelte";
     import { trackEvent } from "../../../lib/analytics";
     import {
         addIptvSource,
@@ -154,7 +154,7 @@
 
 {#if show}
     <div
-        class="fixed inset-0 z-[220] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        class="fixed inset-0 z-[220] flex items-center justify-center bg-[#101010]/56 p-5 backdrop-blur-xl md:p-8"
         onclick={(event) => {
             if (event.currentTarget === event.target) show = false;
         }}
@@ -165,7 +165,7 @@
         tabindex="0"
     >
         <section
-            class="max-h-[92vh] w-full max-w-[1040px] overflow-y-auto rounded-[28px] border border-white/10 bg-[#2b2b2b]/95 p-5 shadow-[0_32px_100px_rgba(0,0,0,0.48)] backdrop-blur-xl"
+            class="max-h-[92vh] w-full max-w-[1040px] overflow-y-auto rounded-4xl bg-[#2b2b2b]/56 p-6 shadow-[0_40px_160px_rgba(0,0,0,0.45)] backdrop-blur-[40px] md:p-8"
             role="dialog"
             aria-modal="true"
             tabindex="-1"
@@ -181,11 +181,11 @@
                     </p>
                 </div>
                 <button
-                    class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/8 text-white/72 transition-colors hover:bg-white/14 hover:text-white"
+                    class="shrink-0 cursor-pointer text-white/50 transition-colors hover:text-white"
                     aria-label="Close source manager"
                     onclick={() => (show = false)}
                 >
-                    <X size={20} strokeWidth={2.2} />
+                    <X size={24} strokeWidth={2} />
                 </button>
             </div>
 
@@ -195,13 +195,6 @@
                         <h3 class="font-poppins text-lg font-semibold">
                             Sources
                         </h3>
-                        <button
-                            class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
-                            aria-label="Add source"
-                            onclick={resetForm}
-                        >
-                            <Plus size={18} strokeWidth={2.4} />
-                        </button>
                     </div>
 
                     {#if $iptvSources.length > 0}

--- a/packages/app/src/pages/live/components/LiveSourceManager.svelte
+++ b/packages/app/src/pages/live/components/LiveSourceManager.svelte
@@ -1,0 +1,365 @@
+<script lang="ts">
+    import { tick } from "svelte";
+    import { Pencil, Plus, Trash2, X } from "@lucide/svelte";
+    import { trackEvent } from "../../../lib/analytics";
+    import {
+        addIptvSource,
+        iptvSources,
+        removeIptvSource,
+        updateIptvSource,
+    } from "../../../lib/iptv/store";
+    import type { IptvSource, IptvSourceKind } from "../../../lib/iptv/types";
+
+    interface IptvExample {
+        name: string;
+        m3uUrl: string;
+        epgUrl: string;
+    }
+
+    export let show = false;
+    export let selectedSourceId = "";
+    export let resetRequest = 0;
+    export let isDev = false;
+    export let iptvExample: IptvExample | null = null;
+    export let onSourceRemoved: (source: IptvSource) => void = () => {};
+
+    let editingSourceId: string | null = null;
+    let formKind: IptvSourceKind = "m3u";
+    let formName = "";
+    let formM3uUrl = "";
+    let formEpgUrl = "";
+    let formXtreamServerUrl = "";
+    let formXtreamUsername = "";
+    let formXtreamCredential = "";
+    let formError = "";
+    let lastResetRequest = resetRequest;
+
+    $: if (resetRequest !== lastResetRequest) {
+        lastResetRequest = resetRequest;
+        resetForm();
+    }
+
+    function focusOnMount(node: HTMLElement) {
+        void tick().then(() => node.focus());
+    }
+
+    function resetForm() {
+        editingSourceId = null;
+        formKind = "m3u";
+        formName = "";
+        formM3uUrl = "";
+        formEpgUrl = "";
+        formXtreamServerUrl = "";
+        formXtreamUsername = "";
+        formXtreamCredential = "";
+        formError = "";
+    }
+
+    function editSource(source: IptvSource) {
+        editingSourceId = source.id;
+        formKind = source.kind;
+        formName = source.name;
+        if (source.kind === "xtream") {
+            formM3uUrl = "";
+            formEpgUrl = "";
+            formXtreamServerUrl = source.serverUrl;
+            formXtreamUsername = source.username;
+            formXtreamCredential = source.credential;
+        } else {
+            formM3uUrl = source.m3uUrl;
+            formEpgUrl = source.epgUrl ?? "";
+            formXtreamServerUrl = "";
+            formXtreamUsername = "";
+            formXtreamCredential = "";
+        }
+        formError = "";
+    }
+
+    function setFormKind(kind: IptvSourceKind) {
+        formKind = kind;
+        formError = "";
+    }
+
+    function fillIptvExample() {
+        if (!iptvExample) return;
+        formKind = "m3u";
+        formName = iptvExample.name;
+        formM3uUrl = iptvExample.m3uUrl;
+        formEpgUrl = iptvExample.epgUrl;
+        formError = "";
+    }
+
+    function saveSource() {
+        try {
+            if (editingSourceId) {
+                const updated =
+                    formKind === "xtream"
+                        ? updateIptvSource(editingSourceId, {
+                              kind: "xtream",
+                              name: formName,
+                              serverUrl: formXtreamServerUrl,
+                              username: formXtreamUsername,
+                              credential: formXtreamCredential,
+                          })
+                        : updateIptvSource(editingSourceId, {
+                              kind: "m3u",
+                              name: formName,
+                              m3uUrl: formM3uUrl,
+                              epgUrl: formEpgUrl,
+                          });
+                if (!updated) {
+                    throw new Error("The selected IPTV source no longer exists");
+                }
+                selectedSourceId = updated.id;
+                trackEvent("iptv_source_updated");
+            } else {
+                const source =
+                    formKind === "xtream"
+                        ? addIptvSource({
+                              kind: "xtream",
+                              name: formName,
+                              serverUrl: formXtreamServerUrl,
+                              username: formXtreamUsername,
+                              credential: formXtreamCredential,
+                          })
+                        : addIptvSource({
+                              kind: "m3u",
+                              name: formName,
+                              m3uUrl: formM3uUrl,
+                              epgUrl: formEpgUrl,
+                          });
+                selectedSourceId = source.id;
+                trackEvent("iptv_source_added");
+            }
+            resetForm();
+        } catch (error) {
+            formError = error instanceof Error ? error.message : String(error);
+        }
+    }
+
+    function deleteSource(source: IptvSource) {
+        const confirmed =
+            typeof window === "undefined" ||
+            window.confirm(`Remove IPTV source "${source.name}"?`);
+        if (!confirmed) return;
+
+        removeIptvSource(source.id);
+        if (editingSourceId === source.id) {
+            resetForm();
+        }
+        onSourceRemoved(source);
+        trackEvent("iptv_source_removed");
+    }
+</script>
+
+{#if show}
+    <div
+        class="fixed inset-0 z-[220] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        onclick={(event) => {
+            if (event.currentTarget === event.target) show = false;
+        }}
+        onkeydown={(event) => {
+            if (event.key === "Escape") show = false;
+        }}
+        role="button"
+        tabindex="0"
+    >
+        <section
+            class="max-h-[92vh] w-full max-w-[1040px] overflow-y-auto rounded-[28px] border border-white/10 bg-[#2b2b2b]/95 p-5 shadow-[0_32px_100px_rgba(0,0,0,0.48)] backdrop-blur-xl"
+            role="dialog"
+            aria-modal="true"
+            tabindex="-1"
+            use:focusOnMount
+        >
+            <div class="mb-5 flex items-start justify-between gap-4">
+                <div>
+                    <h2 class="font-poppins text-2xl font-semibold">
+                        Live TV Sources
+                    </h2>
+                    <p class="mt-1 text-sm text-white/60">
+                        Add M3U playlists, Xtream accounts, and guide data.
+                    </p>
+                </div>
+                <button
+                    class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/8 text-white/72 transition-colors hover:bg-white/14 hover:text-white"
+                    aria-label="Close source manager"
+                    onclick={() => (show = false)}
+                >
+                    <X size={20} strokeWidth={2.2} />
+                </button>
+            </div>
+
+            <div class="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(360px,1.1fr)]">
+                <section class="rounded-[24px] bg-white/4 p-4">
+                    <div class="mb-4 flex items-center justify-between gap-3">
+                        <h3 class="font-poppins text-lg font-semibold">
+                            Sources
+                        </h3>
+                        <button
+                            class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
+                            aria-label="Add source"
+                            onclick={resetForm}
+                        >
+                            <Plus size={18} strokeWidth={2.4} />
+                        </button>
+                    </div>
+
+                    {#if $iptvSources.length > 0}
+                        <div class="flex max-h-[420px] flex-col gap-2 overflow-y-auto pr-1">
+                            {#each $iptvSources as source}
+                                <div
+                                    class={`flex flex-col gap-3 rounded-2xl border p-3 transition-colors sm:flex-row sm:items-center sm:justify-between ${
+                                        selectedSourceId === source.id
+                                            ? "border-white/18 bg-white/[0.10]"
+                                            : "border-white/8 bg-white/[0.04]"
+                                    }`}
+                                >
+                                    <button
+                                        class="min-w-0 flex-1 text-left"
+                                        onclick={() => (selectedSourceId = source.id)}
+                                    >
+                                        <p class="truncate font-medium text-white">
+                                            {source.name}
+                                        </p>
+                                        <p class="mt-1 text-xs uppercase tracking-[0.12em] text-white/42">
+                                            {source.kind === "xtream" ? "Xtream" : "M3U"}
+                                        </p>
+                                    </button>
+                                    <div class="flex shrink-0 gap-2">
+                                        <button
+                                            class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-white/14 hover:text-white"
+                                            aria-label={`Edit ${source.name}`}
+                                            onclick={() => editSource(source)}
+                                        >
+                                            <Pencil size={16} strokeWidth={2.2} />
+                                        </button>
+                                        <button
+                                            class="flex h-9 w-9 items-center justify-center rounded-full bg-white/8 text-white/70 transition-colors hover:bg-red-500/20 hover:text-red-100"
+                                            aria-label={`Remove ${source.name}`}
+                                            onclick={() => deleteSource(source)}
+                                        >
+                                            <Trash2 size={16} strokeWidth={2.2} />
+                                        </button>
+                                    </div>
+                                </div>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-5 text-sm text-white/56">
+                            No source configured yet.
+                        </div>
+                    {/if}
+                </section>
+
+                <section class="rounded-[24px] bg-white/4 p-4">
+                    <h3 class="font-poppins text-lg font-semibold">
+                        {editingSourceId ? "Edit Source" : "Add Source"}
+                    </h3>
+                    <div class="mt-4 flex flex-col gap-4">
+                        <label class="flex flex-col gap-2 text-sm text-white/62">
+                            Name
+                            <input
+                                class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                bind:value={formName}
+                            />
+                        </label>
+
+                        <div class="grid grid-cols-2 gap-1 rounded-full border border-white/10 bg-black/24 p-1">
+                            <button
+                                class={`h-9 rounded-full text-sm font-semibold transition-colors ${formKind === "m3u" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
+                                aria-pressed={formKind === "m3u"}
+                                onclick={() => setFormKind("m3u")}
+                            >
+                                M3U URL
+                            </button>
+                            <button
+                                class={`h-9 rounded-full text-sm font-semibold transition-colors ${formKind === "xtream" ? "bg-white text-black" : "text-white/62 hover:bg-white/8 hover:text-white"}`}
+                                aria-pressed={formKind === "xtream"}
+                                onclick={() => setFormKind("xtream")}
+                            >
+                                Xtream
+                            </button>
+                        </div>
+
+                        {#if formKind === "m3u"}
+                            <label class="flex flex-col gap-2 text-sm text-white/62">
+                                M3U URL
+                                <input
+                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                    bind:value={formM3uUrl}
+                                    inputmode="url"
+                                />
+                            </label>
+                            <label class="flex flex-col gap-2 text-sm text-white/62">
+                                XMLTV URL
+                                <input
+                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                    bind:value={formEpgUrl}
+                                    inputmode="url"
+                                />
+                            </label>
+                        {:else}
+                            <label class="flex flex-col gap-2 text-sm text-white/62">
+                                Server URL
+                                <input
+                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                    bind:value={formXtreamServerUrl}
+                                    inputmode="url"
+                                />
+                            </label>
+                            <label class="flex flex-col gap-2 text-sm text-white/62">
+                                Username
+                                <input
+                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                    bind:value={formXtreamUsername}
+                                    autocomplete="off"
+                                />
+                            </label>
+                            <label class="flex flex-col gap-2 text-sm text-white/62">
+                                Password
+                                <input
+                                    class="h-11 rounded-2xl border border-white/10 bg-black/24 px-4 text-white outline-none focus:border-white/35"
+                                    bind:value={formXtreamCredential}
+                                    type="password"
+                                    autocomplete="off"
+                                />
+                            </label>
+                        {/if}
+
+                        {#if formError}
+                            <div class="rounded-2xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                                {formError}
+                            </div>
+                        {/if}
+
+                        <div class="flex flex-wrap gap-2">
+                            <button
+                                class="h-11 flex-1 rounded-full bg-white px-5 text-sm font-semibold text-black transition-opacity hover:opacity-88"
+                                onclick={saveSource}
+                            >
+                                {editingSourceId ? "Save Source" : "Add Source"}
+                            </button>
+                            {#if editingSourceId}
+                                <button
+                                    class="h-11 flex-1 rounded-full bg-white/8 px-5 text-sm font-semibold text-white/78 transition-colors hover:bg-white/14"
+                                    onclick={resetForm}
+                                >
+                                    Cancel
+                                </button>
+                            {/if}
+                        </div>
+
+                        {#if isDev && iptvExample}
+                            <button
+                                class="h-10 rounded-full border border-white/10 text-sm text-white/60 transition-colors hover:bg-white/8 hover:text-white/82"
+                                onclick={fillIptvExample}
+                            >
+                                Use IPTV example
+                            </button>
+                        {/if}
+                    </div>
+                </section>
+            </div>
+        </section>
+    </div>
+{/if}

--- a/packages/app/src/pages/live/components/LiveSourceManager.svelte
+++ b/packages/app/src/pages/live/components/LiveSourceManager.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-    import { tick } from "svelte";
+    import { onDestroy, tick } from "svelte";
+    import { fade, scale } from "svelte/transition";
     import { Pencil, Trash2, X } from "@lucide/svelte";
     import { trackEvent } from "../../../lib/analytics";
+    import { withOverlayZoomStyle } from "../../../lib/overlayZoom";
     import {
         addIptvSource,
         iptvSources,
@@ -23,6 +25,20 @@
     export let iptvExample: IptvExample | null = null;
     export let onSourceRemoved: (source: IptvSource) => void = () => {};
 
+    const portal = (node: HTMLElement) => {
+        if (typeof document === "undefined") {
+            return { destroy() {} };
+        }
+        document.body.appendChild(node);
+        return {
+            destroy() {
+                if (node.parentNode) {
+                    node.parentNode.removeChild(node);
+                }
+            },
+        };
+    };
+
     let editingSourceId: string | null = null;
     let formKind: IptvSourceKind = "m3u";
     let formName = "";
@@ -33,6 +49,13 @@
     let formXtreamCredential = "";
     let formError = "";
     let lastResetRequest = resetRequest;
+    let bodyOverflowBeforeOpen: string | null = null;
+
+    $: if (show) {
+        lockBodyScroll();
+    } else {
+        unlockBodyScroll();
+    }
 
     $: if (resetRequest !== lastResetRequest) {
         lastResetRequest = resetRequest;
@@ -53,6 +76,22 @@
         formXtreamUsername = "";
         formXtreamCredential = "";
         formError = "";
+    }
+
+    function close() {
+        show = false;
+    }
+
+    function lockBodyScroll() {
+        if (typeof document === "undefined" || bodyOverflowBeforeOpen !== null) return;
+        bodyOverflowBeforeOpen = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+    }
+
+    function unlockBodyScroll() {
+        if (typeof document === "undefined" || bodyOverflowBeforeOpen === null) return;
+        document.body.style.overflow = bodyOverflowBeforeOpen;
+        bodyOverflowBeforeOpen = null;
     }
 
     function editSource(source: IptvSource) {
@@ -150,26 +189,37 @@
         onSourceRemoved(source);
         trackEvent("iptv_source_removed");
     }
+
+    onDestroy(unlockBodyScroll);
 </script>
 
 {#if show}
     <div
-        class="fixed inset-0 z-[220] flex items-center justify-center bg-[#101010]/56 p-5 backdrop-blur-xl md:p-8"
+        use:portal
+        class="fixed inset-0 z-[220] flex items-center justify-center bg-[#101010]/56 backdrop-blur-xl"
+        transition:fade={{ duration: 200 }}
         onclick={(event) => {
-            if (event.currentTarget === event.target) show = false;
+            if (event.currentTarget === event.target) close();
         }}
         onkeydown={(event) => {
-            if (event.key === "Escape") show = false;
+            if (event.key === "Escape") close();
+        }}
+        onwheel={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
         }}
         role="button"
         tabindex="0"
+        style={withOverlayZoomStyle("padding: clamp(20px, 5vw, 150px);")}
     >
         <section
-            class="max-h-[92vh] w-full max-w-[1040px] overflow-y-auto rounded-4xl bg-[#2b2b2b]/56 p-6 shadow-[0_40px_160px_rgba(0,0,0,0.45)] backdrop-blur-[40px] md:p-8"
+            class="max-h-full w-full max-w-[1040px] overflow-y-auto rounded-4xl bg-[#2b2b2b]/56 p-6 shadow-[0_40px_160px_rgba(0,0,0,0.45)] backdrop-blur-[40px] md:p-8"
+            transition:scale={{ start: 0.95, duration: 200 }}
             role="dialog"
             aria-modal="true"
             tabindex="-1"
             use:focusOnMount
+            onwheel={(event) => event.stopPropagation()}
         >
             <div class="mb-5 flex items-start justify-between gap-4">
                 <div>
@@ -183,7 +233,7 @@
                 <button
                     class="shrink-0 cursor-pointer text-white/50 transition-colors hover:text-white"
                     aria-label="Close source manager"
-                    onclick={() => (show = false)}
+                    onclick={close}
                 >
                     <X size={24} strokeWidth={2} />
                 </button>

--- a/packages/app/src/pages/live/components/LiveSourceSelector.svelte
+++ b/packages/app/src/pages/live/components/LiveSourceSelector.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import {
+        Check,
+        ChevronDown,
+        Database,
+        Plus,
+        RefreshCw,
+        Settings2,
+    } from "@lucide/svelte";
+    import LoadingSpinner from "../../../components/common/LoadingSpinner.svelte";
+    import type { IptvSource } from "../../../lib/iptv/types";
+
+    export let sources: IptvSource[] = [];
+    export let selectedSourceId = "";
+    export let sourceSummary = "";
+    export let refreshedLabel = "";
+    export let refreshing = false;
+    export let onManage: () => void = () => {};
+    export let onRefresh: () => void = () => {};
+
+    let open = false;
+    let root: HTMLDivElement;
+
+    $: selectedSource =
+        sources.find((source) => source.id === selectedSourceId) ?? null;
+    $: canRefresh = Boolean(selectedSource) && !refreshing;
+
+    function toggleMenu(event: MouseEvent) {
+        event.stopPropagation();
+        open = !open;
+    }
+
+    function closeMenu() {
+        open = false;
+    }
+
+    function selectSource(sourceId: string) {
+        selectedSourceId = sourceId;
+        closeMenu();
+    }
+
+    function openManager() {
+        closeMenu();
+        onManage();
+    }
+
+    function refreshSource() {
+        if (!canRefresh) return;
+        closeMenu();
+        onRefresh();
+    }
+
+    function handleDocumentPointerDown(event: PointerEvent) {
+        if (root && !root.contains(event.target as Node)) {
+            closeMenu();
+        }
+    }
+
+    onMount(() => {
+        document.addEventListener("pointerdown", handleDocumentPointerDown);
+        return () => {
+            document.removeEventListener("pointerdown", handleDocumentPointerDown);
+        };
+    });
+</script>
+
+<svelte:window onkeydown={(event) => {
+    if (event.key === "Escape") closeMenu();
+}} />
+
+<div class="relative" bind:this={root}>
+    <button
+        type="button"
+        class="flex h-[80px] w-[242px] items-center gap-3 rounded-[24px] bg-[#2C2C2C]/80 px-4 text-left backdrop-blur-md transition-colors hover:bg-[#2C2C2C]/60"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onclick={toggleMenu}
+    >
+        <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-white/8 text-white/72">
+            <Database size={22} strokeWidth={2.2} />
+        </span>
+        <span class="min-w-0 flex-1">
+            <span class="block truncate font-poppins text-base font-semibold text-white">
+                {selectedSource?.name ?? "Live source"}
+            </span>
+            <span class="mt-0.5 block truncate text-xs text-white/48">
+                {refreshedLabel || sourceSummary}
+            </span>
+        </span>
+        <ChevronDown
+            size={19}
+            strokeWidth={2.2}
+            class={`shrink-0 text-white/54 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+    </button>
+
+    {#if open}
+        <div
+            class="absolute left-0 top-[calc(100%+10px)] z-[260] w-[330px] overflow-hidden rounded-[24px] border border-white/10 bg-[#181818]/96 p-2 shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur-xl"
+            role="listbox"
+        >
+            {#if sources.length > 0}
+                <div class="max-h-[310px] overflow-y-auto pr-1">
+                    {#each sources as source}
+                        <button
+                            type="button"
+                            class={`flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors ${
+                                selectedSourceId === source.id
+                                    ? "bg-white/[0.12] text-white"
+                                    : "text-white/76 hover:bg-white/[0.07] hover:text-white"
+                            }`}
+                            role="option"
+                            aria-selected={selectedSourceId === source.id}
+                            onclick={() => selectSource(source.id)}
+                        >
+                            <span class="min-w-0 flex-1">
+                                <span class="block truncate text-sm font-semibold">
+                                    {source.name}
+                                </span>
+                                <span class="mt-0.5 block text-xs uppercase tracking-[0.12em] text-white/38">
+                                    {source.kind === "xtream" ? "Xtream" : "M3U"}
+                                </span>
+                            </span>
+                            {#if selectedSourceId === source.id}
+                                <Check size={18} strokeWidth={2.4} class="shrink-0" />
+                            {/if}
+                        </button>
+                    {/each}
+                </div>
+            {:else}
+                <div class="px-3 py-5 text-sm text-white/54">
+                    No source configured yet.
+                </div>
+            {/if}
+
+            <div class="mt-2 grid grid-cols-2 gap-2 border-t border-white/10 pt-2">
+                <button
+                    type="button"
+                    class="flex h-11 items-center justify-center gap-2 rounded-full bg-white/8 px-3 text-sm font-semibold text-white/74 transition-colors hover:bg-white/14 hover:text-white"
+                    onclick={openManager}
+                >
+                    {#if sources.length > 0}
+                        <Settings2 size={17} strokeWidth={2.2} />
+                        Sources
+                    {:else}
+                        <Plus size={17} strokeWidth={2.2} />
+                        Add
+                    {/if}
+                </button>
+                <button
+                    type="button"
+                    class="flex h-11 items-center justify-center gap-2 rounded-full bg-white px-3 text-sm font-semibold text-black transition-opacity hover:opacity-88 disabled:cursor-not-allowed disabled:opacity-45"
+                    disabled={!canRefresh}
+                    onclick={refreshSource}
+                >
+                    {#if refreshing}
+                        <LoadingSpinner size="15px" color="#111111" />
+                    {:else}
+                        <RefreshCw size={17} strokeWidth={2.2} />
+                    {/if}
+                    Refresh
+                </button>
+            </div>
+        </div>
+    {/if}
+</div>

--- a/packages/app/src/pages/live/liveHelpers.test.ts
+++ b/packages/app/src/pages/live/liveHelpers.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    LIVE_TV_REFRESH_INTERVAL_MS,
+    LIVE_TV_SELECTION_STORAGE_KEY,
+    getStoredLiveTvGroup,
+    getStoredLiveTvSelection,
+    isLiveTvRefreshDue,
+    setStoredLiveTvGroup,
+    setStoredLiveTvSourceId,
+    shouldAutoRefreshLiveTvSource,
+} from "./liveHelpers";
+
+class MemoryStorage {
+    private values = new Map<string, string>();
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    clear() {
+        this.values.clear();
+    }
+}
+
+describe("Live TV selection persistence", () => {
+    let storage: MemoryStorage;
+
+    beforeEach(() => {
+        storage = new MemoryStorage();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: storage,
+            configurable: true,
+        });
+    });
+
+    test("persists the selected source and groups per source", () => {
+        setStoredLiveTvSourceId(" source-1 ");
+        setStoredLiveTvGroup("source-1", " News ");
+        setStoredLiveTvGroup("source-2", "Sports");
+
+        expect(getStoredLiveTvSelection()).toEqual({
+            sourceId: "source-1",
+            groupsBySourceId: {
+                "source-1": "News",
+                "source-2": "Sports",
+            },
+        });
+        expect(getStoredLiveTvGroup("source-1")).toBe("News");
+    });
+
+    test("drops malformed persisted values", () => {
+        storage.setItem(
+            LIVE_TV_SELECTION_STORAGE_KEY,
+            JSON.stringify({
+                sourceId: 42,
+                groupsBySourceId: {
+                    good: "Documentaries",
+                    empty: " ",
+                    bad: null,
+                },
+            }),
+        );
+
+        expect(getStoredLiveTvSelection()).toEqual({
+            sourceId: "",
+            groupsBySourceId: {
+                good: "Documentaries",
+            },
+        });
+    });
+
+    test("returns defaults when storage has invalid JSON", () => {
+        storage.setItem(LIVE_TV_SELECTION_STORAGE_KEY, "{");
+
+        expect(getStoredLiveTvSelection()).toEqual({
+            sourceId: "",
+            groupsBySourceId: {},
+        });
+    });
+});
+
+describe("Live TV refresh schedule", () => {
+    const now = new Date("2026-06-22T20:00:00.000Z");
+
+    test("treats missing or invalid cache timestamps as due", () => {
+        expect(isLiveTvRefreshDue(null, now)).toBe(true);
+        expect(isLiveTvRefreshDue("not-a-date", now)).toBe(true);
+    });
+
+    test("keeps fresh guide data until the scheduled interval elapses", () => {
+        const freshLoadedAt = new Date(now.getTime() - LIVE_TV_REFRESH_INTERVAL_MS + 1).toISOString();
+        const staleLoadedAt = new Date(now.getTime() - LIVE_TV_REFRESH_INTERVAL_MS - 1).toISOString();
+
+        expect(isLiveTvRefreshDue(freshLoadedAt, now)).toBe(false);
+        expect(isLiveTvRefreshDue(staleLoadedAt, now)).toBe(true);
+    });
+
+    test("refreshes old caches that have channel data but no persisted guide", () => {
+        const source = {
+            id: "source-1",
+            kind: "m3u" as const,
+            name: "Dispatcharr",
+            m3uUrl: "https://dispatcharr.example.test/output/m3u",
+            epgUrl: "https://dispatcharr.example.test/output/epg",
+            createdAt: "2026-06-22T10:00:00.000Z",
+            updatedAt: "2026-06-22T10:00:00.000Z",
+        };
+        const freshCacheWithoutGuide = {
+            loadedAt: now.toISOString(),
+            channels: [],
+            groups: [],
+            stats: {
+                channelCount: 1,
+                groupCount: 1,
+                programmeCount: 12,
+            },
+        };
+
+        expect(shouldAutoRefreshLiveTvSource(source, freshCacheWithoutGuide, now)).toBe(true);
+    });
+});

--- a/packages/app/src/pages/live/liveHelpers.test.ts
+++ b/packages/app/src/pages/live/liveHelpers.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
+    FAVORITES_GROUP,
     LIVE_TV_REFRESH_INTERVAL_MS,
     LIVE_TV_SELECTION_STORAGE_KEY,
+    getStoredLiveTvFavoriteChannelIds,
     getStoredLiveTvGroup,
     getStoredLiveTvSelection,
+    getVisibleChannels,
     isLiveTvRefreshDue,
+    setStoredLiveTvFavoriteChannelIds,
     setStoredLiveTvGroup,
     setStoredLiveTvSourceId,
     shouldAutoRefreshLiveTvSource,
+    toggleStoredLiveTvFavoriteChannelId,
 } from "./liveHelpers";
 
 class MemoryStorage {
@@ -52,6 +57,7 @@ describe("Live TV selection persistence", () => {
                 "source-1": "News",
                 "source-2": "Sports",
             },
+            favoritesBySourceId: {},
         });
         expect(getStoredLiveTvGroup("source-1")).toBe("News");
     });
@@ -74,6 +80,7 @@ describe("Live TV selection persistence", () => {
             groupsBySourceId: {
                 good: "Documentaries",
             },
+            favoritesBySourceId: {},
         });
     });
 
@@ -83,7 +90,83 @@ describe("Live TV selection persistence", () => {
         expect(getStoredLiveTvSelection()).toEqual({
             sourceId: "",
             groupsBySourceId: {},
+            favoritesBySourceId: {},
         });
+    });
+
+    test("persists favorite channel ids per source and toggles membership", () => {
+        setStoredLiveTvFavoriteChannelIds(" source-1 ", [
+            " abc ",
+            "abc",
+            " ",
+            "bbc",
+        ]);
+
+        expect(getStoredLiveTvFavoriteChannelIds("source-1")).toEqual(["abc", "bbc"]);
+        expect(toggleStoredLiveTvFavoriteChannelId("source-1", " bbc ")).toEqual(["abc"]);
+        expect(toggleStoredLiveTvFavoriteChannelId("source-1", "cnn")).toEqual(["abc", "cnn"]);
+        expect(getStoredLiveTvFavoriteChannelIds("source-1")).toEqual(["abc", "cnn"]);
+        expect(getStoredLiveTvFavoriteChannelIds("source-2")).toEqual([]);
+    });
+
+    test("drops malformed persisted favorite channel ids", () => {
+        storage.setItem(
+            LIVE_TV_SELECTION_STORAGE_KEY,
+            JSON.stringify({
+                sourceId: "source-1",
+                groupsBySourceId: {},
+                favoritesBySourceId: {
+                    "source-1": ["abc", " ", 42, "bbc", "abc"],
+                    empty: [],
+                    bad: "not-an-array",
+                },
+            }),
+        );
+
+        expect(getStoredLiveTvSelection()).toEqual({
+            sourceId: "source-1",
+            groupsBySourceId: {},
+            favoritesBySourceId: {
+                "source-1": ["abc", "bbc"],
+            },
+        });
+    });
+});
+
+describe("Live TV visible channel filtering", () => {
+    const channels = [
+        {
+            id: "abc",
+            sourceId: "source-1",
+            name: "ABC News",
+            url: "https://example.test/abc.m3u8",
+            group: "News",
+            order: 0,
+        },
+        {
+            id: "espn",
+            sourceId: "source-1",
+            name: "ESPN",
+            url: "https://example.test/espn.m3u8",
+            group: "Sports",
+            order: 1,
+        },
+        {
+            id: "bbc",
+            sourceId: "source-1",
+            name: "BBC World",
+            url: "https://example.test/bbc.m3u8",
+            group: "News",
+            order: 2,
+        },
+    ];
+
+    test("filters the virtual Favorites group by persisted favorite ids", () => {
+        expect(getVisibleChannels(channels, FAVORITES_GROUP, "", ["espn", "missing", "abc"]).map((channel) => channel.id)).toEqual(["abc", "espn"]);
+    });
+
+    test("applies search inside the virtual Favorites group", () => {
+        expect(getVisibleChannels(channels, FAVORITES_GROUP, "news", ["espn", "abc"]).map((channel) => channel.id)).toEqual(["abc"]);
     });
 });
 

--- a/packages/app/src/pages/live/liveHelpers.test.ts
+++ b/packages/app/src/pages/live/liveHelpers.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
+    ALL_GROUPS,
     FAVORITES_GROUP,
     LIVE_TV_REFRESH_INTERVAL_MS,
     LIVE_TV_SELECTION_STORAGE_KEY,
     getStoredLiveTvFavoriteChannelIds,
     getStoredLiveTvGroup,
+    getStoredLiveTvLastChannelId,
     getStoredLiveTvSelection,
     getVisibleChannels,
+    getVisibleLiveTvGroups,
     isLiveTvRefreshDue,
+    normalizeLiveTvGroup,
     setStoredLiveTvFavoriteChannelIds,
     setStoredLiveTvGroup,
+    setStoredLiveTvLastChannelId,
     setStoredLiveTvSourceId,
     shouldAutoRefreshLiveTvSource,
     toggleStoredLiveTvFavoriteChannelId,
@@ -58,6 +63,7 @@ describe("Live TV selection persistence", () => {
                 "source-2": "Sports",
             },
             favoritesBySourceId: {},
+            lastChannelIdsBySourceId: {},
         });
         expect(getStoredLiveTvGroup("source-1")).toBe("News");
     });
@@ -81,6 +87,7 @@ describe("Live TV selection persistence", () => {
                 good: "Documentaries",
             },
             favoritesBySourceId: {},
+            lastChannelIdsBySourceId: {},
         });
     });
 
@@ -91,6 +98,7 @@ describe("Live TV selection persistence", () => {
             sourceId: "",
             groupsBySourceId: {},
             favoritesBySourceId: {},
+            lastChannelIdsBySourceId: {},
         });
     });
 
@@ -109,6 +117,18 @@ describe("Live TV selection persistence", () => {
         expect(getStoredLiveTvFavoriteChannelIds("source-2")).toEqual([]);
     });
 
+    test("persists the last played channel per source", () => {
+        setStoredLiveTvLastChannelId(" source-1 ", " abc ");
+        setStoredLiveTvLastChannelId("source-2", "espn");
+
+        expect(getStoredLiveTvLastChannelId("source-1")).toBe("abc");
+        expect(getStoredLiveTvLastChannelId("source-2")).toBe("espn");
+        expect(getStoredLiveTvSelection().lastChannelIdsBySourceId).toEqual({
+            "source-1": "abc",
+            "source-2": "espn",
+        });
+    });
+
     test("drops malformed persisted favorite channel ids", () => {
         storage.setItem(
             LIVE_TV_SELECTION_STORAGE_KEY,
@@ -120,6 +140,11 @@ describe("Live TV selection persistence", () => {
                     empty: [],
                     bad: "not-an-array",
                 },
+                lastChannelIdsBySourceId: {
+                    "source-1": " abc ",
+                    empty: " ",
+                    bad: 42,
+                },
             }),
         );
 
@@ -128,6 +153,9 @@ describe("Live TV selection persistence", () => {
             groupsBySourceId: {},
             favoritesBySourceId: {
                 "source-1": ["abc", "bbc"],
+            },
+            lastChannelIdsBySourceId: {
+                "source-1": "abc",
             },
         });
     });
@@ -167,6 +195,38 @@ describe("Live TV visible channel filtering", () => {
 
     test("applies search inside the virtual Favorites group", () => {
         expect(getVisibleChannels(channels, FAVORITES_GROUP, "news", ["espn", "abc"]).map((channel) => channel.id)).toEqual(["abc"]);
+    });
+
+    test("falls back unknown persisted groups to all channels", () => {
+        expect(getVisibleChannels(channels, "Removed Group", "", []).map((channel) => channel.id)).toEqual(["abc", "espn", "bbc"]);
+    });
+});
+
+describe("Live TV group filtering", () => {
+    const groups = [
+        { id: "news", name: "News", channelCount: 12 },
+        { id: "sports", name: "Sports", channelCount: 8 },
+        { id: "kids", name: "Kids", channelCount: 4 },
+    ];
+
+    test("returns every group when the group search is empty", () => {
+        expect(getVisibleLiveTvGroups(groups, "  ").map((group) => group.name)).toEqual([
+            "News",
+            "Sports",
+            "Kids",
+        ]);
+    });
+
+    test("filters groups case-insensitively by name", () => {
+        expect(getVisibleLiveTvGroups(groups, "SP").map((group) => group.name)).toEqual([
+            "Sports",
+        ]);
+    });
+
+    test("normalizes removed persisted groups back to all groups", () => {
+        expect(normalizeLiveTvGroup("Sports", groups)).toBe("Sports");
+        expect(normalizeLiveTvGroup(FAVORITES_GROUP, groups)).toBe(FAVORITES_GROUP);
+        expect(normalizeLiveTvGroup("Removed Group", groups)).toBe(ALL_GROUPS);
     });
 });
 

--- a/packages/app/src/pages/live/liveHelpers.ts
+++ b/packages/app/src/pages/live/liveHelpers.ts
@@ -7,6 +7,8 @@ import type {
 } from "../../lib/iptv/types";
 
 export const ALL_GROUPS = "__all__";
+export const FAVORITES_GROUP = "__favorites__";
+export const FAVORITES_GROUP_LABEL = "Favorites";
 export const GUIDE_VIEWPORT_HOURS = 2;
 export const GUIDE_INITIAL_CHANNEL_LIMIT = 100;
 export const GUIDE_CHANNEL_PAGE_SIZE = 100;
@@ -24,10 +26,11 @@ export interface GuideTimeTick {
 export interface LiveTvSelection {
     sourceId: string;
     groupsBySourceId: Record<string, string>;
+    favoritesBySourceId: Record<string, string[]>;
 }
 
 function createDefaultLiveTvSelection(): LiveTvSelection {
-    return { sourceId: "", groupsBySourceId: {} };
+    return { sourceId: "", groupsBySourceId: {}, favoritesBySourceId: {} };
 }
 
 function getStorage(): Storage | null {
@@ -62,6 +65,32 @@ function cleanGroupsBySourceId(value: unknown): Record<string, string> {
     return groupsBySourceId;
 }
 
+function cleanFavoriteChannelIds(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+
+    return Array.from(
+        new Set(
+            value
+                .map(cleanStoredString)
+                .filter((channelId) => Boolean(channelId)),
+        ),
+    );
+}
+
+function cleanFavoritesBySourceId(value: unknown): Record<string, string[]> {
+    if (!isRecord(value)) return {};
+
+    const favoritesBySourceId: Record<string, string[]> = {};
+    for (const [sourceId, channelIds] of Object.entries(value)) {
+        const cleanSourceId = cleanStoredString(sourceId);
+        const cleanChannelIds = cleanFavoriteChannelIds(channelIds);
+        if (cleanSourceId && cleanChannelIds.length > 0) {
+            favoritesBySourceId[cleanSourceId] = cleanChannelIds;
+        }
+    }
+    return favoritesBySourceId;
+}
+
 export function getStoredLiveTvSelection(): LiveTvSelection {
     const storage = getStorage();
     if (!storage) {
@@ -82,6 +111,7 @@ export function getStoredLiveTvSelection(): LiveTvSelection {
         return {
             sourceId: cleanStoredString(parsed.sourceId),
             groupsBySourceId: cleanGroupsBySourceId(parsed.groupsBySourceId),
+            favoritesBySourceId: cleanFavoritesBySourceId(parsed.favoritesBySourceId),
         };
     } catch {
         return createDefaultLiveTvSelection();
@@ -121,6 +151,40 @@ export function setStoredLiveTvGroup(sourceId: string, group: string) {
     persistLiveTvSelection(selection);
 }
 
+export function getStoredLiveTvFavoriteChannelIds(sourceId: string) {
+    const cleanSourceId = sourceId.trim();
+    if (!cleanSourceId) return [];
+    return getStoredLiveTvSelection().favoritesBySourceId[cleanSourceId] ?? [];
+}
+
+export function setStoredLiveTvFavoriteChannelIds(sourceId: string, channelIds: string[]) {
+    const cleanSourceId = sourceId.trim();
+    if (!cleanSourceId) return [];
+
+    const selection = getStoredLiveTvSelection();
+    const cleanChannelIds = cleanFavoriteChannelIds(channelIds);
+    if (cleanChannelIds.length > 0) {
+        selection.favoritesBySourceId[cleanSourceId] = cleanChannelIds;
+    } else {
+        delete selection.favoritesBySourceId[cleanSourceId];
+    }
+    persistLiveTvSelection(selection);
+    return cleanChannelIds;
+}
+
+export function toggleStoredLiveTvFavoriteChannelId(sourceId: string, channelId: string) {
+    const cleanChannelId = channelId.trim();
+    if (!cleanChannelId) {
+        return getStoredLiveTvFavoriteChannelIds(sourceId);
+    }
+
+    const current = getStoredLiveTvFavoriteChannelIds(sourceId);
+    const next = current.includes(cleanChannelId)
+        ? current.filter((favoriteChannelId) => favoriteChannelId !== cleanChannelId)
+        : [...current, cleanChannelId];
+    return setStoredLiveTvFavoriteChannelIds(sourceId, next);
+}
+
 export function isLiveTvRefreshDue(
     loadedAt: string | null | undefined,
     now: Date = new Date(),
@@ -151,10 +215,14 @@ export function getVisibleChannels(
     channels: IptvChannel[],
     group: string,
     query: string,
+    favoriteChannelIds: string[] = [],
 ) {
     const normalizedQuery = query.trim().toLowerCase();
+    const favoriteChannelIdSet =
+        group === FAVORITES_GROUP ? new Set(favoriteChannelIds) : null;
     return channels.filter((channel) => {
-        if (group !== ALL_GROUPS && channel.group !== group) return false;
+        if (favoriteChannelIdSet && !favoriteChannelIdSet.has(channel.id)) return false;
+        if (!favoriteChannelIdSet && group !== ALL_GROUPS && channel.group !== group) return false;
         if (!normalizedQuery) return true;
 
         return (

--- a/packages/app/src/pages/live/liveHelpers.ts
+++ b/packages/app/src/pages/live/liveHelpers.ts
@@ -10,11 +10,141 @@ export const ALL_GROUPS = "__all__";
 export const GUIDE_VIEWPORT_HOURS = 2;
 export const GUIDE_INITIAL_CHANNEL_LIMIT = 100;
 export const GUIDE_CHANNEL_PAGE_SIZE = 100;
+export const LIVE_TV_SELECTION_STORAGE_KEY = "raffi_live_tv_selection_v1";
+export const LIVE_TV_REFRESH_INTERVAL_MS = 6 * 60 * 60_000;
+export const LIVE_TV_REFRESH_CHECK_INTERVAL_MS = 60_000;
+export const LIVE_TV_AUTO_REFRESH_RETRY_MS = 15 * 60_000;
 
 export interface GuideTimeTick {
     value: Date;
     label: string;
     leftPercent: number;
+}
+
+export interface LiveTvSelection {
+    sourceId: string;
+    groupsBySourceId: Record<string, string>;
+}
+
+function createDefaultLiveTvSelection(): LiveTvSelection {
+    return { sourceId: "", groupsBySourceId: {} };
+}
+
+function getStorage(): Storage | null {
+    try {
+        return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch {
+        return null;
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function cleanStoredString(value: unknown): string {
+    return typeof value === "string" ? value.trim() : "";
+}
+
+function cleanGroupsBySourceId(value: unknown): Record<string, string> {
+    if (!isRecord(value)) {
+        return {};
+    }
+
+    const groupsBySourceId: Record<string, string> = {};
+    for (const [sourceId, group] of Object.entries(value)) {
+        const cleanSourceId = cleanStoredString(sourceId);
+        const cleanGroup = cleanStoredString(group);
+        if (cleanSourceId && cleanGroup) {
+            groupsBySourceId[cleanSourceId] = cleanGroup;
+        }
+    }
+    return groupsBySourceId;
+}
+
+export function getStoredLiveTvSelection(): LiveTvSelection {
+    const storage = getStorage();
+    if (!storage) {
+        return createDefaultLiveTvSelection();
+    }
+
+    try {
+        const raw = storage.getItem(LIVE_TV_SELECTION_STORAGE_KEY);
+        if (!raw) {
+            return createDefaultLiveTvSelection();
+        }
+
+        const parsed = JSON.parse(raw) as unknown;
+        if (!isRecord(parsed)) {
+            return createDefaultLiveTvSelection();
+        }
+
+        return {
+            sourceId: cleanStoredString(parsed.sourceId),
+            groupsBySourceId: cleanGroupsBySourceId(parsed.groupsBySourceId),
+        };
+    } catch {
+        return createDefaultLiveTvSelection();
+    }
+}
+
+function persistLiveTvSelection(selection: LiveTvSelection) {
+    const storage = getStorage();
+    if (!storage) return;
+
+    try {
+        storage.setItem(LIVE_TV_SELECTION_STORAGE_KEY, JSON.stringify(selection));
+    } catch {
+        // Live TV selection should stay usable even when persistence is unavailable.
+    }
+}
+
+export function setStoredLiveTvSourceId(sourceId: string) {
+    const selection = getStoredLiveTvSelection();
+    selection.sourceId = sourceId.trim();
+    persistLiveTvSelection(selection);
+}
+
+export function getStoredLiveTvGroup(sourceId: string) {
+    const cleanSourceId = sourceId.trim();
+    if (!cleanSourceId) return "";
+    return getStoredLiveTvSelection().groupsBySourceId[cleanSourceId] ?? "";
+}
+
+export function setStoredLiveTvGroup(sourceId: string, group: string) {
+    const cleanSourceId = sourceId.trim();
+    const cleanGroup = group.trim();
+    if (!cleanSourceId || !cleanGroup) return;
+
+    const selection = getStoredLiveTvSelection();
+    selection.groupsBySourceId[cleanSourceId] = cleanGroup;
+    persistLiveTvSelection(selection);
+}
+
+export function isLiveTvRefreshDue(
+    loadedAt: string | null | undefined,
+    now: Date = new Date(),
+): boolean {
+    if (!loadedAt) return true;
+    const loadedAtMs = new Date(loadedAt).getTime();
+    if (!Number.isFinite(loadedAtMs)) return true;
+    return now.getTime() - loadedAtMs >= LIVE_TV_REFRESH_INTERVAL_MS;
+}
+
+export function shouldAutoRefreshLiveTvSource(
+    source: IptvSource,
+    result: IptvRefreshResult | null,
+    now: Date = new Date(),
+): boolean {
+    if (!result) return true;
+
+    const sourceCanHaveGuide = source.kind === "xtream" || Boolean(source.epgUrl);
+    const cachedStatsSayGuideExists = result.stats.programmeCount > 0;
+    if (sourceCanHaveGuide && cachedStatsSayGuideExists && !result.guide) {
+        return true;
+    }
+
+    return isLiveTvRefreshDue(result.loadedAt, now);
 }
 
 export function getVisibleChannels(

--- a/packages/app/src/pages/live/liveHelpers.ts
+++ b/packages/app/src/pages/live/liveHelpers.ts
@@ -1,0 +1,116 @@
+import { getIptvSourceCacheFingerprint } from "../../lib/iptv/cache";
+import type { GuideGridViewport } from "../../lib/iptv/guideGrid";
+import type {
+    IptvChannel,
+    IptvRefreshResult,
+    IptvSource,
+} from "../../lib/iptv/types";
+
+export const ALL_GROUPS = "__all__";
+export const GUIDE_VIEWPORT_HOURS = 2;
+export const GUIDE_INITIAL_CHANNEL_LIMIT = 100;
+export const GUIDE_CHANNEL_PAGE_SIZE = 100;
+
+export interface GuideTimeTick {
+    value: Date;
+    label: string;
+    leftPercent: number;
+}
+
+export function getVisibleChannels(
+    channels: IptvChannel[],
+    group: string,
+    query: string,
+) {
+    const normalizedQuery = query.trim().toLowerCase();
+    return channels.filter((channel) => {
+        if (group !== ALL_GROUPS && channel.group !== group) return false;
+        if (!normalizedQuery) return true;
+
+        return (
+            channel.name.toLowerCase().includes(normalizedQuery) ||
+            channel.group.toLowerCase().includes(normalizedQuery) ||
+            (channel.tvgName ?? "").toLowerCase().includes(normalizedQuery) ||
+            (channel.tvgId ?? "").toLowerCase().includes(normalizedQuery)
+        );
+    });
+}
+
+export function getLiveSourceCacheKey(source: IptvSource) {
+    return `${source.id}\n${getIptvSourceCacheFingerprint(source)}`;
+}
+
+export function getLiveSourceSummary(
+    currentResult: IptvRefreshResult | null,
+    selectedSource: IptvSource | null,
+) {
+    if (currentResult) {
+        return `${currentResult.stats.channelCount} channels / ${currentResult.stats.groupCount} groups`;
+    }
+
+    return selectedSource
+        ? "Refresh this source to load channels"
+        : "Add a source to start watching";
+}
+
+export function getGuideViewport(now: Date): GuideGridViewport {
+    const viewportStart = new Date(now);
+    viewportStart.setMinutes(0, 0, 0);
+
+    return {
+        viewportStart,
+        viewportEnd: new Date(
+            viewportStart.getTime() + GUIDE_VIEWPORT_HOURS * 60 * 60_000,
+        ),
+        now,
+    };
+}
+
+function getTimePercent(value: Date, viewport: GuideGridViewport) {
+    const viewportStartMs = viewport.viewportStart.getTime();
+    const viewportDurationMs = viewport.viewportEnd.getTime() - viewportStartMs;
+
+    if (viewportDurationMs <= 0) return 0;
+
+    return ((value.getTime() - viewportStartMs) / viewportDurationMs) * 100;
+}
+
+export function buildGuideTimeTicks(viewport: GuideGridViewport) {
+    const ticks: GuideTimeTick[] = [];
+    const tickMs = 30 * 60_000;
+
+    for (
+        let timestamp = viewport.viewportStart.getTime();
+        timestamp <= viewport.viewportEnd.getTime();
+        timestamp += tickMs
+    ) {
+        const value = new Date(timestamp);
+        ticks.push({
+            value,
+            label: formatTime(value),
+            leftPercent: getTimePercent(value, viewport),
+        });
+    }
+
+    return ticks;
+}
+
+export function formatTime(value: Date) {
+    return new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+    }).format(value);
+}
+
+export function formatLoadedAt(value: string) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return "Unknown";
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+    }).format(parsed);
+}

--- a/packages/app/src/pages/live/liveHelpers.ts
+++ b/packages/app/src/pages/live/liveHelpers.ts
@@ -2,6 +2,7 @@ import { getIptvSourceCacheFingerprint } from "../../lib/iptv/cache";
 import type { GuideGridViewport } from "../../lib/iptv/guideGrid";
 import type {
     IptvChannel,
+    IptvGroup,
     IptvRefreshResult,
     IptvSource,
 } from "../../lib/iptv/types";
@@ -27,10 +28,16 @@ export interface LiveTvSelection {
     sourceId: string;
     groupsBySourceId: Record<string, string>;
     favoritesBySourceId: Record<string, string[]>;
+    lastChannelIdsBySourceId: Record<string, string>;
 }
 
 function createDefaultLiveTvSelection(): LiveTvSelection {
-    return { sourceId: "", groupsBySourceId: {}, favoritesBySourceId: {} };
+    return {
+        sourceId: "",
+        groupsBySourceId: {},
+        favoritesBySourceId: {},
+        lastChannelIdsBySourceId: {},
+    };
 }
 
 function getStorage(): Storage | null {
@@ -63,6 +70,22 @@ function cleanGroupsBySourceId(value: unknown): Record<string, string> {
         }
     }
     return groupsBySourceId;
+}
+
+function cleanStringBySourceId(value: unknown): Record<string, string> {
+    if (!isRecord(value)) {
+        return {};
+    }
+
+    const stringsBySourceId: Record<string, string> = {};
+    for (const [sourceId, rawValue] of Object.entries(value)) {
+        const cleanSourceId = cleanStoredString(sourceId);
+        const cleanValue = cleanStoredString(rawValue);
+        if (cleanSourceId && cleanValue) {
+            stringsBySourceId[cleanSourceId] = cleanValue;
+        }
+    }
+    return stringsBySourceId;
 }
 
 function cleanFavoriteChannelIds(value: unknown): string[] {
@@ -112,6 +135,7 @@ export function getStoredLiveTvSelection(): LiveTvSelection {
             sourceId: cleanStoredString(parsed.sourceId),
             groupsBySourceId: cleanGroupsBySourceId(parsed.groupsBySourceId),
             favoritesBySourceId: cleanFavoritesBySourceId(parsed.favoritesBySourceId),
+            lastChannelIdsBySourceId: cleanStringBySourceId(parsed.lastChannelIdsBySourceId),
         };
     } catch {
         return createDefaultLiveTvSelection();
@@ -185,6 +209,22 @@ export function toggleStoredLiveTvFavoriteChannelId(sourceId: string, channelId:
     return setStoredLiveTvFavoriteChannelIds(sourceId, next);
 }
 
+export function getStoredLiveTvLastChannelId(sourceId: string) {
+    const cleanSourceId = sourceId.trim();
+    if (!cleanSourceId) return "";
+    return getStoredLiveTvSelection().lastChannelIdsBySourceId[cleanSourceId] ?? "";
+}
+
+export function setStoredLiveTvLastChannelId(sourceId: string, channelId: string) {
+    const cleanSourceId = sourceId.trim();
+    const cleanChannelId = channelId.trim();
+    if (!cleanSourceId || !cleanChannelId) return;
+
+    const selection = getStoredLiveTvSelection();
+    selection.lastChannelIdsBySourceId[cleanSourceId] = cleanChannelId;
+    persistLiveTvSelection(selection);
+}
+
 export function isLiveTvRefreshDue(
     loadedAt: string | null | undefined,
     now: Date = new Date(),
@@ -217,12 +257,18 @@ export function getVisibleChannels(
     query: string,
     favoriteChannelIds: string[] = [],
 ) {
+    const effectiveGroup =
+        group === ALL_GROUPS ||
+        group === FAVORITES_GROUP ||
+        channels.some((channel) => channel.group === group)
+            ? group
+            : ALL_GROUPS;
     const normalizedQuery = query.trim().toLowerCase();
     const favoriteChannelIdSet =
-        group === FAVORITES_GROUP ? new Set(favoriteChannelIds) : null;
+        effectiveGroup === FAVORITES_GROUP ? new Set(favoriteChannelIds) : null;
     return channels.filter((channel) => {
         if (favoriteChannelIdSet && !favoriteChannelIdSet.has(channel.id)) return false;
-        if (!favoriteChannelIdSet && group !== ALL_GROUPS && channel.group !== group) return false;
+        if (!favoriteChannelIdSet && effectiveGroup !== ALL_GROUPS && channel.group !== effectiveGroup) return false;
         if (!normalizedQuery) return true;
 
         return (
@@ -232,6 +278,24 @@ export function getVisibleChannels(
             (channel.tvgId ?? "").toLowerCase().includes(normalizedQuery)
         );
     });
+}
+
+export function normalizeLiveTvGroup<T extends Pick<IptvGroup, "name">>(
+    group: string,
+    groups: T[],
+) {
+    if (group === ALL_GROUPS || group === FAVORITES_GROUP) return group;
+    return groups.some((candidate) => candidate.name === group) ? group : ALL_GROUPS;
+}
+
+export function getVisibleLiveTvGroups<T extends Pick<IptvGroup, "name">>(
+    groups: T[],
+    query: string,
+) {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return groups;
+
+    return groups.filter((group) => group.name.toLowerCase().includes(normalizedQuery));
 }
 
 export function getLiveSourceCacheKey(source: IptvSource) {

--- a/packages/app/src/pages/live/liveHelpers.ts
+++ b/packages/app/src/pages/live/liveHelpers.ts
@@ -257,6 +257,8 @@ export function getVisibleChannels(
     query: string,
     favoriteChannelIds: string[] = [],
 ) {
+    // Keep this fallback aligned with normalizeLiveTvGroup(), which resets
+    // persisted/UI group selections when the selected group disappears.
     const effectiveGroup =
         group === ALL_GROUPS ||
         group === FAVORITES_GROUP ||

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -1273,7 +1273,10 @@
         pendingAutoJoin = false;
     }
 
-    $: if ($showWatchPartyModal && (liveMode || embedSrc || !$cloudSyncStatus.cloudFeaturesAvailable)) {
+    $: if (
+        $showWatchPartyModal &&
+        (liveMode || embedSrc || $localMode || !$cloudSyncStatus.cloudFeaturesAvailable)
+    ) {
         showWatchPartyModal.set(false);
     }
 

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -94,7 +94,7 @@
         type NextEpisodePrefetchHandoff,
     } from "./nextEpisodePrefetch";
     import { serverUrl } from "../../lib/client";
-    import type { Chapter } from "./types";
+    import type { Chapter, LiveChannelMetadata } from "./types";
 
     // Props
     export let videoSrc: string | null = null;
@@ -111,10 +111,14 @@
     export let joinPartyId: string | null = null;
     export let autoJoin: boolean = false;
     export let autoSkipFromNextEpisode: boolean = false;
+    export let liveMode: boolean = false;
+    export let liveChannel: LiveChannelMetadata | null = null;
 
-    const imdbID = metaData?.meta?.imdb_id || null;
+    let imdbID: string | null = null;
+    $: imdbID = liveMode ? null : metaData?.meta?.imdb_id || null;
 
     const handleProgressInternal = (time: number, dur: number) => {
+        if (liveMode) return;
         if (onProgress) {
             onProgress(time, dur);
         } else if (imdbID) {
@@ -123,6 +127,7 @@
     };
 
     const handleNextEpisodeInternal = () => {
+        if (liveMode) return;
         if (onNextEpisode) {
             return onNextEpisode();
         }
@@ -247,6 +252,9 @@
     const getBrowserPlaybackDetails = () => {
         const src = currentVideoSrc || videoSrc || "";
         const support = src ? Session.getDirectMediaSupport(src, videoElem) : null;
+        if (liveMode) {
+            return "This live stream may use a container or codec this player cannot decode.";
+        }
         const altStreamHint = isDesktopPlatform
             ? "Try an MP4, WebM, or HLS stream. MKV/E-AC-3/DTS streams can be remuxed via the local playback server's transcoder settings."
             : "Try an MP4, WebM, or HLS stream, or use the desktop app for MKV/E-AC-3/DTS streams.";
@@ -265,8 +273,10 @@
         loading.set(false);
         showCanvas.set(false);
         showError.set(true);
-        errorMessage.set("Browser cannot play this stream");
-        errorDetails.set(`${reason} ${getBrowserPlaybackDetails()}`);
+        errorMessage.set(liveMode ? "Live stream failed" : "Browser cannot play this stream");
+        errorDetails.set(
+            `${liveMode && liveChannel?.name ? `${liveChannel.name}: ` : ""}${reason} ${getBrowserPlaybackDetails()}`,
+        );
         trackEvent("browser_direct_stream_failed", {
             reason,
             ...getPlaybackAnalyticsProps(),
@@ -292,7 +302,7 @@
     };
 
     const openWatchPartyModal = () => {
-        if (embedSrc || $localMode || !$cloudSyncStatus.cloudFeaturesAvailable) {
+        if (liveMode || embedSrc || $localMode || !$cloudSyncStatus.cloudFeaturesAvailable) {
             showWatchPartyModal.set(false);
             return;
         }
@@ -324,6 +334,7 @@
             season,
             episode,
             watchPartyActive: $watchParty.isActive,
+            liveMode,
         });
 
     const trackPlaybackClosed = () => {
@@ -354,6 +365,7 @@
     };
 
     const handleEmbedMessage = (event: MessageEvent) => {
+        if (liveMode) return;
         if (!embedSrc || !imdbID || !metaData) return;
 
         const data = parseEmbedMessageData(event.data);
@@ -453,10 +465,10 @@
 
     const handleClose = async () => {
         getWindowControls()?.exitMiniPlayer?.();
-        if (imdbID) {
+        if (!liveMode && imdbID) {
             void flushPendingLibraryProgress(imdbID);
         }
-        if (hasStarted && !traktScrobbler.isStopSent()) {
+        if (!liveMode && hasStarted && !traktScrobbler.isStopSent()) {
             void traktScrobbler.send("stop", true);
         }
         trackPlaybackClosed();
@@ -504,7 +516,7 @@
     });
 
     const computeHasNextEpisode = (): boolean => {
-        if (!metaData || metaData.meta?.type !== "series") return false;
+        if (liveMode || !metaData || metaData.meta?.type !== "series") return false;
         const videos: any[] = Array.isArray((metaData as any).meta?.videos)
             ? ((metaData as any).meta.videos as any[])
             : [];
@@ -522,6 +534,7 @@
     $: hasNextEpisode = computeHasNextEpisode();
 
     $: bingeNextSupported =
+        !liveMode &&
         metaData?.meta?.type === "series" &&
         Boolean($selectedStream?.behaviorHints?.bingeGroup) &&
         !$watchParty.isActive;
@@ -532,7 +545,7 @@
         introDbChapters,
     );
 
-    $: showNextEpisodeAllowed = $showNextEpisode && hasNextEpisode;
+    $: showNextEpisodeAllowed = !liveMode && $showNextEpisode && hasNextEpisode;
 
     const disposeNextEpisodePrefetch = (opts?: { transfer?: boolean }) => {
         nextEpisodePrefetchRunId += 1;
@@ -600,7 +613,7 @@
         },
         getSessionId: () => sessionId,
         getCueLinePercent: () => cueLinePercent,
-        shouldShowSeekStyleInfoModal,
+        shouldShowSeekStyleInfoModal: () => !liveMode && shouldShowSeekStyleInfoModal(),
         setPendingStartAfterSeekStyleModal: (value) => {
             pendingStartAfterSeekStyleModal = value;
         },
@@ -609,6 +622,13 @@
             introDbChapters = chapters;
         },
         resolvePlaybackStart: async ({ sessionData, startTime, metaData, season, episode }) => {
+            if (liveMode) {
+                return {
+                    effectiveStartTime: 0,
+                    introDbChapters: [],
+                };
+            }
+
             let nextIntroDbChapters: Chapter[] = [];
 
             if (metaData?.meta?.type === "series" && metaData.meta.imdb_id && season != null && episode != null) {
@@ -690,7 +710,7 @@
 
         if ($showSeekStyleModal) return;
 
-        if (shouldShowSeekStyleInfoModal()) {
+        if (!liveMode && shouldShowSeekStyleInfoModal()) {
             showSeekStyleModal.set(true);
             pendingStartAfterSeekStyleModal = true;
             return;
@@ -806,6 +826,7 @@
 
         metadataCheckInterval = setInterval(() => {
             if (!videoElem) return;
+            if (liveMode) return;
 
             const currentTime = videoElem.currentTime;
             const durationVal = videoElem.duration;
@@ -847,10 +868,10 @@
             canEnter: false,
         });
         getWindowControls()?.exitMiniPlayer?.();
-        if (imdbID) {
+        if (!liveMode && imdbID) {
             void flushPendingLibraryProgress(imdbID);
         }
-        if (hasStarted && !traktScrobbler.isStopSent()) {
+        if (!liveMode && hasStarted && !traktScrobbler.isStopSent()) {
             void traktScrobbler.send("stop", true);
         }
         trackPlaybackClosed();
@@ -881,9 +902,12 @@
         }
         const time = $playbackOffset + videoElem.currentTime;
         currentTime.set(time);
-        handleProgressInternal(time, $duration);
+        if (!liveMode) {
+            handleProgressInternal(time, $duration);
+        }
 
         if (
+            !liveMode &&
             !traktScrobbler.isStopSent() &&
             $duration > 0 &&
             time / $duration >= TRAKT_COMPLETION_THRESHOLD
@@ -891,7 +915,7 @@
             void traktScrobbler.send("stop", true);
         }
 
-        if (!$seekGuard) {
+        if (!liveMode && !$seekGuard) {
             const result = Chapters.checkChapters(
                 time,
                 $sessionData,
@@ -974,7 +998,9 @@
     const handlePlay = () => {
         isPlaying.set(true);
         hasStarted = true;
-        void traktScrobbler.send("start");
+        if (!liveMode) {
+            void traktScrobbler.send("start");
+        }
         if (!playbackStartTracked) {
             trackEvent("playback_started", getPlaybackAnalyticsProps());
             playbackStartTracked = true;
@@ -995,6 +1021,7 @@
     const handlePause = () => {
         isPlaying.set(false);
         if (
+            !liveMode &&
             !traktScrobbler.isStopSent() &&
             !(
                 $duration > 0 &&
@@ -1070,6 +1097,7 @@
     };
 
     const handleSkipIntro = () => {
+        if (liveMode) return;
         trackEvent("skip_chapter_clicked", {
             chapter_kind: $currentChapter?.kind || null,
             chapter_source: $currentChapter?.source || null,
@@ -1092,10 +1120,10 @@
     });
 
     const handleEnded = () => {
-        if (hasStarted && !traktScrobbler.isStopSent()) {
+        if (!liveMode && hasStarted && !traktScrobbler.isStopSent()) {
             void traktScrobbler.send("stop", true);
         }
-        if (bingeNextSupported && hasNextEpisode && !bingeAutoAdvancing) {
+        if (!liveMode && bingeNextSupported && hasNextEpisode && !bingeAutoAdvancing) {
             bingeAutoAdvancing = true;
             handleNextEpisodeClick();
         }
@@ -1179,6 +1207,7 @@
 
         const handoff = nextEpisodePrefetchHandoff;
         const canReuseHandoff =
+            !liveMode &&
             handoff &&
             handoff.src === videoSrc &&
             handoff.fileIdx === fileIdx &&
@@ -1202,7 +1231,9 @@
         loadVideo(videoSrc, reuseSession ? { reuseSession } : undefined);
     }
 
-    $: effectiveChapterMarkers = Chapters.getEffectiveChapterSegments($sessionData, introDbChapters);
+    $: effectiveChapterMarkers = liveMode
+        ? []
+        : Chapters.getEffectiveChapterSegments($sessionData, introDbChapters);
 
     $: if (videoElem) {
         videoElem.muted = false;
@@ -1237,12 +1268,12 @@
         resizeCounter += 1;
     }
 
-    $: if (pendingAutoJoin && joinPartyId && autoJoin && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable) {
+    $: if (!liveMode && pendingAutoJoin && joinPartyId && autoJoin && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable) {
         showWatchPartyModal.set(true);
         pendingAutoJoin = false;
     }
 
-    $: if ($showWatchPartyModal && (embedSrc || !$cloudSyncStatus.cloudFeaturesAvailable)) {
+    $: if ($showWatchPartyModal && (liveMode || embedSrc || !$cloudSyncStatus.cloudFeaturesAvailable)) {
         showWatchPartyModal.set(false);
     }
 
@@ -1390,6 +1421,7 @@
         loading={$loading && !miniPlayerActive}
         onClose={handleClose}
         {metaData}
+        liveTitle={liveMode ? liveChannel?.name ?? "Live TV" : null}
         backdropSrc={loadingBackdropSrc}
         backdropMode={loadingBackdropMode}
         stage={$loadingStage}
@@ -1419,7 +1451,7 @@
                 <PlayerOverlays
                     showSkipIntro={$showSkipIntro}
                     showNextEpisode={showNextEpisodeAllowed}
-                    isWatchPartyMember={!$localMode && $watchParty.isActive && !$watchParty.isHost}
+                    isWatchPartyMember={!liveMode && !$localMode && $watchParty.isActive && !$watchParty.isHost}
                     skipLabel={skipButtonLabel}
                     skipChapter={handleSkipIntro}
                     nextEpisode={handleNextEpisodeClick}
@@ -1442,10 +1474,10 @@
                         {sessionId}
                         {videoSrc}
                         {metaData}
-                        {hasNextEpisode}
+                        hasNextEpisode={!liveMode && hasNextEpisode}
                         currentAudioLabel={$currentAudioLabel}
                         currentSubtitleLabel={$currentSubtitleLabel}
-                        isWatchPartyMember={!$localMode && $watchParty.isActive && !$watchParty.isHost}
+                        isWatchPartyMember={!liveMode && !$localMode && $watchParty.isActive && !$watchParty.isHost}
                         togglePlay={togglePlayWithFeedback}
                         onSeekInput={(e) =>
                             controlsManager.onSeekInput(e, $duration, pendingSeek.set)}
@@ -1456,11 +1488,11 @@
                         objectFit={$objectFit}
                         toggleObjectFit={handleToggleObjectFit}
                         onNextEpisode={handleNextEpisodeClick}
-                        showWatchParty={!$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
+                        showWatchParty={!liveMode && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
                         onAudioClick={openAudioSelection}
                         onSubtitleClick={openSubtitleSelection}
                         onWatchPartyClick={() => {
-                            if (!$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc) {
+                            if (!liveMode && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc) {
                                 openWatchPartyModal();
                             } else {
                                 showWatchPartyModal.set(false);
@@ -1484,7 +1516,7 @@
         showAudioSelection={$showAudioSelection}
         showSubtitleSelection={$showSubtitleSelection}
         showError={$showError}
-        showWatchPartyModal={$showWatchPartyModal && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
+        showWatchPartyModal={$showWatchPartyModal && !liveMode && !$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
         showSeekStyleModal={$showSeekStyleModal}
         audioTracks={$audioTracks}
         subtitleTracks={$subtitleTracks}

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -603,6 +603,7 @@
         getMetaData: () => metaData,
         getSeason: () => season,
         getEpisode: () => episode,
+        isLiveMode: () => liveMode,
         getVideoElem: () => videoElem,
         getHls: () => hls,
         setHls: (value) => {

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -1478,6 +1478,7 @@
                         {sessionId}
                         {videoSrc}
                         {metaData}
+                        {liveMode}
                         hasNextEpisode={!liveMode && hasNextEpisode}
                         currentAudioLabel={$currentAudioLabel}
                         currentSubtitleLabel={$currentSubtitleLabel}

--- a/packages/app/src/pages/player/components/PlayerLoadingScreen.svelte
+++ b/packages/app/src/pages/player/components/PlayerLoadingScreen.svelte
@@ -21,6 +21,7 @@
     export let loading: boolean;
     export let onClose: () => void;
     export let metaData: ShowResponse | null;
+    export let liveTitle: string | null = null;
 
 	export let stage: string = "Loading...";
 	export let details: string = "";
@@ -58,6 +59,15 @@
                     alt="Logo"
                     class="w-100 object-contain animate-pulse drop-shadow-[0_10px_40px_rgba(0,0,0,0.45)]"
                 />
+            </div>
+        {:else if liveTitle}
+            <div class="relative z-10 flex flex-col items-center gap-2 px-8 text-center">
+                <div class="text-white/92 text-[28px] font-poppins font-semibold leading-tight">
+                    {liveTitle}
+                </div>
+                <div class="text-white/55 text-[14px] uppercase tracking-[0.18em]">
+                    Live TV
+                </div>
             </div>
         {/if}
 

--- a/packages/app/src/pages/player/playerAnalytics.ts
+++ b/packages/app/src/pages/player/playerAnalytics.ts
@@ -14,6 +14,7 @@ export const getPlaybackAnalyticsProps = ({
     season,
     episode,
     watchPartyActive,
+    liveMode,
 }: {
     currentVideoSrc: string | null;
     sessionData: any;
@@ -23,8 +24,9 @@ export const getPlaybackAnalyticsProps = ({
     season: number | null;
     episode: number | null;
     watchPartyActive: boolean;
+    liveMode?: boolean;
 }) => {
-    const sourceType = getPlaybackSourceType(currentVideoSrc, sessionData);
+    const sourceType = liveMode ? "live" : getPlaybackSourceType(currentVideoSrc, sessionData);
     const isTorrent = sourceType === "torrent";
     const isLocal = sourceType === "local";
     const progressPercent = duration > 0 ? Math.round((currentTime / duration) * 100) : null;
@@ -34,6 +36,7 @@ export const getPlaybackAnalyticsProps = ({
         is_torrent: isTorrent,
         is_local: isLocal,
         content_type: metaData?.meta?.type ?? null,
+        live_mode: Boolean(liveMode),
         season: season ?? null,
         episode: episode ?? null,
         watch_party: watchPartyActive,

--- a/packages/app/src/pages/player/playerSessionLoader.ts
+++ b/packages/app/src/pages/player/playerSessionLoader.ts
@@ -40,6 +40,7 @@ export type PlayerSessionLoaderDeps = {
     getMetaData: () => ShowResponse | null;
     getSeason: () => number | null;
     getEpisode: () => number | null;
+    isLiveMode: () => boolean;
     getVideoElem: () => HTMLVideoElement | undefined;
     getHls: () => any;
     setHls: (value: any) => void;
@@ -88,10 +89,18 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
             const metaData = deps.getMetaData();
             const season = deps.getSeason();
             const episode = deps.getEpisode();
-            const directHttp = !opts?.reuseSession && Session.shouldBypassServerForHttpStream(
-                src,
-                deps.getVideoElem(),
-            );
+            const directHls =
+                !opts?.reuseSession &&
+                deps.isLiveMode() &&
+                /^https?:\/\//i.test(src) &&
+                Session.isHlsManifestUrl(src);
+            const directHttp =
+                !opts?.reuseSession &&
+                (directHls ||
+                    Session.shouldBypassServerForHttpStream(
+                        src,
+                        deps.getVideoElem(),
+                    ));
 
             const result = await Session.loadVideoSession(
                 src,
@@ -137,6 +146,7 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
                 {
                     ...opts,
                     directHttp,
+                    directHls,
                 },
             );
 
@@ -190,11 +200,22 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
                 deps.setPendingStartAfterSeekStyleModal(true);
             }
 
-            const bypassServer = Session.shouldBypassServerForHttpStream(src, videoElem);
+            const bypassServer =
+                Boolean(result.sessionData?.isDirectHttp) ||
+                Session.shouldBypassServerForHttpStream(src, videoElem);
+            const directHlsPlayback = Boolean(result.sessionData?.isDirectHls);
 
             if (bypassServer) {
-                loadingStage.set("Loading stream directly");
-                loadingDetails.set("Bypassing server transcoding");
+                loadingStage.set(
+                    directHlsPlayback
+                        ? "Loading live stream directly"
+                        : "Loading stream directly",
+                );
+                loadingDetails.set(
+                    directHlsPlayback
+                        ? "Loading HLS manifest..."
+                        : "Bypassing server transcoding",
+                );
                 loadingProgress.set(null);
 
                 const hls = deps.getHls();
@@ -224,6 +245,23 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
                         // ignore
                     });
                 loading.set(true);
+
+                if (directHlsPlayback) {
+                    const hlsInstance = Session.initDirectHLS(
+                        videoElem,
+                        src,
+                        needsSeekStyleModal ? false : deps.autoPlay,
+                        {
+                            setLoading: loading.set,
+                            setShowCanvas: showCanvas.set,
+                            setShowError: showError.set,
+                            setErrorMessage: errorMessage.set,
+                            setErrorDetails: errorDetails.set,
+                        },
+                    );
+                    deps.setHls(hlsInstance);
+                    return;
+                }
 
                 const onLoaded = () => {
                     const currentVideo = deps.getVideoElem();

--- a/packages/app/src/pages/player/types.ts
+++ b/packages/app/src/pages/player/types.ts
@@ -32,6 +32,14 @@ export interface SessionData {
     audioIndex?: number;
 }
 
+export interface LiveChannelMetadata {
+    name: string;
+    group?: string | null;
+    logo?: string | null;
+    tvgId?: string | null;
+    programmeTitle?: string | null;
+}
+
 export interface SeekFeedback {
     type: "forward" | "backward";
     id: number;

--- a/packages/app/src/pages/player/videoSession.ts
+++ b/packages/app/src/pages/player/videoSession.ts
@@ -75,6 +75,10 @@ const getMediaPathname = (src: string) => {
   }
 };
 
+export function isHlsManifestUrl(src: string): boolean {
+  return getMediaPathname(src).split(/[?#]/)[0].endsWith(".m3u8");
+}
+
 export function getDirectMediaSupport(src: string, videoElem?: HTMLVideoElement) {
   const elem = videoElem ?? document.createElement("video");
   const pathname = getMediaPathname(src);
@@ -121,8 +125,8 @@ export function shouldBypassServerForHttpStream(
   if (!src) return false;
   if (!/^https?:\/\//i.test(src)) return false;
 
-  // If the addon already provides an HLS manifest, let the existing pipeline handle it.
-  if (/\.m3u8(\?|$)/i.test(src)) return false;
+  // For movies and shows, keep HLS manifests on the existing local pipeline.
+  if (isHlsManifestUrl(src)) return false;
 
   if (isWeb) return true;
 
@@ -192,6 +196,7 @@ export async function loadVideoSession(
   options?: {
     reuseSession?: { sessionId: string; sessionData: any };
     directHttp?: boolean;
+    directHls?: boolean;
   },
 ): Promise<{ sessionId: string; sessionData: any }> {
   const {
@@ -258,6 +263,7 @@ export async function loadVideoSession(
     if (options?.directHttp) {
       const sessionData = {
         isDirectHttp: true,
+        isDirectHls: Boolean(options.directHls),
         sourceUrl: src,
         durationSeconds: 0,
       };
@@ -404,6 +410,176 @@ export async function loadVideoSession(
     setLoading(false);
     throw err;
   }
+}
+
+const DIRECT_HLS_START_TIMEOUT_MS = 12_000;
+
+function getDirectHlsErrorDetails(data: any): string {
+  const details = typeof data?.details === "string" ? data.details : "";
+  const error = data?.error instanceof Error ? data.error.message : "";
+  return details || error || "The HLS manifest could not be loaded directly.";
+}
+
+export function initDirectHLS(
+  videoElem: HTMLVideoElement,
+  src: string,
+  autoPlay: boolean,
+  setStates: {
+    setLoading: (loading: boolean) => void;
+    setShowCanvas: (show: boolean) => void;
+    setShowError: (show: boolean) => void;
+    setErrorMessage: (msg: string) => void;
+    setErrorDetails: (details: string) => void;
+  },
+): Hls | null {
+  const {
+    setLoading,
+    setShowCanvas,
+    setShowError,
+    setErrorMessage,
+    setErrorDetails,
+  } = setStates;
+
+  let hls: Hls | null = null;
+  let disposed = false;
+  let startTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const clearStartTimeout = () => {
+    if (!startTimeout) return;
+    clearTimeout(startTimeout);
+    startTimeout = null;
+  };
+
+  const cleanup = () => {
+    clearStartTimeout();
+    videoElem.removeEventListener("loadedmetadata", handleNativeReady);
+    videoElem.removeEventListener("canplay", handleNativeReady);
+    videoElem.removeEventListener("error", handleVideoError);
+  };
+
+  const dispose = () => {
+    disposed = true;
+    cleanup();
+  };
+
+  const fail = (message: string, details: string) => {
+    if (disposed) return;
+    cleanup();
+    if (hls) {
+      const hlsInstance = hls;
+      hls = null;
+      hlsInstance.destroy();
+    }
+    try {
+      videoElem.pause();
+    } catch {
+      // ignore
+    }
+    setErrorMessage(message);
+    setErrorDetails(details);
+    setShowError(true);
+    setLoading(false);
+  };
+
+  const finishLoad = () => {
+    if (disposed) return;
+    cleanup();
+    setLoading(false);
+    setShowCanvas(false);
+
+    if (autoPlay) {
+      videoElem.play().catch((err) => {
+        console.warn("autoplay failed:", err);
+      });
+    }
+  };
+
+  function handleNativeReady() {
+    finishLoad();
+  }
+
+  function handleVideoError() {
+    const error = videoElem.error;
+    fail(
+      "Live stream failed",
+      error?.message || `Media error ${error?.code ?? "unknown"}.`,
+    );
+  }
+
+  setLoading(true);
+  setShowCanvas(false);
+  setShowError(false);
+  setErrorMessage("");
+  setErrorDetails("");
+
+  startTimeout = setTimeout(() => {
+    fail(
+      "Live stream failed",
+      "The HLS manifest did not load quickly. Please try another channel.",
+    );
+  }, DIRECT_HLS_START_TIMEOUT_MS);
+
+  videoElem.addEventListener("error", handleVideoError);
+
+  if (Hls.isSupported()) {
+    hls = new Hls({
+      lowLatencyMode: true,
+      enableWorker: true,
+      manifestLoadingTimeOut: 8000,
+      manifestLoadingMaxRetry: 1,
+      manifestLoadingMaxRetryTimeout: 8000,
+      levelLoadingTimeOut: 8000,
+      levelLoadingMaxRetry: 1,
+      levelLoadingMaxRetryTimeout: 8000,
+      fragLoadPolicy: {
+        default: {
+          maxTimeToFirstByteMs: 8000,
+          maxLoadTimeMs: 20000,
+          timeoutRetry: {
+            maxNumRetry: 1,
+            retryDelayMs: 500,
+            maxRetryDelayMs: 1000,
+          },
+          errorRetry: {
+            maxNumRetry: 1,
+            retryDelayMs: 500,
+            maxRetryDelayMs: 1000,
+          },
+        },
+      },
+    });
+
+    const originalDestroy = hls.destroy.bind(hls);
+    hls.destroy = () => {
+      dispose();
+      originalDestroy();
+    };
+
+    hls.on(Hls.Events.MANIFEST_PARSED, finishLoad);
+    hls.on(Hls.Events.ERROR, (_, data) => {
+      console.error("DIRECT HLS ERROR", data);
+      if (!data.fatal) return;
+      fail("Live stream failed", getDirectHlsErrorDetails(data));
+    });
+
+    hls.loadSource(src);
+    hls.attachMedia(videoElem);
+    return hls;
+  }
+
+  if (videoElem.canPlayType("application/vnd.apple.mpegurl")) {
+    videoElem.addEventListener("loadedmetadata", handleNativeReady);
+    videoElem.addEventListener("canplay", handleNativeReady);
+    videoElem.src = src;
+    videoElem.load();
+    return null;
+  }
+
+  fail(
+    "Live stream failed",
+    "This browser does not support direct HLS playback.",
+  );
+  return null;
 }
 
 export function initHLS(

--- a/packages/app/src/pages/player/videoSession.ts
+++ b/packages/app/src/pages/player/videoSession.ts
@@ -414,6 +414,8 @@ export async function loadVideoSession(
 
 const DIRECT_HLS_START_TIMEOUT_MS = 12_000;
 
+type DirectHlsHandle = Pick<Hls, "destroy">;
+
 function getDirectHlsErrorDetails(data: any): string {
   const details = typeof data?.details === "string" ? data.details : "";
   const error = data?.error instanceof Error ? data.error.message : "";
@@ -431,7 +433,7 @@ export function initDirectHLS(
     setErrorMessage: (msg: string) => void;
     setErrorDetails: (details: string) => void;
   },
-): Hls | null {
+): DirectHlsHandle | null {
   const {
     setLoading,
     setShowCanvas,
@@ -557,7 +559,11 @@ export function initDirectHLS(
 
     hls.on(Hls.Events.MANIFEST_PARSED, finishLoad);
     hls.on(Hls.Events.ERROR, (_, data) => {
-      console.error("DIRECT HLS ERROR", data);
+      console.error("DIRECT HLS ERROR", {
+        type: data.type,
+        details: data.details,
+        fatal: data.fatal,
+      });
       if (!data.fatal) return;
       fail("Live stream failed", getDirectHlsErrorDetails(data));
     });
@@ -568,11 +574,23 @@ export function initDirectHLS(
   }
 
   if (videoElem.canPlayType("application/vnd.apple.mpegurl")) {
+    const nativeHandle: DirectHlsHandle = {
+      destroy: () => {
+        dispose();
+        try {
+          videoElem.pause();
+          videoElem.removeAttribute("src");
+          videoElem.load();
+        } catch {
+          // ignore
+        }
+      },
+    };
     videoElem.addEventListener("loadedmetadata", handleNativeReady);
     videoElem.addEventListener("canplay", handleNativeReady);
     videoElem.src = src;
     videoElem.load();
-    return null;
+    return nativeHandle;
   }
 
   fail(

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -21,5 +21,8 @@
     "src/**/*.ts",
     "src/**/*.js",
     "src/**/*.svelte"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
   ]
 }

--- a/scripts/smoke-iptv-dispatcharr.mjs
+++ b/scripts/smoke-iptv-dispatcharr.mjs
@@ -3,6 +3,7 @@ import { getNowNext, getProgrammeCount, parseXmltv } from "../packages/app/src/l
 
 const MAX_M3U_BYTES = 64 * 1024 * 1024;
 const MAX_EPG_BYTES = 128 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
 
 function requireEnv(name) {
     const value = String(process.env[name] || "").trim();
@@ -13,25 +14,36 @@ function requireEnv(name) {
 }
 
 async function fetchText(label, target, maxBytes) {
-    let response;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
     try {
-        response = await fetch(target, { redirect: "follow" });
+        const response = await fetch(target, {
+            redirect: "follow",
+            signal: controller.signal,
+        });
+        const arrayBuffer = await response.arrayBuffer();
+
+        if (arrayBuffer.byteLength > maxBytes) {
+            throw new Error("IPTV response exceeded maximum size");
+        }
+
+        return {
+            status: response.status,
+            ok: response.ok,
+            text: new TextDecoder("utf-8").decode(arrayBuffer),
+        };
     } catch (error) {
+        if (error?.name === "AbortError") {
+            throw new Error(
+                `${label} fetch timed out after ${REQUEST_TIMEOUT_MS / 1000} seconds`,
+            );
+        }
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`${label} fetch failed before HTTP response: ${message}`);
+        throw new Error(`${label} fetch failed: ${message}`);
+    } finally {
+        clearTimeout(timeout);
     }
-
-    const arrayBuffer = await response.arrayBuffer();
-
-    if (arrayBuffer.byteLength > maxBytes) {
-        throw new Error("IPTV response exceeded maximum size");
-    }
-
-    return {
-        status: response.status,
-        ok: response.ok,
-        text: new TextDecoder("utf-8").decode(arrayBuffer),
-    };
 }
 
 async function main() {
@@ -44,6 +56,9 @@ async function main() {
     }
 
     const parsed = parseM3U(m3u.text, "smoke");
+    if (parsed.channels.length === 0) {
+        throw new Error("The IPTV playlist did not contain any channels");
+    }
 
     const epg = await fetchText("EPG", epgUrl, MAX_EPG_BYTES);
     if (!epg.ok) {

--- a/scripts/smoke-iptv-dispatcharr.mjs
+++ b/scripts/smoke-iptv-dispatcharr.mjs
@@ -1,0 +1,84 @@
+import { parseM3U } from "../packages/app/src/lib/iptv/m3u.ts";
+import { getNowNext, getProgrammeCount, parseXmltv } from "../packages/app/src/lib/iptv/xmltv.ts";
+
+const MAX_M3U_BYTES = 64 * 1024 * 1024;
+const MAX_EPG_BYTES = 128 * 1024 * 1024;
+
+function requireEnv(name) {
+    const value = String(process.env[name] || "").trim();
+    if (!value) {
+        throw new Error(`${name} is required`);
+    }
+    return value;
+}
+
+async function fetchText(label, target, maxBytes) {
+    let response;
+    try {
+        response = await fetch(target, { redirect: "follow" });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`${label} fetch failed before HTTP response: ${message}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+
+    if (arrayBuffer.byteLength > maxBytes) {
+        throw new Error("IPTV response exceeded maximum size");
+    }
+
+    return {
+        status: response.status,
+        ok: response.ok,
+        text: new TextDecoder("utf-8").decode(arrayBuffer),
+    };
+}
+
+async function main() {
+    const m3uUrl = requireEnv("IPTV_M3U_URL");
+    const epgUrl = requireEnv("IPTV_EPG_URL");
+
+    const m3u = await fetchText("M3U", m3uUrl, MAX_M3U_BYTES);
+    if (!m3u.ok) {
+        throw new Error(`M3U fetch failed with HTTP ${m3u.status}`);
+    }
+
+    const parsed = parseM3U(m3u.text, "smoke");
+
+    const epg = await fetchText("EPG", epgUrl, MAX_EPG_BYTES);
+    if (!epg.ok) {
+        throw new Error(`EPG fetch failed with HTTP ${epg.status}`);
+    }
+
+    const guide = parseXmltv(epg.text);
+    const sampleChannels = parsed.channels.slice(0, 50);
+    const nowNextMatchesInFirst50 = sampleChannels.filter((channel) => {
+        const match = getNowNext(channel, guide);
+        return Boolean(match.now || match.next);
+    }).length;
+
+    console.log(
+        JSON.stringify(
+            {
+                m3uStatus: m3u.status,
+                channelCount: parsed.channels.length,
+                groupCount: parsed.groups.length,
+                epgStatus: epg.status,
+                programmeCount: getProgrammeCount(guide),
+                nowNextMatchesInFirst50,
+            },
+            null,
+            2,
+        ),
+    );
+}
+
+main().catch((error) => {
+    console.error(
+        JSON.stringify({
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+        }),
+    );
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds native IPTV / M3U Live TV support with XMLTV guide data and a TV-guide-style EPG grid.

## Highlights

- Add IPTV source management for M3U + XMLTV URLs
- Parse and refresh IPTV playlists
- Parse XMLTV guide metadata
- Persist refreshed channel/group state locally
- Add Live TV guide grid:
  - channel/logo rail
  - horizontal programme blocks
  - current-time marker
  - current/future programme styling
- Add regression tests for IPTV cache and EPG layout

## Verification

- `bun test packages/app/src/lib/iptv/guideGrid.test.ts packages/app/src/lib/iptv/*.test.ts`
- `bun run check:app`
- `bun run check:desktop`
- `bun run build:desktop`
- Packaged and verified in a macOS VM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Live TV page with source add/edit/remove, channel refresh, group filtering, favorites, and a current/next guide grid.
  * Added a toggleable Home “Live TV” shortcut that navigates to the Live TV page.
  * Enabled dedicated live playback in the player with live-specific UI/loading behavior.
* **Security & Reliability**
  * Improved IPTV text fetching with strict URL checks, safer redirect handling, timeouts, and maximum download-size limits.
* **Performance**
  * Added local caching for IPTV refresh results and guide data to speed up reloads.
* **Analytics**
  * Updated playback analytics to report live mode; added analytics for Live TV navigation and shortcut toggles.
* **Tests**
  * Added/expanded IPTV and Live TV test coverage for parsing, caching, and scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->