### PR TITLE
fix: appImage to use persistent path

### DIFF
--- a/apps/desktop/electron/services/protocol.cjs
+++ b/apps/desktop/electron/services/protocol.cjs
@@ -194,6 +194,11 @@ function registerLinuxProtocolHandler({
 }) {
   if (process.platform !== "linux") return;
 
+  // AppImage mounts to a temporary path,
+  // so using execPath messes up our .desktop entry
+  // Use the actual image path in that case
+  const packagedExecPath = process.env.APPIMAGE || process.execPath;
+
   try {
     const desktopDir = path.join(app.getPath("home"), ".local", "share", "applications");
     fs.mkdirSync(desktopDir, { recursive: true });
@@ -208,7 +213,7 @@ function registerLinuxProtocolHandler({
     const launchTarget = isDev ? path.resolve(process.argv[1] || "") : process.execPath;
     const execLine = isDev
       ? `\"${process.execPath}\" \"${launchTarget}\" %U`
-      : `\"${process.execPath}\" %U`;
+      : `\"${packagedExecPath}\" %U`;
     const existingMainDesktop = readDesktopFile(fs, localMainDesktop);
 
     if (isDev) {
@@ -235,7 +240,7 @@ function registerLinuxProtocolHandler({
       writePackagedLauncherDesktop({
         fs,
         desktopPath: localMainDesktop,
-        execPath: process.execPath,
+        execPath: packagedExecPath,
         iconName,
         startupWMClass,
       });
@@ -246,7 +251,7 @@ function registerLinuxProtocolHandler({
       fs,
       desktopPath: localHandlerDesktop,
       execLine,
-      tryExec: process.execPath,
+      tryExec: packagedExecPath,
       iconName,
       startupWMClass,
       isDev,


### PR DESCRIPTION
Hello,

Thanks for the project! Its much less bloated than stremio and already more refined.

There's a bug with appImages and how raffi overwrites their entry. AppImages mount on a temp location, and we currently overwrite to that location while recreating .desktop entry.
This PR checks if we're in appImage, and uses the executable path instead.

Ideally we should not overwrite .desktop if its already created, but that change is bigger and product altering.

Let me know if this is the way to go,

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux protocol handling for packaged apps, including AppImage-based installs.
  * Fixed app launch shortcuts so they point to the correct executable path in packaged mode, helping links open reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->