### PR TITLE
fix: seek feedback position for normal mode

### DIFF
--- a/packages/app/src/components/player/SeekFeedback.svelte
+++ b/packages/app/src/components/player/SeekFeedback.svelte
@@ -2,10 +2,19 @@
     import { fade } from "svelte/transition";
 
     export let type: "forward" | "backward";
-    export let side: "left" | "right";
+    export let seekBarStyle: "raffi" | "normal" = "raffi";
     export let id: number;
 
     let rotation = 0;
+
+    $: side =
+        seekBarStyle === "normal"
+            ? type === "forward"
+                ? "right"
+                : "left"
+            : type === "forward"
+                ? "left"
+                : "right";
 
     $: if (id) {
         triggerAnimation();

--- a/packages/app/src/components/player/SeekFeedback.svelte
+++ b/packages/app/src/components/player/SeekFeedback.svelte
@@ -2,6 +2,7 @@
     import { fade } from "svelte/transition";
 
     export let type: "forward" | "backward";
+    export let side: "left" | "right";
     export let id: number;
 
     let rotation = 0;
@@ -20,7 +21,7 @@
 
 <div
     class="absolute top-1/2 -translate-y-1/2 z-40 flex flex-col items-center justify-center text-white pointer-events-none
-    {type === 'forward' ? 'left-[20%]' : 'right-[20%]'}"
+    {side === 'left' ? 'left-[20%]' : 'right-[20%]'}"
     transition:fade={{ duration: 200 }}
 >
     <div class="relative flex items-center justify-center">

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -94,7 +94,7 @@
         type NextEpisodePrefetchHandoff,
     } from "./nextEpisodePrefetch";
     import { serverUrl } from "../../lib/client";
-    import type { Chapter, SeekFeedback as SeekFeedbackState } from "./types";
+    import type { Chapter } from "./types";
 
     // Props
     export let videoSrc: string | null = null;
@@ -163,16 +163,6 @@
     const handleSeekStyleChange = (style: SeekBarStyle) => {
         seekBarStyle = style;
         persistSeekBarStyle(style);
-    };
-
-    const getSeekFeedbackSide = (
-        type: SeekFeedbackState["type"],
-    ): "left" | "right" => {
-        if (seekBarStyle === "normal") {
-            return type === "forward" ? "right" : "left";
-        }
-
-        return type === "forward" ? "left" : "right";
     };
 
     const handleSeekStyleAcknowledge = async () => {
@@ -1397,7 +1387,7 @@
     {#if $seekFeedback && !embedSrc}
         <SeekFeedback
             type={$seekFeedback.type}
-            side={getSeekFeedbackSide($seekFeedback.type)}
+            seekBarStyle={seekBarStyle}
             id={$seekFeedback.id}
         />
     {/if}

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -94,7 +94,7 @@
         type NextEpisodePrefetchHandoff,
     } from "./nextEpisodePrefetch";
     import { serverUrl } from "../../lib/client";
-    import type { Chapter } from "./types";
+    import type { Chapter, SeekFeedback as SeekFeedbackState } from "./types";
 
     // Props
     export let videoSrc: string | null = null;
@@ -163,6 +163,16 @@
     const handleSeekStyleChange = (style: SeekBarStyle) => {
         seekBarStyle = style;
         persistSeekBarStyle(style);
+    };
+
+    const getSeekFeedbackSide = (
+        type: SeekFeedbackState["type"],
+    ): "left" | "right" => {
+        if (seekBarStyle === "normal") {
+            return type === "forward" ? "right" : "left";
+        }
+
+        return type === "forward" ? "left" : "right";
     };
 
     const handleSeekStyleAcknowledge = async () => {
@@ -1385,7 +1395,11 @@
     {/if}
 
     {#if $seekFeedback && !embedSrc}
-        <SeekFeedback type={$seekFeedback.type} id={$seekFeedback.id} />
+        <SeekFeedback
+            type={$seekFeedback.type}
+            side={getSeekFeedbackSide($seekFeedback.type)}
+            id={$seekFeedback.id}
+        />
     {/if}
 
     <PlayerLoadingScreen


### PR DESCRIPTION
Hello!

Right now even in 'normal' mode, the forward seek feedback appears on the left, and back appears on the right. While this works for raffi style, I feel it should be swapped for normal mode.

What do you think? Worth the merge or keep as is?