### PR TITLE
Improve streaming reliability, torrent controls, and episode playback

### DIFF
--- a/packages/app/src/App.svelte
+++ b/packages/app/src/App.svelte
@@ -22,6 +22,7 @@
     import { userZoom } from "./lib/stores/settingsStore";
     import { warmTraktClientAuth } from "./lib/db/db";
     import ZoomModal from "./components/common/ZoomModal.svelte";
+    import { syncTorrentingPreference } from "./lib/stores/torrenting";
 
     const pages = {
         home: Home,
@@ -286,6 +287,9 @@
         initAnalytics();
         trackEvent("app_started");
         trackPageView($router.page);
+        void syncTorrentingPreference().catch((error) => {
+            console.warn("Failed to sync torrenting preference with playback server", error);
+        });
 
         try {
             const storedRpc = localStorage.getItem("discord_rpc_enabled");

--- a/packages/app/src/components/home/modals/PlayModal.svelte
+++ b/packages/app/src/components/home/modals/PlayModal.svelte
@@ -7,6 +7,14 @@
     import { cloudSyncStatus, getWatchPartyInfo } from "../../../lib/db/db";
     import { overlayZoomStyle } from "../../../lib/overlayZoom";
     import { localMode } from "../../../lib/stores/authStore";
+    import { get } from "svelte/store";
+    import TorrentWarningModal from "../../meta/modals/TorrentWarningModal.svelte";
+    import {
+        acknowledgeTorrentWarning,
+        allowTorrenting,
+        hasAcknowledgedTorrentWarning,
+        setTorrentingAllowed,
+    } from "../../../lib/stores/torrenting";
 
     const portal = (node: HTMLElement) => {
         if (typeof document === "undefined") {
@@ -33,6 +41,7 @@
     let partyDetails: any = null;
     let loading = false;
     let error = "";
+    let showTorrentWarning = false;
 
     let fileInput: HTMLInputElement;
 
@@ -143,7 +152,7 @@
         target.value = "";
     }
 
-    function playMagnet() {
+    function openMagnetPlayer() {
         if (!magnetLink.trim()) return;
         router.navigate("player", {
             videoSrc: magnetLink.trim(),
@@ -154,6 +163,33 @@
             episode: null,
         });
         onClose();
+    }
+
+    function playMagnet() {
+        if (!magnetLink.trim()) return;
+        error = "";
+        if (!hasAcknowledgedTorrentWarning()) {
+            showTorrentWarning = true;
+            return;
+        }
+        if (!get(allowTorrenting)) {
+            error = "Torrenting is disabled. Turn on Allow Torrenting in Settings before playing a magnet link.";
+            return;
+        }
+        openMagnetPlayer();
+    }
+
+    async function confirmTorrentWarning() {
+        try {
+            await setTorrentingAllowed(true);
+            acknowledgeTorrentWarning();
+            showTorrentWarning = false;
+            openMagnetPlayer();
+        } catch (cause) {
+            console.error("Failed to enable torrenting", cause);
+            showTorrentWarning = false;
+            error = "Could not enable torrenting. Please try again from Settings.";
+        }
     }
 
     async function fetchPartyDetails() {
@@ -330,6 +366,12 @@
                         ></textarea>
                     </div>
 
+                    {#if error}
+                        <div class="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm text-center">
+                            {error}
+                        </div>
+                    {/if}
+
                     <div class="flex gap-3 mt-2">
                         <button
                             class="flex-1 py-3 bg-white/10 hover:bg-white/20 text-white rounded-xl font-medium transition-colors"
@@ -440,4 +482,11 @@
             {/if}
         </div>
     </div>
+
+    {#if showTorrentWarning}
+        <TorrentWarningModal
+            onConfirm={confirmTorrentWarning}
+            onCancel={() => (showTorrentWarning = false)}
+        />
+    {/if}
 </div>

--- a/packages/app/src/components/home/modals/settings/PreferencesSection.svelte
+++ b/packages/app/src/components/home/modals/settings/PreferencesSection.svelte
@@ -11,6 +11,10 @@
 		autoSkipIntros,
 		miniPlayerOnMinimize,
 	} from "../../../../lib/stores/playbackPreferences";
+	import {
+		allowTorrenting,
+		setTorrentingAllowed,
+	} from "../../../../lib/stores/torrenting";
 	import { currentUser, localMode } from "../../../../lib/stores/authStore";
 	import {
 		getHeroCatalogSourceOptions,
@@ -40,6 +44,8 @@
 	let heroSourceOptions: HeroCatalogSourceOption[] = [];
 	let heroSourceLoading = false;
 	let traktHeroSourceAvailable = false;
+	let torrentingSaving = false;
+	let torrentingError = "";
 	const HOME_REFRESH_EVENT = "raffi:home-refresh";
 
 	onMount(() => {
@@ -88,6 +94,22 @@
 			trackEvent("mini_player_on_minimize_toggled", { enabled: nextValue });
 			return nextValue;
 		});
+	}
+
+	async function toggleTorrenting() {
+		if (torrentingSaving) return;
+		torrentingSaving = true;
+		torrentingError = "";
+		const enabled = !$allowTorrenting;
+		try {
+			await setTorrentingAllowed(enabled);
+			trackEvent("torrenting_toggled", { enabled });
+		} catch (error) {
+			console.error("Failed to update torrenting setting", error);
+			torrentingError = "Could not update the playback server. Please try again.";
+		} finally {
+			torrentingSaving = false;
+		}
 	}
 
 	async function loadHeroSourceOptions() {
@@ -265,6 +287,38 @@
 				}`}
 			>
 				{miniPlayerEnabled ? "On" : "Off"}
+			</span>
+		</button>
+	</div>
+
+	<div class="rounded-2xl bg-white/8 p-4 flex flex-wrap items-center gap-4 justify-between">
+		<div>
+			<p class="text-white font-medium">Allow Torrenting</p>
+			<p class="text-white/60 text-sm">
+				Allow Raffi to start, download, and seed torrent streams. Turning this off stops all torrent activity.
+			</p>
+			{#if torrentingError}
+				<p class="mt-1 text-red-300 text-xs">{torrentingError}</p>
+			{/if}
+		</div>
+		<button
+			class={`relative w-16 h-9 rounded-full border border-white/10 transition-colors duration-200 cursor-pointer disabled:cursor-wait disabled:opacity-60 ${
+				$allowTorrenting ? "bg-white" : "bg-white/10"
+			}`}
+			on:click={toggleTorrenting}
+			disabled={torrentingSaving}
+			aria-label="Toggle torrenting"
+			role="switch"
+			aria-checked={$allowTorrenting}
+		>
+			<span
+				class={`absolute top-1 left-1 w-7 h-7 rounded-full text-[10px] font-semibold flex items-center justify-center transition-all duration-200 ${
+					$allowTorrenting
+						? "translate-x-7 bg-black text-white/90"
+						: "translate-x-0 bg-white/80 text-black"
+				}`}
+			>
+				{$allowTorrenting ? "On" : "Off"}
 			</span>
 		</button>
 	</div>

--- a/packages/app/src/components/player/PlayerControls.svelte
+++ b/packages/app/src/components/player/PlayerControls.svelte
@@ -14,7 +14,6 @@
         AudioWaveform,
         Subtitles,
         Users,
-        SkipForward,
         Download,
         Scissors,
     } from "@lucide/svelte";
@@ -31,7 +30,6 @@
     export let objectFit: "contain" | "cover" = "contain";
     export let pendingSeek: number | null = null;
     export let isWatchPartyMember = false;
-    export let hasNextEpisode = true;
     export let showWatchParty = true;
     export let chapterMarkers: Chapter[] = [];
 
@@ -43,7 +41,6 @@
     export let onVolumeChange: (e: Event) => void;
     export let toggleFullscreen: () => void;
     export let toggleObjectFit: () => void;
-    export let onNextEpisode: () => void;
 
     export let onAudioClick: () => void = () => {};
     export let onSubtitleClick: () => void = () => {};
@@ -65,6 +62,7 @@
     let seekHoverVisible = false;
     let seekHoverLeftPct = 0;
     let seekHoverTime = 0;
+    let seekHoverChapter: Chapter | null = null;
 
     const updateSeekHover = (event: MouseEvent) => {
         if (!duration || duration <= 0) return;
@@ -82,10 +80,14 @@
         seekHoverVisible = true;
         seekHoverLeftPct = ratio * 100;
         seekHoverTime = Math.max(0, Math.min(duration, desiredGlobal));
+        seekHoverChapter = chapterMarkers.find(
+            (chapter) => seekHoverTime >= chapter.startTime && seekHoverTime < chapter.endTime,
+        ) ?? null;
     };
 
     const hideSeekHover = () => {
         seekHoverVisible = false;
+        seekHoverChapter = null;
     };
 
     const setClipPanelOpen = (open: boolean) => {
@@ -108,6 +110,19 @@
         return ((endTime - chapter.startTime) / duration) * 100;
     };
 
+    const getMarkerColor = (chapter: Chapter) => {
+        switch (chapter.kind) {
+            case "intro":
+                return "rgba(59,130,246,0.92)";
+            case "recap":
+                return "rgba(245,158,11,0.92)";
+            case "outro":
+                return "rgba(168,85,247,0.94)";
+            default:
+                return "rgba(87,87,87,0.85)";
+        }
+    };
+
     $: chapterSliderMarkers = duration > 0
         ? chapterMarkers
             .map((chapter) => {
@@ -123,7 +138,7 @@
                 return {
                     left,
                     width,
-                    color: "rgba(87,87,87,0.85)",
+                    color: getMarkerColor(chapter),
                     roundStart: touchesStart || !touchesEnd,
                     roundEnd: touchesEnd || !touchesStart,
                 };
@@ -212,7 +227,7 @@
                             <div
                                 class="tabular-nums bg-[#000000]/60 backdrop-blur-md text-white text-[12px] px-2 py-1 rounded-md"
                             >
-                                {formatTime(seekHoverTime)}
+                                {formatTime(seekHoverTime)}{#if seekHoverChapter} · {seekHoverChapter.title}{/if}
                             </div>
                         </div>
                     {/if}
@@ -269,12 +284,6 @@
                     onClick={onWatchPartyClick}
                 >
                     <Users size={20} color="#E9E9E9" strokeWidth={2} />
-                </ExpandingButton>
-            {/if}
-
-            {#if metaData?.meta.type === "series" && onNextEpisode && !isWatchPartyMember && hasNextEpisode}
-                <ExpandingButton label={"Next Episode"} onClick={onNextEpisode}>
-                    <SkipForward size={20} color="#E9E9E9" strokeWidth={2} />
                 </ExpandingButton>
             {/if}
 

--- a/packages/app/src/components/player/PlayerOverlays.svelte
+++ b/packages/app/src/components/player/PlayerOverlays.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
     export let showSkipIntro = false;
-    export let showNextEpisode = false;
     export let isWatchPartyMember = false;
     export let skipLabel = "Skip Intro";
     export let skipChapter: () => void;
-    export let nextEpisode: () => void;
 </script>
 
 <div
@@ -38,37 +36,6 @@
                 />
             </svg>
             {skipLabel}
-        </button>
-    {/if}
-
-    {#if showNextEpisode && !isWatchPartyMember}
-        <button
-            class="bg-white text-black px-6 py-2 rounded-full font-bold hover:bg-[#FFFFFF]/70 cursor-pointer transition-colors flex items-center gap-2"
-            on:click={nextEpisode}
-        >
-            <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-            >
-                <path
-                    d="M11.9997 5.99994C11.9998 5.60444 12.0937 5.21784 12.2695 4.88902C12.4453 4.5602 12.6952 4.30392 12.9875 4.15258C13.2798 4.00124 13.6014 3.96164 13.9117 4.03877C14.222 4.11591 14.5071 4.30632 14.7309 4.58594L19.5307 10.5859C19.8306 10.961 19.9991 11.4696 19.9991 11.9999C19.9991 12.5303 19.8306 13.0389 19.5307 13.4139L14.7309 19.4139C14.5071 19.6936 14.222 19.884 13.9117 19.9611C13.6014 20.0382 13.2798 19.9986 12.9875 19.8473C12.6952 19.696 12.4453 19.4397 12.2695 19.1109C12.0937 18.782 11.9998 18.3954 11.9997 17.9999V5.99994Z"
-                    stroke="#000000"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                />
-                <path
-                    d="M4 5.99994C4.00007 5.60444 4.09394 5.21784 4.26975 4.88902C4.44556 4.5602 4.69541 4.30392 4.98772 4.15258C5.28003 4.00124 5.60167 3.96164 5.91199 4.03877C6.2223 4.11591 6.50736 4.30632 6.73111 4.58594L11.531 10.5859C11.8309 10.961 11.9994 11.4696 11.9994 11.9999C11.9994 12.5303 11.8309 13.0389 11.531 13.4139L6.73111 19.4139C6.50736 19.6936 6.2223 19.884 5.91199 19.9611C5.60167 20.0382 5.28003 19.9986 4.98772 19.8473C4.69541 19.696 4.44556 19.4397 4.26975 19.1109C4.09394 18.782 4.00007 18.3954 4 17.9999V5.99994Z"
-                    stroke="#000000"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                />
-            </svg>
-            Next Episode
         </button>
     {/if}
 </div>

--- a/packages/app/src/lib/client.ts
+++ b/packages/app/src/lib/client.ts
@@ -4,6 +4,10 @@ export const serverUrl = CORE_BASE;
 export type SessionKind = "http" | "torrent";
 
 export async function createSession(source: string, kind: SessionKind = "http", startTime: number = 0, fileIdx?: number) {
+    if (kind === "torrent") {
+        const { ensureTorrentingAllowed } = await import("./stores/torrenting");
+        await ensureTorrentingAllowed();
+    }
     const res = await fetch(`${CORE_BASE}/sessions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/app/src/lib/client.ts
+++ b/packages/app/src/lib/client.ts
@@ -3,7 +3,7 @@ export const serverUrl = CORE_BASE;
 
 export type SessionKind = "http" | "torrent";
 
-export async function createSession(source: string, kind: SessionKind = "http", startTime: number = 0, fileIdx?: number) {
+export async function createSession(source: string, kind: SessionKind = "http", startTime: number = 0, fileIdx?: number, options?: { prefetch?: boolean }) {
     if (kind === "torrent") {
         const { ensureTorrentingAllowed } = await import("./stores/torrenting");
         await ensureTorrentingAllowed();
@@ -11,7 +11,7 @@ export async function createSession(source: string, kind: SessionKind = "http", 
     const res = await fetch(`${CORE_BASE}/sessions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ source, kind, startTime, fileIdx })
+        body: JSON.stringify({ source, kind, startTime, fileIdx, prefetch: options?.prefetch === true })
     });
 
     if (!res.ok) {

--- a/packages/app/src/lib/stores/torrenting.ts
+++ b/packages/app/src/lib/stores/torrenting.ts
@@ -1,0 +1,65 @@
+import { get, writable } from "svelte/store";
+import { serverUrl } from "../client";
+
+const ALLOW_TORRENTING_KEY = "raffi_allow_torrenting";
+const TORRENT_WARNING_SHOWN_KEY = "torrentWarningShown";
+
+const readStoredBoolean = (key: string, fallback = false) => {
+    try {
+        const value = localStorage.getItem(key);
+        return value == null ? fallback : value === "true";
+    } catch {
+        return fallback;
+    }
+};
+
+export const allowTorrenting = writable(readStoredBoolean(ALLOW_TORRENTING_KEY, false));
+
+allowTorrenting.subscribe((value) => {
+    try {
+        localStorage.setItem(ALLOW_TORRENTING_KEY, value ? "true" : "false");
+    } catch {
+        // Keep the in-memory preference usable when storage is unavailable.
+    }
+});
+
+export const hasAcknowledgedTorrentWarning = () =>
+    readStoredBoolean(TORRENT_WARNING_SHOWN_KEY, false);
+
+export const acknowledgeTorrentWarning = () => {
+    try {
+        localStorage.setItem(TORRENT_WARNING_SHOWN_KEY, "true");
+    } catch {
+        // The server gate still prevents torrenting without explicit consent.
+    }
+};
+
+const updateServerTorrenting = async (enabled: boolean) => {
+    const response = await fetch(`${serverUrl}/settings/torrenting`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+    });
+    if (!response.ok) {
+        const details = await response.text();
+        throw new Error(`Could not ${enabled ? "enable" : "disable"} torrenting: ${details || response.status}`);
+    }
+};
+
+export const setTorrentingAllowed = async (enabled: boolean) => {
+    await updateServerTorrenting(enabled);
+    allowTorrenting.set(enabled);
+};
+
+export const syncTorrentingPreference = async () => {
+    await updateServerTorrenting(get(allowTorrenting));
+};
+
+export const ensureTorrentingAllowed = async () => {
+    if (!get(allowTorrenting)) {
+        throw new Error("Torrenting is disabled. Turn on Allow Torrenting in Settings to play torrent sources.");
+    }
+    // The playback server starts with torrenting disabled. Reassert the persisted
+    // preference here as well as at app startup so restarts and startup races are safe.
+    await updateServerTorrenting(true);
+};

--- a/packages/app/src/pages/meta/navigationLogic.ts
+++ b/packages/app/src/pages/meta/navigationLogic.ts
@@ -66,6 +66,38 @@ export const resolveNextEpisodeStream = async (
     return { stream: match, nextEpisode: nextEp };
 };
 
+export const playResolvedNextEpisode = (
+    resolved: { stream: Stream; nextEpisode: any },
+    progressMap: any,
+) => {
+    const { stream, nextEpisode } = resolved;
+    if (nextEpisode.season !== get(currentSeason)) {
+        currentSeason.set(nextEpisode.season);
+    }
+
+    const isTorrent =
+        stream.infoHash ||
+        (stream.url && stream.url.startsWith("magnet:"));
+
+    if (isTorrent && !hasAcknowledgedTorrentWarning()) {
+        pendingTorrentStream.set(stream);
+        showTorrentWarning.set(true);
+        selectedStreamUrl.set(null);
+        selectedEpisode.set(nextEpisode);
+        router.back();
+    } else if (!isTorrent || get(allowTorrenting)) {
+        selectedEpisode.set(nextEpisode);
+        playStream(stream, progressMap, {
+            replace: true,
+            autoSkipFromNextEpisode: true,
+        });
+    } else {
+        selectedStreamUrl.set(null);
+        selectedEpisode.set(nextEpisode);
+        router.back();
+    }
+};
+
 export const handleNextEpisode = async (imdbID: string, progressMap: any) => {
     const episode = get(selectedEpisode);
     const data = get(metaData);
@@ -118,27 +150,7 @@ export const handleNextEpisode = async (imdbID: string, progressMap: any) => {
 
         if (match) {
             console.log("Auto-selecting matching stream:", match);
-            const isTorrent =
-                match.infoHash ||
-                (match.url && match.url.startsWith("magnet:"));
-
-            if (isTorrent && !hasAcknowledgedTorrentWarning()) {
-                pendingTorrentStream.set(match);
-                showTorrentWarning.set(true);
-                selectedStreamUrl.set(null);
-                selectedEpisode.set(nextEp);
-                router.back();
-            } else if (!isTorrent || get(allowTorrenting)) {
-                selectedEpisode.set(nextEp);
-                playStream(match, progressMap, {
-                    replace: true,
-                    autoSkipFromNextEpisode: true,
-                });
-            } else {
-                selectedStreamUrl.set(null);
-                selectedEpisode.set(nextEp);
-                router.back();
-            }
+            playResolvedNextEpisode({ stream: match, nextEpisode: nextEp }, progressMap);
         } else {
             selectedStreamUrl.set(null);
             selectedEpisode.set(nextEp);

--- a/packages/app/src/pages/meta/navigationLogic.ts
+++ b/packages/app/src/pages/meta/navigationLogic.ts
@@ -7,6 +7,7 @@ import {
 import { router } from "../../lib/stores/router";
 import { fetchStreams, fetchStreamListForEpisodeOnly, playStream } from "./streamLogic";
 import type { Stream } from "./types";
+import { allowTorrenting, hasAcknowledgedTorrentWarning } from "../../lib/stores/torrenting";
 
 export const resolveNextEpisodeStream = async (
     imdbID: string,
@@ -121,18 +122,22 @@ export const handleNextEpisode = async (imdbID: string, progressMap: any) => {
                 match.infoHash ||
                 (match.url && match.url.startsWith("magnet:"));
 
-            if (isTorrent && !localStorage.getItem("torrentWarningShown")) {
+            if (isTorrent && !hasAcknowledgedTorrentWarning()) {
                 pendingTorrentStream.set(match);
                 showTorrentWarning.set(true);
                 selectedStreamUrl.set(null);
                 selectedEpisode.set(nextEp);
                 router.back();
-            } else {
+            } else if (!isTorrent || get(allowTorrenting)) {
                 selectedEpisode.set(nextEp);
                 playStream(match, progressMap, {
                     replace: true,
                     autoSkipFromNextEpisode: true,
                 });
+            } else {
+                selectedStreamUrl.set(null);
+                selectedEpisode.set(nextEp);
+                router.back();
             }
         } else {
             selectedStreamUrl.set(null);

--- a/packages/app/src/pages/meta/streamLogic.ts
+++ b/packages/app/src/pages/meta/streamLogic.ts
@@ -19,6 +19,12 @@ import {
     isStreamFailed,
     markStreamFailed,
 } from "./streamFailures";
+import {
+    acknowledgeTorrentWarning,
+    allowTorrenting,
+    hasAcknowledgedTorrentWarning,
+    setTorrentingAllowed,
+} from "../../lib/stores/torrenting";
 
 let streamFetchGeneration = 0;
 
@@ -250,6 +256,11 @@ export const playStream = (
         url = `magnet:?xt=urn:btih:${stream.infoHash}`;
     }
 
+    if (url?.startsWith("magnet:") && !get(allowTorrenting)) {
+        streamFailureMessage.set("Torrenting is disabled. Turn on Allow Torrenting in Settings to play this source.");
+        return;
+    }
+
     if (url) {
         clearStreamFailureMessage();
         selectedStream.set(stream);
@@ -311,10 +322,14 @@ export const onStreamClick = (stream: Stream, progressMap: any) => {
     const isTorrent = stream.infoHash || (stream.url && stream.url.startsWith("magnet:"));
 
     if (isTorrent) {
-        const hasSeenWarning = localStorage.getItem("torrentWarningShown");
-        if (!hasSeenWarning) {
+        if (!hasAcknowledgedTorrentWarning()) {
             pendingTorrentStream.set(stream);
             showTorrentWarning.set(true);
+            return;
+        }
+        if (!get(allowTorrenting)) {
+            trackEvent("torrent_stream_blocked_disabled", getStreamAnalyticsProps(stream));
+            streamFailureMessage.set("Torrenting is disabled. Turn on Allow Torrenting in Settings to play this source.");
             return;
         }
     }
@@ -322,13 +337,20 @@ export const onStreamClick = (stream: Stream, progressMap: any) => {
     playStream(stream, progressMap);
 };
 
-export const handleTorrentWarningConfirm = (progressMap: any) => {
-    localStorage.setItem("torrentWarningShown", "true");
-    showTorrentWarning.set(false);
+export const handleTorrentWarningConfirm = async (progressMap: any) => {
     const pending = get(pendingTorrentStream);
-    if (pending) {
+    if (!pending) return;
+    try {
+        await setTorrentingAllowed(true);
+        acknowledgeTorrentWarning();
+        showTorrentWarning.set(false);
         trackEvent("torrent_warning_confirmed", getStreamAnalyticsProps(pending));
         playStream(pending, progressMap);
+        pendingTorrentStream.set(null);
+    } catch (error) {
+        console.error("Failed to enable torrenting", error);
+        streamFailureMessage.set("Could not enable torrenting. Please try again from Settings.");
+        showTorrentWarning.set(false);
         pendingTorrentStream.set(null);
     }
 };

--- a/packages/app/src/pages/player/Player.svelte
+++ b/packages/app/src/pages/player/Player.svelte
@@ -20,7 +20,7 @@
         autoSkipIntros,
         miniPlayerOnMinimize,
     } from "../../lib/stores/playbackPreferences";
-    import { ChevronLeft } from "@lucide/svelte";
+    import { ChevronLeft, SkipForward } from "@lucide/svelte";
     import * as NavigationLogic from "../meta/navigationLogic";
     import { streamToPlayableUrl } from "../meta/streamLogic";
     import * as ProgressLogic from "../meta/progressLogic";
@@ -34,6 +34,7 @@
         loadingStage,
         loadingDetails,
         loadingProgress,
+        playbackBuffering,
         showCanvas,
         currentTime,
         duration,
@@ -123,6 +124,12 @@
     };
 
     const handleNextEpisodeInternal = () => {
+        if (nextEpisodePrefetchResolved) {
+            return NavigationLogic.playResolvedNextEpisode(
+                nextEpisodePrefetchResolved,
+                get(metaProgressMap),
+            );
+        }
         if (onNextEpisode) {
             return onNextEpisode();
         }
@@ -138,9 +145,11 @@
     let nextEpisodePrefetchDispose: ((opts?: { transfer?: boolean }) => void) | null =
         null;
     let nextEpisodePrefetchHandoff: NextEpisodePrefetchHandoff | null = null;
+    let nextEpisodePrefetchResolved: Awaited<ReturnType<typeof NavigationLogic.resolveNextEpisodeStream>> = null;
     let bingeAutoAdvancing = false;
     let nextEpisodePrefetchRunId = 0;
     let nextEpisodePrefetchStarting = false;
+    let nextEpisodePrefetchRetryAt = 0;
     let effectiveChapterMarkers: Chapter[] = [];
     let skipButtonLabel = "Skip Intro";
     let miniPlayerActive = false;
@@ -531,8 +540,8 @@
         $sessionData,
         introDbChapters,
     );
-
-    $: showNextEpisodeAllowed = $showNextEpisode && hasNextEpisode;
+    $: nextEpisodePrefetchStartAt = Math.min(nextEpisodePrefetchWindow.startAt, 60);
+    $: nextEpisodeHighlighted = $currentChapter?.kind === "outro";
 
     $: nowPlayingLabel = (() => {
         const name = metaData?.meta?.name;
@@ -552,11 +561,13 @@
     const disposeNextEpisodePrefetch = (opts?: { transfer?: boolean }) => {
         nextEpisodePrefetchRunId += 1;
         nextEpisodePrefetchStarting = false;
+        nextEpisodePrefetchRetryAt = 0;
         if (nextEpisodePrefetchDispose) {
             nextEpisodePrefetchDispose(opts);
             nextEpisodePrefetchDispose = null;
         }
         nextEpisodePrefetchHandoff = null;
+        nextEpisodePrefetchResolved = null;
     };
 
     const handleTorrentError = (message: string) => {
@@ -657,6 +668,7 @@
             };
         },
         startTorrentStatusPolling: torrentStatusPoller.start,
+        awaitTorrentReady: torrentStatusPoller.waitUntilReady,
         stopTorrentStatusPolling: torrentStatusPoller.stop,
         awaitDomUpdate: tick,
     });
@@ -876,7 +888,6 @@
         if (torrentFailureExitTimeout) clearTimeout(torrentFailureExitTimeout);
         clearEmbedLoadFallback();
         clearBrowserAudioCheck();
-        playerSessionLoader.clearLoadTimeout();
         disposeNextEpisodePrefetch();
         Session.cleanupSession(
             hls,
@@ -949,46 +960,63 @@
                     return;
                 }
 
-                if (
-                    imdbID &&
-                    hasNextEpisode &&
-                    !nextEpisodePrefetchDispose &&
-                    !nextEpisodePrefetchStarting &&
-                    time >= nextEpisodePrefetchWindow.startAt &&
-                    time < nextEpisodePrefetchWindow.creditsAt &&
-                    nextEpisodePrefetchWindow.creditsAt > 0
-                ) {
-                    nextEpisodePrefetchStarting = true;
-                    const runId = ++nextEpisodePrefetchRunId;
-                    void (async () => {
-                        try {
-                            const resolved = await NavigationLogic.resolveNextEpisodeStream(imdbID);
-                            if (runId !== nextEpisodePrefetchRunId) return;
-                            if (!nextEpisodePrefetchVideo || !resolved) return;
-                            const playable = streamToPlayableUrl(resolved.stream);
-                            if (!playable) return;
-                            const { dispose, handoff } = await startNextEpisodePrefetch(
-                                playable.url,
-                                playable.fileIdx,
-                                nextEpisodePrefetchVideo,
-                                () => {},
-                            );
-                            if (runId !== nextEpisodePrefetchRunId) {
-                                dispose();
-                                return;
-                            }
-                            nextEpisodePrefetchDispose = dispose;
-                            nextEpisodePrefetchHandoff = handoff;
-                        } finally {
-                            nextEpisodePrefetchStarting = false;
+            }
+
+            if (
+                imdbID &&
+                hasNextEpisode &&
+                !$watchParty.isActive &&
+                !nextEpisodePrefetchDispose &&
+                !nextEpisodePrefetchStarting &&
+                Date.now() >= nextEpisodePrefetchRetryAt &&
+                time >= nextEpisodePrefetchStartAt &&
+                nextEpisodePrefetchWindow.creditsAt > 0
+            ) {
+                nextEpisodePrefetchStarting = true;
+                const runId = ++nextEpisodePrefetchRunId;
+                void (async () => {
+                    try {
+                        const resolved = await NavigationLogic.resolveNextEpisodeStream(imdbID);
+                        if (runId !== nextEpisodePrefetchRunId) return;
+                        if (!nextEpisodePrefetchVideo || !resolved) {
+                            nextEpisodePrefetchRetryAt = Date.now() + 10_000;
+                            return;
                         }
-                    })();
-                }
+                        const playable = streamToPlayableUrl(resolved.stream);
+                        if (!playable) {
+                            nextEpisodePrefetchRetryAt = Date.now() + 10_000;
+                            return;
+                        }
+                        const { dispose, handoff } = await startNextEpisodePrefetch(
+                            playable.url,
+                            playable.fileIdx,
+                            nextEpisodePrefetchVideo,
+                            () => {},
+                        );
+                        if (runId !== nextEpisodePrefetchRunId) {
+                            dispose?.();
+                            return;
+                        }
+                        if (!dispose) {
+                            nextEpisodePrefetchRetryAt = Date.now() + 10_000;
+                            return;
+                        }
+                        nextEpisodePrefetchDispose = dispose;
+                        nextEpisodePrefetchHandoff = handoff;
+                        nextEpisodePrefetchResolved = resolved;
+                    } catch (error) {
+                        console.warn("Next episode prefetch attempt failed", error);
+                        nextEpisodePrefetchRetryAt = Date.now() + 10_000;
+                    } finally {
+                        nextEpisodePrefetchStarting = false;
+                    }
+                })();
             }
         }
     };
 
     const handlePlay = () => {
+        torrentStatusPoller.stop();
         isPlaying.set(true);
         hasStarted = true;
         void traktScrobbler.send("start");
@@ -1063,11 +1091,12 @@
         loadVideo(currentVideoSrc);
     };
 
-    $: if (!$loading) {
-        torrentStatusPoller.stop();
-    }
-
     $: if ($showError && !errorModalOpen) {
+        loading.set(false);
+        loadingStage.set("");
+        loadingDetails.set("");
+        loadingProgress.set(null);
+        playbackBuffering.set(false);
         errorModalOpen = true;
         trackEvent("player_error_shown", {
             message: $errorMessage || null,
@@ -1355,12 +1384,17 @@
                     }
                 }}
                 on:waiting={() => {
-                    captureLoadingBackdrop();
-                    loading.set(true);
-                    loadingStage.set("Buffering");
+                    if (hasStarted) {
+                        playbackBuffering.set(true);
+                    } else {
+                        captureLoadingBackdrop();
+                        loading.set(true);
+                        loadingStage.set("Buffering");
+                    }
                     handleBufferStart();
                 }}
                 on:playing={() => {
+                    playbackBuffering.set(false);
                     loading.set(false);
                     loadingStage.set("");
                     loadingDetails.set("");
@@ -1369,6 +1403,7 @@
                     scheduleBrowserAudioCheck();
                 }}
                 on:canplay={() => {
+                    playbackBuffering.set(false);
                     loading.set(false);
                 }}
                 on:error={handleVideoError}
@@ -1418,6 +1453,12 @@
         progress={$loadingProgress}
     />
 
+    {#if $playbackBuffering && !$loading && !miniPlayerActive && !embedSrc}
+        <div class="pointer-events-none absolute inset-0 z-40 flex items-center justify-center" aria-label="Buffering">
+            <div class="h-14 w-14 animate-spin rounded-full border-4 border-white/25 border-t-white drop-shadow-lg"></div>
+        </div>
+    {/if}
+
     {#if !$loading && !miniPlayerActive}
         <div
             class="absolute left-0 top-0 p-4 sm:p-10 z-50 transition-all duration-300 ease-in-out transform {$controlsVisible
@@ -1433,14 +1474,33 @@
             </button>
         </div>
 
+        {#if metaData?.meta?.type === "series" && hasNextEpisode && !(!$localMode && $watchParty.isActive && !$watchParty.isHost)}
+            <div
+                class="absolute right-0 top-0 p-4 sm:p-10 z-50 transition-all duration-300 ease-in-out transform {nextEpisodeHighlighted || $controlsVisible
+                    ? 'translate-y-0 opacity-100'
+                    : '-translate-y-10 opacity-0 pointer-events-none'} will-change-transform will-change-opacity"
+            >
+                <button
+                    class="backdrop-blur-md transition-all duration-200 rounded-full p-4 cursor-pointer {nextEpisodeHighlighted
+                        ? 'bg-white shadow-[0_0_0_4px_rgba(255,255,255,0.22),0_0_32px_rgba(255,255,255,0.5)] scale-105'
+                        : 'bg-[#000000]/20 hover:bg-[#FFFFFF]/20'}"
+                    on:click={handleNextEpisodeClick}
+                    aria-label="Next episode"
+                    title={nextEpisodeHighlighted ? "Next Episode — Outro" : "Next Episode"}
+                >
+                    <SkipForward size={30} color={nextEpisodeHighlighted ? "black" : "white"} strokeWidth={2} />
+                </button>
+            </div>
+        {/if}
+
         {#if nowPlayingLabel}
             <div
-                class="absolute top-4 inset-x-24 sm:top-10 sm:inset-x-28 z-50 flex items-center justify-center h-14 sm:h-16 pointer-events-none select-none transition-all duration-300 ease-in-out transform {$controlsVisible
+                class="absolute top-4 inset-x-24 sm:top-10 sm:inset-x-28 z-50 flex h-[62px] items-center justify-center pointer-events-none select-none transition-all duration-300 ease-in-out transform {$controlsVisible
                     ? 'translate-y-0 opacity-100'
                     : '-translate-y-10 opacity-0'} will-change-transform will-change-opacity"
             >
                 <span
-                    class="inline-block max-w-full truncate rounded-full bg-[#000000]/60 px-5 py-3 text-[16px] leading-6 font-medium text-white backdrop-blur-md sm:max-w-[640px] sm:px-8 sm:text-[18px] {$controlsVisible
+                    class="inline-flex min-h-[62px] max-w-full items-center truncate rounded-full bg-[#000000]/20 p-4 text-[16px] leading-6 font-medium text-white backdrop-blur-md transition-colors duration-200 sm:max-w-[640px] sm:px-8 sm:text-[18px] {$controlsVisible
                         ? 'pointer-events-auto'
                         : 'pointer-events-none'}"
                     title={nowPlayingLabel}
@@ -1456,11 +1516,9 @@
             >
                 <PlayerOverlays
                     showSkipIntro={$showSkipIntro}
-                    showNextEpisode={showNextEpisodeAllowed}
                     isWatchPartyMember={!$localMode && $watchParty.isActive && !$watchParty.isHost}
                     skipLabel={skipButtonLabel}
                     skipChapter={handleSkipIntro}
-                    nextEpisode={handleNextEpisodeClick}
                 />
 
                 <div
@@ -1480,7 +1538,6 @@
                         {sessionId}
                         {videoSrc}
                         {metaData}
-                        {hasNextEpisode}
                         currentAudioLabel={$currentAudioLabel}
                         currentSubtitleLabel={$currentSubtitleLabel}
                         isWatchPartyMember={!$localMode && $watchParty.isActive && !$watchParty.isHost}
@@ -1493,7 +1550,6 @@
                         toggleFullscreen={handleToggleFullscreen}
                         objectFit={$objectFit}
                         toggleObjectFit={handleToggleObjectFit}
-                        onNextEpisode={handleNextEpisodeClick}
                         showWatchParty={!$localMode && $cloudSyncStatus.cloudFeaturesAvailable && !embedSrc}
                         onAudioClick={openAudioSelection}
                         onSubtitleClick={openSubtitleSelection}

--- a/packages/app/src/pages/player/introdb.ts
+++ b/packages/app/src/pages/player/introdb.ts
@@ -1,10 +1,12 @@
 import type { Chapter, ChapterKind } from "./types";
 
 type IntroDbSegment = {
-    start_sec: number;
-    end_sec: number;
-    confidence: number;
-    submission_count: number;
+    start_sec?: number | string;
+    end_sec?: number | string;
+    start_ms?: number;
+    end_ms?: number;
+    confidence?: number;
+    submission_count?: number;
 };
 
 type IntroDbResponse = {
@@ -17,12 +19,26 @@ type IntroDbResponse = {
 };
 
 const INTRO_DB_BASE_URL = "https://api.introdb.app";
+const chapterCache = new Map<string, Chapter[]>();
+
+const parseTimestamp = (seconds: unknown, milliseconds: unknown): number => {
+    if (typeof seconds === "string" && seconds.includes(":")) {
+        const parts = seconds.split(":").map(Number);
+        if (parts.every(Number.isFinite)) {
+            return parts.reduce((total, part) => total * 60 + part, 0);
+        }
+    }
+    const secondsValue = Number(seconds);
+    if (Number.isFinite(secondsValue)) return secondsValue;
+    const millisecondsValue = Number(milliseconds);
+    return Number.isFinite(millisecondsValue) ? millisecondsValue / 1000 : Number.NaN;
+};
 
 const toChapter = (kind: ChapterKind, segment: IntroDbSegment | null): Chapter | null => {
     if (!segment) return null;
 
-    const startTime = Number(segment.start_sec);
-    const endTime = Number(segment.end_sec);
+    const startTime = parseTimestamp(segment.start_sec, segment.start_ms);
+    const endTime = parseTimestamp(segment.end_sec, segment.end_ms);
     if (!Number.isFinite(startTime) || !Number.isFinite(endTime) || endTime <= startTime) {
         return null;
     }
@@ -50,6 +66,10 @@ export async function fetchIntroDbChapters(
         return [];
     }
 
+    const cacheKey = `${imdbId}:${season}:${episode}`;
+    const cached = chapterCache.get(cacheKey);
+    if (cached) return cached;
+
     const params = new URLSearchParams({
         imdb_id: imdbId,
         season: String(season),
@@ -76,9 +96,19 @@ export async function fetchIntroDbChapters(
         data = (await response.json()) as IntroDbResponse;
     }
 
-    return [
+    if (!data || typeof data !== "object") {
+        return [];
+    }
+
+    const chapters = [
         toChapter("recap", data.recap),
         toChapter("intro", data.intro),
         toChapter("outro", data.outro),
     ].filter((chapter): chapter is Chapter => Boolean(chapter));
+    console.info(
+        chapters.length > 0 ? "Loaded IntroDB chapters" : "No IntroDB chapters available",
+        { imdbId, season, episode, chapters },
+    );
+    chapterCache.set(cacheKey, chapters);
+    return chapters;
 }

--- a/packages/app/src/pages/player/nextEpisodePrefetch.ts
+++ b/packages/app/src/pages/player/nextEpisodePrefetch.ts
@@ -39,7 +39,7 @@ export async function startNextEpisodePrefetch(
     videoElem: HTMLVideoElement,
     onBufferRatio: (ratio: number) => void,
 ): Promise<{
-    dispose: (opts?: { transfer?: boolean }) => void;
+    dispose: ((opts?: { transfer?: boolean }) => void) | null;
     handoff: NextEpisodePrefetchHandoff | null;
 }> {
     let hlsInstance: Hls | null = null;
@@ -96,9 +96,9 @@ export async function startNextEpisodePrefetch(
 
         const kind = src.startsWith("magnet:") ? "torrent" : "http";
         if (fileIdx != null && fileIdx !== undefined) {
-            sessionId = await createSession(src, kind, 0, fileIdx);
+            sessionId = await createSession(src, kind, 0, fileIdx, { prefetch: true });
         } else {
-            sessionId = await createSession(src, kind, 0);
+            sessionId = await createSession(src, kind, 0, undefined, { prefetch: true });
         }
 
         const res = await fetch(`${serverUrl}/sessions/${sessionId}`);
@@ -120,6 +120,7 @@ export async function startNextEpisodePrefetch(
                 setErrorDetails: noop,
             },
             null,
+            "prefetch",
         );
 
         pollId = setInterval(() => {
@@ -136,6 +137,6 @@ export async function startNextEpisodePrefetch(
     } catch (e) {
         console.warn("Next episode prefetch failed", e);
         dispose();
-        return { dispose: () => {}, handoff: null };
+        return { dispose: null, handoff: null };
     }
 }

--- a/packages/app/src/pages/player/playerModalHandlers.ts
+++ b/packages/app/src/pages/player/playerModalHandlers.ts
@@ -10,6 +10,7 @@ import {
     firstSeekLoad,
     loading,
     loadingStage,
+    playbackBuffering,
     pendingSeek,
     playbackOffset,
     seekGuard,
@@ -88,7 +89,7 @@ export const createPlayerModalHandlers = ({
                             {
                                 setPendingSeek: pendingSeek.set,
                                 setSeekGuard: seekGuard.set,
-                                setLoading: loading.set,
+                                setBuffering: playbackBuffering.set,
                                 setShowCanvas: showCanvas.set,
                                 setFirstSeekLoad: firstSeekLoad.set,
                                 setPlaybackOffset: playbackOffset.set,

--- a/packages/app/src/pages/player/playerNextEpisode.ts
+++ b/packages/app/src/pages/player/playerNextEpisode.ts
@@ -28,7 +28,6 @@ export const createNextEpisodeHandler = ({
         nextEpisodeAttemptId += 1;
         const attemptId = nextEpisodeAttemptId;
         setCurrentVideoSrc(getVideoSrc());
-        const beforeSrc = getVideoSrc();
         if (!suppressInitialLoading?.()) {
             loading.set(true);
         }
@@ -53,15 +52,5 @@ export const createNextEpisodeHandler = ({
             showActionLoading("Next Episode Failed", err);
             return;
         }
-
-        window.setTimeout(() => {
-            if (attemptId !== nextEpisodeAttemptId) return;
-            if (get(loading) && getVideoSrc() === beforeSrc) {
-                showActionLoading(
-                    "Next Episode Failed",
-                    "No new stream started. Please try again.",
-                );
-            }
-        }, 10000);
     };
 };

--- a/packages/app/src/pages/player/playerSessionLoader.ts
+++ b/packages/app/src/pages/player/playerSessionLoader.ts
@@ -1,5 +1,6 @@
 import { get } from "svelte/store";
 import type { ShowResponse } from "../../lib/library/types/meta_types";
+import { serverUrl } from "../../lib/client";
 import type { Chapter, Track } from "./types";
 import * as Session from "./videoSession";
 import * as Subtitles from "./subtitles";
@@ -11,6 +12,7 @@ import {
     loadingStage,
     loadingDetails,
     loadingProgress,
+    playbackBuffering,
     showCanvas,
     currentTime,
     duration,
@@ -29,7 +31,6 @@ import {
     seekGuard,
     firstSeekLoad,
     showSeekStyleModal,
-    hasStarted as hasStartedStore,
     currentChapter,
 } from "./playerState";
 
@@ -61,19 +62,12 @@ export type PlayerSessionLoaderDeps = {
         introDbChapters: Chapter[];
     }>;
     startTorrentStatusPolling: (torrentInfoHash: string) => void;
+    awaitTorrentReady: (torrentInfoHash: string) => Promise<void>;
     stopTorrentStatusPolling: () => void;
     awaitDomUpdate: () => Promise<void>;
 };
 
 export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
-    let loadTimeout: ReturnType<typeof setTimeout> | null = null;
-
-    const clearLoadTimeout = () => {
-        if (!loadTimeout) return;
-        clearTimeout(loadTimeout);
-        loadTimeout = null;
-    };
-
     const loadVideo = async (
         src: string,
         opts?: { reuseSession?: { sessionId: string; sessionData: any } },
@@ -141,6 +135,21 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
             );
 
             deps.setSessionId(result.sessionId);
+
+            if (result.sessionData?.isTorrent && result.sessionData?.torrentInfoHash) {
+                const torrentInfoHash = result.sessionData.torrentInfoHash;
+                deps.startTorrentStatusPolling(torrentInfoHash);
+                await deps.awaitTorrentReady(torrentInfoHash);
+
+                const readySession = await fetch(`${serverUrl}/sessions/${result.sessionId}`);
+                if (!readySession.ok) {
+                    throw new Error("Failed to refresh ready torrent session info");
+                }
+                result.sessionData = await readySession.json();
+            } else {
+                deps.stopTorrentStatusPolling();
+            }
+
             sessionData.set(result.sessionData);
 
             const playbackStart = await deps.resolvePlaybackStart({
@@ -152,12 +161,6 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
             });
             const effectiveStartTime = playbackStart.effectiveStartTime;
             deps.setIntroDbChapters(playbackStart.introDbChapters);
-
-            if (result.sessionData?.isTorrent && result.sessionData?.torrentInfoHash) {
-                deps.startTorrentStatusPolling(result.sessionData.torrentInfoHash);
-            } else {
-                deps.stopTorrentStatusPolling();
-            }
 
             await deps.awaitDomUpdate();
             const videoElem = deps.getVideoElem();
@@ -316,7 +319,7 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
                     {
                         setPendingSeek: pendingSeek.set,
                         setSeekGuard: seekGuard.set,
-                        setLoading: loading.set,
+                        setBuffering: playbackBuffering.set,
                         setShowCanvas: showCanvas.set,
                         setFirstSeekLoad: firstSeekLoad.set,
                         setPlaybackOffset: playbackOffset.set,
@@ -334,26 +337,23 @@ export function createPlayerSessionLoader(deps: PlayerSessionLoaderDeps) {
             );
             deps.setHls(hlsInstance);
 
-            clearLoadTimeout();
-            loadTimeout = setTimeout(() => {
-                if (
-                    get(loading) &&
-                    !get(hasStartedStore) &&
-                    !get(isPlaying)
-                ) {
-                    loading.set(false);
-                    showError.set(true);
-                    errorMessage.set("Stream took too long to load");
-                    errorDetails.set("Please try another stream.");
-                }
-            }, 60000);
         } catch (err) {
-            console.error(err);
+            console.error("Failed to prepare playback", err);
+            deps.stopTorrentStatusPolling();
+            playbackBuffering.set(false);
+            loading.set(false);
+            loadingStage.set("");
+            loadingDetails.set("");
+            loadingProgress.set(null);
+            showCanvas.set(false);
+            seekGuard.set(false);
+            errorMessage.set("Failed to prepare stream");
+            errorDetails.set(err instanceof Error ? err.message : String(err));
+            showError.set(true);
         }
     };
 
     return {
-        clearLoadTimeout,
         loadVideo,
     };
 }

--- a/packages/app/src/pages/player/playerState.ts
+++ b/packages/app/src/pages/player/playerState.ts
@@ -8,6 +8,7 @@ export const loading = writable(true);
 export const loadingStage = writable("Loading...");
 export const loadingDetails = writable("");
 export const loadingProgress = writable<number | null>(null);
+export const playbackBuffering = writable(false);
 export const showCanvas = writable(false);
 export const hasStarted = writable(false);
 
@@ -66,6 +67,7 @@ export function resetPlayerState() {
     loadingStage.set("Loading...");
     loadingDetails.set("");
     loadingProgress.set(null);
+    playbackBuffering.set(false);
     showCanvas.set(false);
     hasStarted.set(false);
     currentTime.set(0);

--- a/packages/app/src/pages/player/torrentStatusPolling.ts
+++ b/packages/app/src/pages/player/torrentStatusPolling.ts
@@ -11,6 +11,9 @@ export const createTorrentStatusPoller = ({
     let intervalRef: ReturnType<typeof setInterval> | null = null;
     let statusHash: string | null = null;
     let fatalHandled = false;
+    let readyPromise: Promise<void> | null = null;
+    let resolveReady: (() => void) | null = null;
+    let rejectReady: ((error: Error) => void) | null = null;
 
     const stop = () => {
         if (intervalRef) {
@@ -19,6 +22,12 @@ export const createTorrentStatusPoller = ({
         }
         statusHash = null;
         fatalHandled = false;
+        if (rejectReady) {
+            rejectReady(new Error("Torrent readiness wait canceled"));
+        }
+        readyPromise = null;
+        resolveReady = null;
+        rejectReady = null;
     };
 
     const start = (hash: string) => {
@@ -28,6 +37,10 @@ export const createTorrentStatusPoller = ({
         stop();
         statusHash = hash;
         fatalHandled = false;
+        readyPromise = new Promise<void>((resolve, reject) => {
+            resolveReady = resolve;
+            rejectReady = reject;
+        });
 
         const poll = async () => {
             try {
@@ -52,6 +65,9 @@ export const createTorrentStatusPoller = ({
                         fatalHandled = true;
                         onTorrentError?.(error);
                     }
+                    rejectReady?.(new Error(error));
+                    resolveReady = null;
+                    rejectReady = null;
                     return;
                 }
 
@@ -82,6 +98,9 @@ export const createTorrentStatusPoller = ({
                         loadingDetails.set("");
                     }
                     loadingProgress.set(null);
+                    resolveReady?.();
+                    resolveReady = null;
+                    rejectReady = null;
                 }
             } catch {
                 // ignore polling errors
@@ -92,8 +111,14 @@ export const createTorrentStatusPoller = ({
         intervalRef = setInterval(poll, 1000);
     };
 
+    const waitUntilReady = (hash: string) => {
+        start(hash);
+        return readyPromise ?? Promise.resolve();
+    };
+
     return {
         start,
         stop,
+        waitUntilReady,
     };
 };

--- a/packages/app/src/pages/player/videoSession.ts
+++ b/packages/app/src/pages/player/videoSession.ts
@@ -341,7 +341,7 @@ export async function loadVideoSession(
       sessionId = reuse.sessionId;
       setLoadingStage?.("Using prefetched stream");
       setLoadingDetails?.("");
-      const res = await fetch(`${serverUrl}/sessions/${sessionId}`);
+      const res = await fetch(`${serverUrl}/sessions/${sessionId}?playback=1`);
       if (!res.ok) throw new Error("Failed to load session info");
       sessionData = await res.json();
       setPlaybackOffset(startTime);
@@ -497,6 +497,7 @@ export function initHLS(
     setErrorDetails: (details: string) => void;
   },
   initialSeekTime: number | null = null,
+  bufferMode: "playback" | "prefetch" = "playback",
 ): Hls | null {
   const {
     setLoading,
@@ -543,10 +544,12 @@ export function initHLS(
   let hls: Hls | null = null;
 
   if (Hls.isSupported()) {
+    const maxBufferLength = bufferMode === "prefetch" ? 12 : 50;
+    const maxMaxBufferLength = bufferMode === "prefetch" ? 12 : 80;
     hls = new Hls({
       lowLatencyMode: false,
-      maxBufferLength: 50,
-      maxMaxBufferLength: 80,
+      maxBufferLength,
+      maxMaxBufferLength,
       backBufferLength: 30,
       maxBufferHole: 0,
       maxFragLookUpTolerance: 0,
@@ -775,7 +778,7 @@ export function createSeekHandler(
   setStates: {
     setPendingSeek: (seek: number | null) => void;
     setSeekGuard: (guard: boolean) => void;
-    setLoading: (loading: boolean) => void;
+    setBuffering: (buffering: boolean) => void;
     setShowCanvas: (show: boolean) => void;
     setFirstSeekLoad: (load: boolean) => void;
     setPlaybackOffset: (offset: number) => void;
@@ -784,7 +787,7 @@ export function createSeekHandler(
   const {
     setPendingSeek,
     setSeekGuard,
-    setLoading,
+    setBuffering,
     setShowCanvas,
     setFirstSeekLoad,
     setPlaybackOffset,
@@ -806,13 +809,13 @@ export function createSeekHandler(
     }
 
     setSeekGuard(true);
-    setLoading(true);
+    setBuffering(true);
     setShowCanvas(true);
     setFirstSeekLoad(true);
     const sessionId = getSessionId();
     if (!sessionId) {
       setSeekGuard(false);
-      setLoading(false);
+      setBuffering(false);
       setShowCanvas(false);
       return;
     }
@@ -826,7 +829,6 @@ export function createSeekHandler(
       const onSeekParsed = () => {
         console.log("HLS MANIFEST_PARSED (seek)");
         setSeekGuard(false);
-        setLoading(false);
         setShowCanvas(false);
 
         // Re-fetch subtitles if active
@@ -855,7 +857,6 @@ export function createSeekHandler(
         setPlaybackOffset(desiredGlobal);
         videoElem.currentTime = 0;
         setSeekGuard(false);
-        setLoading(false);
         setShowCanvas(false);
 
         // Re-fetch subtitles if active

--- a/packages/app/src/pages/player/videoSession.ts
+++ b/packages/app/src/pages/player/videoSession.ts
@@ -595,6 +595,11 @@ export function initHLS(
       }
     };
 
+    let networkRetries = 0;
+    let mediaRetries = 0;
+    const MAX_NETWORK_RETRIES = 5;
+    const MAX_MEDIA_RETRIES = 3;
+
     hls.on(Hls.Events.MANIFEST_LOADED, (_, data) => {
       console.log("MANIFEST_LOADED data:", data);
       if (
@@ -625,10 +630,16 @@ export function initHLS(
 
     hls.on(Hls.Events.MANIFEST_PARSED, onInitialParsed);
 
-    let networkRetries = 0;
-    let mediaRetries = 0;
-    const MAX_NETWORK_RETRIES = 5;
-    const MAX_MEDIA_RETRIES = 3;
+    // Retries represent consecutive failures, not every transient failure over
+    // the lifetime of a movie. A successful fragment proves the pipeline has
+    // recovered and must reset the circuit breaker.
+    hls.on(Hls.Events.FRAG_LOADED, () => {
+      networkRetries = 0;
+    });
+    hls.on(Hls.Events.FRAG_BUFFERED, () => {
+      networkRetries = 0;
+      mediaRetries = 0;
+    });
 
     hls.on(Hls.Events.ERROR, (_, data) => {
       console.error("HLS ERROR", data);

--- a/services/server/main.go
+++ b/services/server/main.go
@@ -103,6 +103,7 @@ func main() {
 	mux.HandleFunc("/sessions/", srv.handleSessionByID)
 	mux.HandleFunc("/cleanup", srv.handleCleanup)
 	mux.HandleFunc("/torrents/", srv.torrentStreamer.ServeHTTP)
+	mux.HandleFunc("/settings/torrenting", srv.handleTorrentingSetting)
 	mux.HandleFunc("/community-addons", srv.handleCommunityAddons)
 
 	addr := strings.TrimSpace(os.Getenv("RAFFI_SERVER_ADDR"))
@@ -303,6 +304,10 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	if req.Kind == session.SessionKindTorrent {
 		streamURL, infoHash, err := s.torrentStreamer.AddTorrent(req.Source, req.FileIdx)
 		if err != nil {
+			if errors.Is(err, stream.ErrTorrentingDisabled) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
 			http.Error(w, fmt.Sprintf("failed to start torrent: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -324,6 +329,54 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, struct {
 		ID string `json:"id"`
 	}{ID: sess.ID})
+}
+
+func (s *Server) handleTorrentingSetting(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method == http.MethodGet {
+		writeJSON(w, struct {
+			Enabled bool `json:"enabled"`
+		}{Enabled: s.torrentStreamer.IsEnabled()})
+		return
+	}
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.Enabled {
+		if err := s.torrentStreamer.Enable(); err != nil {
+			http.Error(w, fmt.Sprintf("failed to enable torrenting: %v", err), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		s.torrentStreamer.Disable()
+		for _, sess := range s.sessions.List() {
+			if sess == nil || !sess.IsTorrent {
+				continue
+			}
+			if s.hlsController != nil {
+				_ = s.hlsController.StopSession(sess.ID)
+			}
+			s.probeMu.Lock()
+			delete(s.probeCooldown, sess.ID)
+			s.probeMu.Unlock()
+			_ = s.sessions.Delete(sess.ID)
+		}
+	}
+	writeJSON(w, struct {
+		Enabled bool `json:"enabled"`
+	}{Enabled: s.torrentStreamer.IsEnabled()})
 }
 
 // /sessions/{id}         GET -> info
@@ -693,7 +746,7 @@ func withCORS(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
 		}
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, HEAD")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS, DELETE, HEAD")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept-Encoding, Range, Origin, Accept")
 		w.Header().Set("Access-Control-Expose-Headers", "X-Raffi-Slice-Start, Accept-Ranges, Content-Range, Content-Length")
 		w.Header().Set("Access-Control-Max-Age", "86400")

--- a/services/server/main.go
+++ b/services/server/main.go
@@ -237,9 +237,7 @@ func (s *Server) handleSubtitleTrack(w http.ResponseWriter, r *http.Request, id,
 		}
 	}
 	if !found && s.hlsController != nil {
-		ctx, cancel := context.WithTimeout(r.Context(), 12*time.Second)
-		meta, probeErr := s.hlsController.ProbeMetadata(ctx, sess.ID, sess.Source)
-		cancel()
+		meta, probeErr := s.hlsController.ProbeMetadata(r.Context(), sess.ID, sess.Source)
 		if probeErr == nil && meta != nil {
 			streams, _ := hls.StreamsFromMetadata(meta)
 			for _, stream := range streams {
@@ -292,6 +290,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 		Kind      session.SessionKind `json:"kind"`
 		StartTime float64             `json:"startTime"`
 		FileIdx   *int                `json:"fileIdx,omitempty"`
+		Prefetch  bool                `json:"prefetch,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
@@ -324,6 +323,9 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if req.Prefetch && s.hlsController != nil {
+		s.hlsController.SetBufferAheadLimit(sess.ID, hls.PrefetchBufferAhead)
 	}
 
 	writeJSON(w, struct {
@@ -446,6 +448,9 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request, id str
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
+	if r.URL.Query().Get("playback") == "1" && s.hlsController != nil {
+		s.hlsController.SetBufferAheadLimit(sess.ID, hls.MaxBufferAhead)
+	}
 
 	if sess.Kind == session.SessionKindHTTP && s.hlsController != nil {
 		if audioIdx, streams, ok := s.hlsController.DescribeSession(sess.ID); ok {
@@ -479,17 +484,12 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request, id str
 			var meta *hls.Metadata
 			var probeErr error
 			maxAttempts := 3
-			probeTimeout := 12 * time.Second
 			if sess.IsTorrent {
 				maxAttempts = 2
-				probeTimeout = 30 * time.Second
 			}
 
 			for attempt := 0; attempt < maxAttempts; attempt++ {
-				ctx := r.Context()
-				ctx, cancel := context.WithTimeout(ctx, probeTimeout)
-				meta, probeErr = s.hlsController.ProbeMetadata(ctx, sess.ID, sess.Source)
-				cancel()
+				meta, probeErr = s.hlsController.ProbeMetadata(r.Context(), sess.ID, sess.Source)
 				if probeErr == nil && meta != nil {
 					break
 				}
@@ -582,31 +582,32 @@ func (s *Server) handleHLSSessionAsset(w http.ResponseWriter, r *http.Request, s
 		forceSlice := r.URL.Query().Get("force_slice") == "1"
 
 		sliceStart := 0.0
+		manifestPath := ""
 		if s.hlsController != nil {
 			sliceStart = s.hlsController.GetSliceStart(sess.ID)
 		}
 
 		if start != "" {
 			if val, err := strconv.ParseFloat(start, 64); err == nil && val >= 0 {
-				shouldSeek := forceSlice || !s.hlsController.IsDuplicateSeek(sess.ID, seekID)
-				if shouldSeek {
-					dur, actualStart, _, err := s.hlsController.Seek(r.Context(), sess.ID, sess.Source, val, seekID, forceSlice)
-					if err != nil {
-						log.Printf("seek error for %s: %v", sess.ID, err)
-						http.Error(w, "failed to seek", http.StatusInternalServerError)
-						return
-					}
-					if dur > 0 {
-						sess.DurationSeconds = dur
-					}
-					sliceStart = actualStart
+				dur, actualStart, readyManifestPath, err := s.hlsController.Seek(r.Context(), sess.ID, sess.Source, val, seekID, forceSlice)
+				if err != nil {
+					log.Printf("seek error for %s: %v", sess.ID, err)
+					http.Error(w, "failed to seek", http.StatusInternalServerError)
+					return
 				}
+				if dur > 0 {
+					sess.DurationSeconds = dur
+				}
+				sliceStart = actualStart
+				manifestPath = readyManifestPath
 			}
 		} else {
-			if _, _, err := s.hlsController.EnsureSession(r.Context(), sess.ID, sess.Source, sess.StartTime); err != nil {
+			if _, readyManifestPath, err := s.hlsController.EnsureSession(r.Context(), sess.ID, sess.Source, sess.StartTime); err != nil {
 				log.Printf("failed to prepare stream for session %s (source=%s): %v", sess.ID, sess.Source, err)
 				http.Error(w, "failed to prepare stream", http.StatusInternalServerError)
 				return
+			} else {
+				manifestPath = readyManifestPath
 			}
 			sliceStart = s.hlsController.GetSliceStart(sess.ID)
 		}
@@ -618,7 +619,10 @@ func (s *Server) handleHLSSessionAsset(w http.ResponseWriter, r *http.Request, s
 			http.Error(w, "no active slice", http.StatusInternalServerError)
 			return
 		}
-		fullPath := filepath.Clean(filepath.Join(sliceDir, asset))
+		fullPath := manifestPath
+		if fullPath == "" {
+			fullPath = filepath.Clean(filepath.Join(sliceDir, asset))
+		}
 
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
@@ -676,11 +680,15 @@ func (s *Server) handleHLSSessionAsset(w http.ResponseWriter, r *http.Request, s
 	if s.hlsController != nil {
 		ext := strings.ToLower(filepath.Ext(fullPath))
 		if ext == ".ts" {
-			s.hlsController.NotifyClientAssetRequest(sess.ID)
+			if _, err := os.Stat(fullPath); errors.Is(err, os.ErrNotExist) {
+				s.hlsController.NotifyClientAssetRequest(sess.ID)
+			}
 		}
 	}
 
-	if err := waitForFile(r.Context(), fullPath, 20*time.Second); err != nil {
+	if err := waitForFile(r.Context(), fullPath, func() bool {
+		return s.hlsController != nil && s.hlsController.IsProducing(sess.ID)
+	}); err != nil {
 		log.Printf("segment wait failed for %s: %v", fullPath, err)
 		http.Error(w, "segment unavailable", http.StatusServiceUnavailable)
 		return
@@ -708,10 +716,8 @@ func (s *Server) handleHLSSessionAsset(w http.ResponseWriter, r *http.Request, s
 	http.ServeFile(w, r, fullPath)
 }
 
-func waitForFile(ctx context.Context, p string, timeout time.Duration) error {
-	deadline := time.NewTimer(timeout)
+func waitForFile(ctx context.Context, p string, producerActive func() bool) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
-	defer deadline.Stop()
 	defer ticker.Stop()
 
 	for {
@@ -720,15 +726,13 @@ func waitForFile(ctx context.Context, p string, timeout time.Duration) error {
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
+		if producerActive != nil && !producerActive() {
+			return fmt.Errorf("stream producer stopped before file was ready: %s", p)
+		}
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-deadline.C:
-			if _, err := os.Stat(p); err == nil {
-				return nil
-			}
-			return fmt.Errorf("timeout waiting for file: %s", p)
 		case <-ticker.C:
 		}
 	}

--- a/services/server/src/session/session.go
+++ b/services/server/src/session/session.go
@@ -47,6 +47,7 @@ type Chapter struct {
 type Store interface {
 	Create(source string, kind SessionKind, startTime float64) (*Session, error)
 	Get(id string) (*Session, error)
+	List() []*Session
 	Delete(id string) error
 }
 
@@ -103,6 +104,16 @@ func (s *memoryStore) Get(id string) (*Session, error) {
 		return nil, errors.New("not found")
 	}
 	return sess, nil
+}
+
+func (s *memoryStore) List() []*Session {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sessions := make([]*Session, 0, len(s.sessions))
+	for _, sess := range s.sessions {
+		sessions = append(sessions, sess)
+	}
+	return sessions
 }
 
 func (s *memoryStore) Delete(id string) error {

--- a/services/server/src/stream/hls/controller.go
+++ b/services/server/src/stream/hls/controller.go
@@ -121,13 +121,23 @@ func (c *Controller) EnsureSession(ctx context.Context, id, source string, start
 		return 0, "", err
 	}
 
-	if err := c.ensureCmdLocked(id, source, sess, sess.Slices[sess.SliceIndex].StartTime, sliceDir, false, len(sess.AvailableStreams) > 0); err != nil {
+	resumeAt := sess.Slices[sess.SliceIndex].StartTime
+	startSequence := sess.SliceIndex
+	appendMode := false
+	manifestPath := filepath.Join(sliceDir, "child.m3u8")
+	if resumeTime, nextSequence, ok := playlistResumePoint(manifestPath, resumeAt); ok {
+		resumeAt = resumeTime
+		startSequence = nextSequence
+		appendMode = true
+		log.Printf("Resuming interrupted HLS session %s at %.2fs (sequence %d)", id, resumeAt, startSequence)
+	}
+
+	if err := c.ensureCmdLocked(id, source, sess, resumeAt, startSequence, sliceDir, appendMode, len(sess.AvailableStreams) > 0); err != nil {
 		c.mu.Unlock()
 		return 0, "", err
 	}
 
 	duration := sess.DurationHint
-	manifestPath := filepath.Join(sliceDir, "child.m3u8")
 	abortFn := c.transcoderAbortFn(id)
 	c.mu.Unlock()
 
@@ -168,40 +178,20 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 		}
 		duration := meta.Format.DurationSeconds
 
-		audioIndex := 0
-		audioCount := 0
-		foundEng := false
-		for _, st := range meta.Streams {
-			if st.CodecType == "audio" {
-				if st.Tags.Language == "eng" && !foundEng {
-					audioIndex = audioCount
-					foundEng = true
-				}
-				audioCount++
-			}
-		}
-
-		// Find codec for selected audio index
-		audioCodec := "aac" // Default
-		currentAudioIdx := 0
-		for _, st := range meta.Streams {
-			if st.CodecType == "audio" {
-				if currentAudioIdx == audioIndex {
-					audioCodec = st.CodecName
-					break
-				}
-				currentAudioIdx++
-			}
-		}
+		streams, audioIndex := StreamsFromMetadata(meta)
+		audioCodec := AudioCodecForIndex(meta, audioIndex)
 
 		sess = &Session{
-			WorkDir:       baseDir,
-			DurationHint:  duration,
-			Codec:         codec,
-			AudioIndex:    audioIndex,
-			AudioCodec:    audioCodec,
-			LastServedSeq: -1,
-			SliceIndex:    0,
+			ID:               id,
+			Source:           source,
+			WorkDir:          baseDir,
+			DurationHint:     duration,
+			Codec:            codec,
+			AudioIndex:       audioIndex,
+			AudioCodec:       audioCodec,
+			AvailableStreams: streams,
+			LastServedSeq:    -1,
+			SliceIndex:       0,
 			Slices: []SliceInfo{
 				{Index: 0, StartTime: target},
 			},
@@ -216,7 +206,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 			return 0, 0, "", err
 		}
 
-		if err := c.ensureCmdLocked(id, source, sess, target, sliceDir, false, len(sess.AvailableStreams) > 0); err != nil {
+		if err := c.ensureCmdLocked(id, source, sess, target, sess.SliceIndex, sliceDir, false, len(sess.AvailableStreams) > 0); err != nil {
 			c.mu.Unlock()
 			return 0, 0, "", err
 		}
@@ -264,7 +254,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 		for _, slice := range sess.Slices {
 			sliceDir := filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", slice.Index))
 			manifestPath := filepath.Join(sliceDir, "child.m3u8")
-			_, timeline, err := readPlaylistTimeline(manifestPath, slice.StartTime)
+			mediaSeq, timeline, err := readPlaylistTimeline(manifestPath, slice.StartTime)
 			if err != nil || len(timeline) == 0 {
 				continue
 			}
@@ -296,7 +286,8 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 
 			if sess.Cmd == nil && !sess.Finished && endTime < sess.DurationHint {
 				resumeTime := endTime
-				if err := c.ensureCmdLocked(id, source, sess, resumeTime, sliceDir, true, len(sess.AvailableStreams) > 0); err != nil {
+				nextSequence := mediaSeq + len(timeline)
+				if err := c.ensureCmdLocked(id, source, sess, resumeTime, nextSequence, sliceDir, true, len(sess.AvailableStreams) > 0); err != nil {
 					log.Printf("Failed to resume slice %d: %v", slice.Index, err)
 				}
 			}
@@ -321,7 +312,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 		return 0, 0, "", err
 	}
 
-	if err := c.ensureCmdLocked(id, source, sess, target, sliceDir, false, len(sess.AvailableStreams) > 0); err != nil {
+	if err := c.ensureCmdLocked(id, source, sess, target, sess.SliceIndex, sliceDir, false, len(sess.AvailableStreams) > 0); err != nil {
 		c.mu.Unlock()
 		return 0, 0, "", err
 	}

--- a/services/server/src/stream/hls/controller.go
+++ b/services/server/src/stream/hls/controller.go
@@ -16,15 +16,16 @@ import (
 const (
 	DefaultSegmentDuration = 6 * time.Second
 	MaxBufferAhead         = 90 * time.Second
-	sliceReuseSafetyMargin = 5.0
+	PrefetchBufferAhead    = 12 * time.Second
 )
 
 type Controller struct {
-	mu         sync.Mutex
-	sessions   map[string]*Session
-	probeCache map[string]probeCacheEntry
-	ffprobeFn  func(ctx context.Context, source string) (*Metadata, string, error)
-	startCmd   TranscoderFunc
+	mu           sync.Mutex
+	sessions     map[string]*Session
+	probeCache   map[string]probeCacheEntry
+	bufferLimits map[string]time.Duration
+	ffprobeFn    func(ctx context.Context, source string) (*Metadata, string, error)
+	startCmd     TranscoderFunc
 }
 
 type probeCacheEntry struct {
@@ -34,10 +35,11 @@ type probeCacheEntry struct {
 
 func NewController(ffmpegPath, ffprobePath string) *Controller {
 	return &Controller{
-		sessions:   make(map[string]*Session),
-		probeCache: make(map[string]probeCacheEntry),
-		ffprobeFn:  NewProbeDuration(ffprobePath),
-		startCmd:   NewTranscoder(ffmpegPath),
+		sessions:     make(map[string]*Session),
+		probeCache:   make(map[string]probeCacheEntry),
+		bufferLimits: make(map[string]time.Duration),
+		ffprobeFn:    NewProbeDuration(ffprobePath),
+		startCmd:     NewTranscoder(ffmpegPath),
 	}
 }
 
@@ -71,14 +73,7 @@ func (c *Controller) EnsureSession(ctx context.Context, id, source string, start
 			return 0, "", err
 		}
 
-		probeCtx := ctx
-		if isTorrentSource(source) {
-			ctxProbe, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
-			probeCtx = ctxProbe
-		}
-
-		meta, codec, err := c.getOrProbeLocked(probeCtx, source)
+		meta, codec, err := c.getOrProbeLocked(ctx, source)
 		if err != nil {
 			c.mu.Unlock()
 			return 0, "", fmt.Errorf("probe failed: %w", err)
@@ -97,6 +92,7 @@ func (c *Controller) EnsureSession(ctx context.Context, id, source string, start
 			AudioIndex:       audioIndex,
 			AudioCodec:       audioCodec,
 			AvailableStreams: streams,
+			BufferAheadLimit: c.bufferAheadLimitLocked(id),
 			LastServedSeq:    -1,
 			SliceIndex:       0,
 			Slices: []SliceInfo{
@@ -111,8 +107,16 @@ func (c *Controller) EnsureSession(ctx context.Context, id, source string, start
 	if (sess.Cmd != nil && sess.Cmd.Process != nil) || sess.Finished {
 		sliceDir := filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", sess.SliceIndex))
 		manifestPath := filepath.Join(sliceDir, "child.m3u8")
+		duration := sess.DurationHint
+		active := sess.Cmd != nil && sess.Cmd.Process != nil
+		abortFn := c.transcoderAbortFn(id)
 		c.mu.Unlock()
-		return sess.DurationHint, manifestPath, nil
+		if active {
+			if err := waitForManifestReady(ctx, manifestPath, abortFn); err != nil {
+				return 0, "", err
+			}
+		}
+		return duration, manifestPath, nil
 	}
 
 	sliceDir := filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", sess.SliceIndex))
@@ -141,11 +145,7 @@ func (c *Controller) EnsureSession(ctx context.Context, id, source string, start
 	abortFn := c.transcoderAbortFn(id)
 	c.mu.Unlock()
 
-	manifestTimeout := 10 * time.Second
-	if isTorrentSource(source) {
-		manifestTimeout = 60 * time.Second
-	}
-	if err := waitForManifestReady(manifestPath, manifestTimeout, abortFn); err != nil {
+	if err := waitForManifestReady(ctx, manifestPath, abortFn); err != nil {
 		return 0, "", err
 	}
 
@@ -165,13 +165,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 			return 0, 0, "", err
 		}
 
-		probeCtx := ctx
-		if isTorrentSource(source) {
-			ctxProbe, cancel := context.WithTimeout(ctx, 2*time.Minute)
-			defer cancel()
-			probeCtx = ctxProbe
-		}
-		meta, codec, err := c.getOrProbeLocked(probeCtx, source)
+		meta, codec, err := c.getOrProbeLocked(ctx, source)
 		if err != nil {
 			c.mu.Unlock()
 			return 0, 0, "", fmt.Errorf("probe failed: %w", err)
@@ -190,6 +184,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 			AudioIndex:       audioIndex,
 			AudioCodec:       audioCodec,
 			AvailableStreams: streams,
+			BufferAheadLimit: c.bufferAheadLimitLocked(id),
 			LastServedSeq:    -1,
 			SliceIndex:       0,
 			Slices: []SliceInfo{
@@ -215,11 +210,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 		abortFn := c.transcoderAbortFn(id)
 		c.mu.Unlock()
 
-		manifestTimeout := 10 * time.Second
-		if isTorrentSource(source) {
-			manifestTimeout = 60 * time.Second
-		}
-		if err := waitForManifestReady(manifestPath, manifestTimeout, abortFn); err != nil {
+		if err := waitForManifestSegments(ctx, manifestPath, abortFn, 1); err != nil {
 			return 0, 0, "", err
 		}
 
@@ -238,8 +229,16 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 			}
 		}
 
+		duration := sess.DurationHint
+		active := sess.Cmd != nil && sess.Cmd.Process != nil
+		abortFn := c.transcoderAbortFn(id)
 		c.mu.Unlock()
-		return sess.DurationHint, startTime, manifestPath, nil
+		if active {
+			if err := waitForManifestSegments(ctx, manifestPath, abortFn, 1); err != nil {
+				return 0, 0, "", err
+			}
+		}
+		return duration, startTime, manifestPath, nil
 	}
 
 	if target < 0 {
@@ -261,7 +260,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 
 			lastSegment := timeline[len(timeline)-1]
 			endTime := lastSegment.End
-			if target < slice.StartTime || target >= (endTime-sliceReuseSafetyMargin) {
+			if target < slice.StartTime || target >= endTime {
 				continue
 			}
 
@@ -322,7 +321,7 @@ func (c *Controller) Seek(ctx context.Context, id, source string, target float64
 	abortFn := c.transcoderAbortFn(id)
 	c.mu.Unlock()
 
-	if err := waitForManifestReady(manifestPath, 10*time.Second, abortFn); err != nil {
+	if err := waitForManifestSegments(ctx, manifestPath, abortFn, 1); err != nil {
 		return 0, 0, "", err
 	}
 
@@ -385,6 +384,35 @@ func (c *Controller) CurrentSliceDir(id string) string {
 		return ""
 	}
 	return filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", sess.SliceIndex))
+}
+
+func (c *Controller) SetBufferAheadLimit(id string, limit time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if limit <= 0 || limit >= MaxBufferAhead {
+		delete(c.bufferLimits, id)
+		limit = MaxBufferAhead
+	} else {
+		c.bufferLimits[id] = limit
+	}
+	if sess := c.sessions[id]; sess != nil {
+		sess.BufferAheadLimit = limit
+		c.adjustThrottleLocked(sess)
+	}
+}
+
+func (c *Controller) bufferAheadLimitLocked(id string) time.Duration {
+	if limit := c.bufferLimits[id]; limit > 0 {
+		return limit
+	}
+	return MaxBufferAhead
+}
+
+func (c *Controller) IsProducing(id string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sess := c.sessions[id]
+	return sess != nil && sess.Cmd != nil && !sess.Finished
 }
 
 func (c *Controller) GetAllSessionIDs() []string {

--- a/services/server/src/stream/hls/lifecycle.go
+++ b/services/server/src/stream/hls/lifecycle.go
@@ -81,6 +81,7 @@ func (c *Controller) ensureCmdLocked(
 	id, source string,
 	sess *Session,
 	seek float64,
+	startSeq int,
 	outDir string,
 	append bool,
 	hasAudio bool,
@@ -94,7 +95,7 @@ func (c *Controller) ensureCmdLocked(
 	ctxCmd, cancel := context.WithCancel(context.Background())
 	sess.CmdCancel = cancel
 
-	cmd, err := c.startCmd(ctxCmd, source, outDir, seek, sess.SliceIndex, DefaultSegmentDuration, MaxBufferAhead, sess.Codec, sess.AudioIndex, sess.AudioCodec, append, hasAudio)
+	cmd, err := c.startCmd(ctxCmd, source, outDir, seek, startSeq, DefaultSegmentDuration, MaxBufferAhead, sess.Codec, sess.AudioIndex, sess.AudioCodec, append, hasAudio)
 	if err != nil {
 		cancel()
 		return err
@@ -105,7 +106,9 @@ func (c *Controller) ensureCmdLocked(
 	sess.CurrentlyAt = seek
 	sess.Paused = false
 	sess.PausedByCap = false
-	sess.LastServedSeq = -1
+	if !append {
+		sess.LastServedSeq = -1
+	}
 	sess.Finished = false
 
 	go func(sessionID string, command *exec.Cmd, cmdCtx context.Context) {

--- a/services/server/src/stream/hls/lifecycle.go
+++ b/services/server/src/stream/hls/lifecycle.go
@@ -13,6 +13,7 @@ func (c *Controller) StopSession(id string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	sess := c.sessions[id]
+	delete(c.bufferLimits, id)
 	if sess == nil {
 		return nil
 	}
@@ -107,7 +108,9 @@ func (c *Controller) ensureCmdLocked(
 	sess.Paused = false
 	sess.PausedByCap = false
 	if !append {
-		sess.LastServedSeq = -1
+		// Sequence numbers can start above zero after seeks. Track the sequence
+		// immediately before this slice so buffer depth counts segments, not IDs.
+		sess.LastServedSeq = startSeq - 1
 	}
 	sess.Finished = false
 

--- a/services/server/src/stream/hls/monitor.go
+++ b/services/server/src/stream/hls/monitor.go
@@ -17,6 +17,16 @@ const (
 	playlistDemandNudgeMinGap = 2 * time.Second
 )
 
+func isRemoteHTTPSource(source string) bool {
+	isHTTPSource := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
+	return isHTTPSource && !isTorrentSource(source)
+}
+
+func throttleAllowsWork(now time.Time) bool {
+	phase := time.Duration(now.UnixNano()) % throttleCycleWindow
+	return phase < throttleActivePortion
+}
+
 func (c *Controller) monitorBuffer(id string, ctx context.Context) {
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
@@ -39,11 +49,7 @@ func (c *Controller) monitorBuffer(id string, ctx context.Context) {
 }
 
 func (c *Controller) adjustThrottleLocked(sess *Session) {
-	isHTTPSource := false
-	if sess != nil {
-		src := sess.Source
-		isHTTPSource = strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://")
-	}
+	isRemoteHTTP := sess != nil && isRemoteHTTPSource(sess.Source)
 
 	mediaSeq, segCount, err := readPlaylistState(filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", sess.SliceIndex), "child.m3u8"))
 	if err != nil || segCount == 0 {
@@ -61,18 +67,16 @@ func (c *Controller) adjustThrottleLocked(sess *Session) {
 	aheadDuration := time.Duration(aheadSegments) * DefaultSegmentDuration
 
 	if !sess.DemandResumeUntil.IsZero() && time.Now().Before(sess.DemandResumeUntil) {
-		if aheadDuration < MaxBufferAhead {
-			if sess.Paused && sess.PausedByCap {
-				sess.PausedByCap = false
-				resumeProcessPlatform(sess, c, sess.ID, sess.Source)
-			}
-			return
+		if sess.Paused && sess.PausedByCap {
+			sess.PausedByCap = false
+			resumeProcessPlatform(sess, c, sess.ID, sess.Source)
 		}
+		return
 	}
 
 	switch {
 	case aheadDuration >= MaxBufferAhead && !sess.Paused:
-		if !isHTTPSource {
+		if !isRemoteHTTP {
 			sess.PausedByCap = true
 			pauseProcess(sess)
 		}
@@ -82,16 +86,12 @@ func (c *Controller) adjustThrottleLocked(sess *Session) {
 	}
 
 	if aheadDuration >= MaxBufferAhead {
-		// Local files are already fully paused above; only HTTP sources need the
-		// duty-cycle approach to keep the remote connection alive.
-		if !isHTTPSource {
+		// Local files and loopback torrent sources are already fully paused above;
+		// only remote HTTP sources need duty cycling to keep their connection alive.
+		if !isRemoteHTTP {
 			return
 		}
-		now := time.Now()
-		phase := time.Duration(now.UnixNano()) % throttleCycleWindow
-		allowWork := phase < (20 * time.Millisecond)
-
-		if allowWork {
+		if throttleAllowsWork(time.Now()) {
 			if sess.Paused {
 				sess.PausedByCap = false
 				resumeProcessPlatform(sess, c, sess.ID, sess.Source)
@@ -129,11 +129,7 @@ func (c *Controller) adjustThrottleLocked(sess *Session) {
 		return
 	}
 
-	now := time.Now()
-	phase := time.Duration(now.UnixNano()) % throttleCycleWindow
-	allowWork := phase < throttleActivePortion
-
-	if allowWork {
+	if throttleAllowsWork(time.Now()) {
 		if sess.Paused && sess.PausedByCap {
 			sess.PausedByCap = false
 			resumeProcessPlatform(sess, c, sess.ID, sess.Source)

--- a/services/server/src/stream/hls/monitor.go
+++ b/services/server/src/stream/hls/monitor.go
@@ -4,31 +4,27 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
 const (
-	throttleCycleWindow       = time.Second
-	throttleActivePortion     = 600 * time.Millisecond // ~60% active
-	throttleMinAheadToEngage  = 12 * time.Second
+	bufferMonitorInterval     = 100 * time.Millisecond
 	clientDemandResumeGrace   = 4 * time.Second
 	playlistDemandResumeGrace = 1200 * time.Millisecond
 	playlistDemandNudgeMinGap = 2 * time.Second
 )
 
-func isRemoteHTTPSource(source string) bool {
-	isHTTPSource := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
-	return isHTTPSource && !isTorrentSource(source)
-}
-
-func throttleAllowsWork(now time.Time) bool {
-	phase := time.Duration(now.UnixNano()) % throttleCycleWindow
-	return phase < throttleActivePortion
+func bufferedAheadDuration(mediaSeq, segCount, lastServedSeq int) time.Duration {
+	if segCount <= 0 {
+		return 0
+	}
+	highest := mediaSeq + segCount - 1
+	aheadSegments := max(highest-lastServedSeq, 0)
+	return time.Duration(aheadSegments) * DefaultSegmentDuration
 }
 
 func (c *Controller) monitorBuffer(id string, ctx context.Context) {
-	ticker := time.NewTicker(250 * time.Millisecond)
+	ticker := time.NewTicker(bufferMonitorInterval)
 	defer ticker.Stop()
 
 	for {
@@ -49,8 +45,6 @@ func (c *Controller) monitorBuffer(id string, ctx context.Context) {
 }
 
 func (c *Controller) adjustThrottleLocked(sess *Session) {
-	isRemoteHTTP := sess != nil && isRemoteHTTPSource(sess.Source)
-
 	mediaSeq, segCount, err := readPlaylistState(filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", sess.SliceIndex), "child.m3u8"))
 	if err != nil || segCount == 0 {
 		if !sess.DemandResumeUntil.IsZero() && time.Now().Before(sess.DemandResumeUntil) {
@@ -62,43 +56,16 @@ func (c *Controller) adjustThrottleLocked(sess *Session) {
 		return
 	}
 
-	highest := mediaSeq + segCount - 1
-	aheadSegments := max(highest-sess.LastServedSeq, 0)
-	aheadDuration := time.Duration(aheadSegments) * DefaultSegmentDuration
-
-	if !sess.DemandResumeUntil.IsZero() && time.Now().Before(sess.DemandResumeUntil) {
-		if sess.Paused && sess.PausedByCap {
-			sess.PausedByCap = false
-			resumeProcessPlatform(sess, c, sess.ID, sess.Source)
-		}
-		return
+	aheadDuration := bufferedAheadDuration(mediaSeq, segCount, sess.LastServedSeq)
+	bufferLimit := sess.BufferAheadLimit
+	if bufferLimit <= 0 {
+		bufferLimit = MaxBufferAhead
 	}
+	resumeAhead := max(bufferLimit-2*DefaultSegmentDuration, 0)
+	now := time.Now()
+	hasDemand := !sess.DemandResumeUntil.IsZero() && now.Before(sess.DemandResumeUntil)
 
-	switch {
-	case aheadDuration >= MaxBufferAhead && !sess.Paused:
-		if !isRemoteHTTP {
-			sess.PausedByCap = true
-			pauseProcess(sess)
-		}
-	case aheadDuration <= MaxBufferAhead/2 && sess.Paused:
-		sess.PausedByCap = false
-		resumeProcessPlatform(sess, c, sess.ID, sess.Source)
-	}
-
-	if aheadDuration >= MaxBufferAhead {
-		// Local files and loopback torrent sources are already fully paused above;
-		// only remote HTTP sources need duty cycling to keep their connection alive.
-		if !isRemoteHTTP {
-			return
-		}
-		if throttleAllowsWork(time.Now()) {
-			if sess.Paused {
-				sess.PausedByCap = false
-				resumeProcessPlatform(sess, c, sess.ID, sess.Source)
-			}
-			return
-		}
-
+	if aheadDuration >= bufferLimit {
 		if !sess.Paused {
 			sess.PausedByCap = true
 			pauseProcess(sess)
@@ -106,40 +73,11 @@ func (c *Controller) adjustThrottleLocked(sess *Session) {
 		return
 	}
 
-	if aheadDuration <= MaxBufferAhead/2 {
-		return
-	}
-
-	// First startup buffer should run uncapped for fastest time-to-first-frame.
-	// We only cap after playback has started serving at least one segment.
-	if sess.LastServedSeq < 0 {
+	if hasDemand || aheadDuration <= resumeAhead {
 		if sess.Paused && sess.PausedByCap {
 			sess.PausedByCap = false
 			resumeProcessPlatform(sess, c, sess.ID, sess.Source)
 		}
-		return
-	}
-
-	// Don't cap when the ahead buffer is still shallow to avoid rebuffer risk.
-	if aheadDuration < throttleMinAheadToEngage {
-		if sess.Paused && sess.PausedByCap {
-			sess.PausedByCap = false
-			resumeProcessPlatform(sess, c, sess.ID, sess.Source)
-		}
-		return
-	}
-
-	if throttleAllowsWork(time.Now()) {
-		if sess.Paused && sess.PausedByCap {
-			sess.PausedByCap = false
-			resumeProcessPlatform(sess, c, sess.ID, sess.Source)
-		}
-		return
-	}
-
-	if !sess.Paused {
-		sess.PausedByCap = true
-		pauseProcess(sess)
 	}
 }
 
@@ -190,6 +128,13 @@ func (c *Controller) NotifyClientPlaylistRequest(id string) {
 
 	sess := c.sessions[id]
 	if sess == nil {
+		return
+	}
+
+	// Polling an already usable playlist is not demand for more media. Without
+	// this guard, normal HLS polling continuously wakes a saturated transcoder.
+	manifestPath := filepath.Join(sess.WorkDir, fmt.Sprintf("slice_%03d", sess.SliceIndex), "child.m3u8")
+	if _, segCount, err := readPlaylistState(manifestPath); err == nil && segCount > 0 {
 		return
 	}
 

--- a/services/server/src/stream/hls/playlist.go
+++ b/services/server/src/stream/hls/playlist.go
@@ -55,6 +55,15 @@ func readPlaylistTimeline(path string, sliceStart float64) (int, []PlaylistSegme
 	return readPlaylistTimelineFromReader(f, sliceStart)
 }
 
+func playlistResumePoint(path string, sliceStart float64) (resumeTime float64, nextSequence int, ok bool) {
+	mediaSequence, timeline, err := readPlaylistTimeline(path, sliceStart)
+	if err != nil || len(timeline) == 0 {
+		return 0, 0, false
+	}
+	lastSegment := timeline[len(timeline)-1]
+	return lastSegment.End, mediaSequence + len(timeline), true
+}
+
 func readPlaylistTimelineFromReader(r io.Reader, sliceStart float64) (int, []PlaylistSegment, error) {
 	scanner := bufio.NewScanner(r)
 	mediaSeq := 0

--- a/services/server/src/stream/hls/playlist.go
+++ b/services/server/src/stream/hls/playlist.go
@@ -2,6 +2,7 @@ package hls
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -127,36 +128,30 @@ func readPlaylistTimelineFromReader(r io.Reader, sliceStart float64) (int, []Pla
 	return mediaSeq, segments, nil
 }
 
-func waitForManifestReady(manifestPath string, timeout time.Duration, shouldAbort func() bool) error {
-	deadline := time.Now().Add(timeout)
+func waitForManifestReady(ctx context.Context, manifestPath string, shouldAbort func() bool) error {
+	return waitForManifestSegments(ctx, manifestPath, shouldAbort, 1)
+}
+
+func waitForManifestSegments(ctx context.Context, manifestPath string, shouldAbort func() bool, minSegments int) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
-		if shouldAbort != nil && shouldAbort() {
-			return fmt.Errorf("transcoder exited before manifest was ready: %s", manifestPath)
-		}
 		if _, err := os.Stat(manifestPath); err == nil {
-			break
+			_, segCount, readErr := readPlaylistState(manifestPath)
+			if readErr == nil && segCount >= minSegments {
+				return nil
+			}
 		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for manifest: %s", manifestPath)
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	// best-effort: wait for at least 2 segments to ensure smooth start
-	for {
 		if shouldAbort != nil && shouldAbort() {
-			return fmt.Errorf("transcoder exited before manifest had segments: %s", manifestPath)
+			return fmt.Errorf("transcoder exited before manifest had usable segments: %s", manifestPath)
 		}
-		_, segCount, err := readPlaylistState(manifestPath)
-		if err == nil && segCount >= 2 {
-			return nil
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
 		}
-		if time.Now().After(deadline) {
-			fmt.Printf("warning: manifest %s has few segments yet, continuing\n", manifestPath)
-			return nil
-		}
-		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/services/server/src/stream/hls/recovery_test.go
+++ b/services/server/src/stream/hls/recovery_test.go
@@ -1,0 +1,74 @@
+package hls
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPlaylistResumePoint(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "child.m3u8")
+	manifest := "#EXTM3U\n" +
+		"#EXT-X-MEDIA-SEQUENCE:7\n" +
+		"#EXTINF:6.0,\nsegment00007.ts\n" +
+		"#EXTINF:5.5,\nsegment00008.ts\n"
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resumeTime, nextSequence, ok := playlistResumePoint(manifestPath, 100)
+	if !ok {
+		t.Fatal("expected a resume point")
+	}
+	if resumeTime != 111.5 {
+		t.Fatalf("resume time = %v, want 111.5", resumeTime)
+	}
+	if nextSequence != 9 {
+		t.Fatalf("next sequence = %d, want 9", nextSequence)
+	}
+}
+
+func TestThrottleUsesConfiguredActivePortion(t *testing.T) {
+	base := time.Unix(0, 0)
+	if !throttleAllowsWork(base.Add(throttleActivePortion - time.Millisecond)) {
+		t.Fatal("expected work inside the active throttle window")
+	}
+	if throttleAllowsWork(base.Add(throttleActivePortion)) {
+		t.Fatal("expected throttling after the active window")
+	}
+}
+
+func TestPlaylistResumePointRequiresSegments(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "child.m3u8")
+	if err := os.WriteFile(manifestPath, []byte("#EXTM3U\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, ok := playlistResumePoint(manifestPath, 0); ok {
+		t.Fatal("empty playlist should not produce a resume point")
+	}
+}
+
+func TestRemoteHTTPSourceExcludesTorrentLoopback(t *testing.T) {
+	tests := []struct {
+		source string
+		want   bool
+	}{
+		{source: "https://example.com/video.mkv", want: true},
+		{source: "http://127.0.0.1:6969/torrents/abc123", want: false},
+		{source: `C:\\Videos\\movie.mkv`, want: false},
+	}
+
+	for _, test := range tests {
+		if got := isRemoteHTTPSource(test.source); got != test.want {
+			t.Errorf("isRemoteHTTPSource(%q) = %v, want %v", test.source, got, test.want)
+		}
+	}
+}
+
+func TestRemoteHTTPSourceRecognizesDebridURL(t *testing.T) {
+	if !isRemoteHTTPSource("https://download.example-debrid.test/path/movie.mkv?token=abc") {
+		t.Fatal("expected a debrid HTTPS URL to use remote HTTP throttling")
+	}
+}

--- a/services/server/src/stream/hls/recovery_test.go
+++ b/services/server/src/stream/hls/recovery_test.go
@@ -1,6 +1,8 @@
 package hls
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,16 +31,6 @@ func TestPlaylistResumePoint(t *testing.T) {
 	}
 }
 
-func TestThrottleUsesConfiguredActivePortion(t *testing.T) {
-	base := time.Unix(0, 0)
-	if !throttleAllowsWork(base.Add(throttleActivePortion - time.Millisecond)) {
-		t.Fatal("expected work inside the active throttle window")
-	}
-	if throttleAllowsWork(base.Add(throttleActivePortion)) {
-		t.Fatal("expected throttling after the active window")
-	}
-}
-
 func TestPlaylistResumePointRequiresSegments(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "child.m3u8")
 	if err := os.WriteFile(manifestPath, []byte("#EXTM3U\n"), 0o600); err != nil {
@@ -50,25 +42,70 @@ func TestPlaylistResumePointRequiresSegments(t *testing.T) {
 	}
 }
 
-func TestRemoteHTTPSourceExcludesTorrentLoopback(t *testing.T) {
-	tests := []struct {
-		source string
-		want   bool
-	}{
-		{source: "https://example.com/video.mkv", want: true},
-		{source: "http://127.0.0.1:6969/torrents/abc123", want: false},
-		{source: `C:\\Videos\\movie.mkv`, want: false},
+func TestBufferedAheadDurationUsesSequenceBaseline(t *testing.T) {
+	if got := bufferedAheadDuration(15, 1, 14); got != DefaultSegmentDuration {
+		t.Fatalf("one segment at a non-zero sequence = %v, want %v", got, DefaultSegmentDuration)
 	}
-
-	for _, test := range tests {
-		if got := isRemoteHTTPSource(test.source); got != test.want {
-			t.Errorf("isRemoteHTTPSource(%q) = %v, want %v", test.source, got, test.want)
-		}
+	if got := bufferedAheadDuration(15, 15, 14); got != MaxBufferAhead {
+		t.Fatalf("full buffer at a non-zero sequence = %v, want %v", got, MaxBufferAhead)
 	}
 }
 
-func TestRemoteHTTPSourceRecognizesDebridURL(t *testing.T) {
-	if !isRemoteHTTPSource("https://download.example-debrid.test/path/movie.mkv?token=abc") {
-		t.Fatal("expected a debrid HTTPS URL to use remote HTTP throttling")
+func TestControllerBufferAheadLimitDefaultsAndOverrides(t *testing.T) {
+	controller := &Controller{
+		sessions:     make(map[string]*Session),
+		bufferLimits: make(map[string]time.Duration),
+	}
+	if got := controller.bufferAheadLimitLocked("prefetch"); got != MaxBufferAhead {
+		t.Fatalf("default buffer limit = %v, want %v", got, MaxBufferAhead)
+	}
+	controller.SetBufferAheadLimit("prefetch", PrefetchBufferAhead)
+	if got := controller.bufferAheadLimitLocked("prefetch"); got != PrefetchBufferAhead {
+		t.Fatalf("prefetch buffer limit = %v, want %v", got, PrefetchBufferAhead)
+	}
+	controller.SetBufferAheadLimit("prefetch", MaxBufferAhead)
+	if got := controller.bufferAheadLimitLocked("prefetch"); got != MaxBufferAhead {
+		t.Fatalf("promoted buffer limit = %v, want %v", got, MaxBufferAhead)
+	}
+}
+
+func TestWaitForManifestSegmentsAllowsSeekAfterFirstSegment(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "child.m3u8")
+	manifest := "#EXTM3U\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:6.0,\nsegment00000.ts\n"
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := waitForManifestSegments(context.Background(), manifestPath, nil, 1); err != nil {
+		t.Fatalf("seek manifest should be ready after its first segment: %v", err)
+	}
+}
+
+func TestWaitForManifestSegmentsWaitsForPlaylistCreation(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "child.m3u8")
+	written := make(chan error, 1)
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		manifest := "#EXTM3U\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:6.0,\nsegment00000.ts\n"
+		written <- os.WriteFile(manifestPath, []byte(manifest), 0o600)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := waitForManifestSegments(ctx, manifestPath, nil, 1); err != nil {
+		t.Fatalf("manifest wait returned before playlist creation: %v", err)
+	}
+	if err := <-written; err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func TestWaitForManifestSegmentsStopsWhenRequestIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitForManifestSegments(ctx, filepath.Join(t.TempDir(), "missing.m3u8"), nil, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("wait error = %v, want context cancellation", err)
 	}
 }

--- a/services/server/src/stream/hls/session.go
+++ b/services/server/src/stream/hls/session.go
@@ -27,6 +27,7 @@ type Session struct {
 	LastServedSeq     int
 	Paused            bool
 	PausedByCap       bool
+	BufferAheadLimit  time.Duration
 	DemandResumeUntil time.Time
 	LastPlaylistNudge time.Time
 

--- a/services/server/src/stream/hls/transcoder.go
+++ b/services/server/src/stream/hls/transcoder.go
@@ -91,8 +91,11 @@ func NewTranscoder(ffmpegPath string) TranscoderFunc {
 		}
 
 		args := []string{
+			"-hide_banner",
+			"-loglevel", "error",
+			"-nostats",
 			"-hwaccel", "auto",
-			"-fflags", "+genpts+nofillin",
+			"-fflags", "+genpts",
 			"-probesize", "1000000",
 			"-analyzeduration", "1000000",
 		}
@@ -124,7 +127,6 @@ func NewTranscoder(ffmpegPath string) TranscoderFunc {
 		args = append(args, "-c:v", videoCodec)
 		if videoCodec == "copy" {
 			args = append(args,
-				"-copytb", "1",
 				"-bsf:v", "h264_mp4toannexb",
 			)
 		}

--- a/services/server/src/stream/torrent.go
+++ b/services/server/src/stream/torrent.go
@@ -22,7 +22,10 @@ type TorrentStreamer struct {
 	mu      sync.RWMutex
 	streams map[string]*TorrentStream
 	dataDir string
+	enabled bool
 }
+
+var ErrTorrentingDisabled = errors.New("torrenting is disabled")
 
 type TorrentStream struct {
 	t        *torrent.Torrent
@@ -317,18 +320,31 @@ func (ts *TorrentStream) prepare() error {
 }
 
 func NewTorrentStreamer(dataDir string) *TorrentStreamer {
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
-		log.Fatalf("failed to create torrent data dir: %v", err)
+	return &TorrentStreamer{
+		streams: make(map[string]*TorrentStream),
+		dataDir: dataDir,
+	}
+}
+
+func (s *TorrentStreamer) Enable() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.enabled && s.client != nil {
+		return nil
+	}
+
+	if err := os.MkdirAll(s.dataDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create torrent data dir: %w", err)
 	}
 
 	cfg := torrent.NewDefaultClientConfig()
-	cfg.DataDir = dataDir
+	cfg.DataDir = s.dataDir
 
-	pc, err := storage.NewDefaultPieceCompletionForDir(dataDir)
+	pc, err := storage.NewDefaultPieceCompletionForDir(s.dataDir)
 	if err != nil {
-		log.Fatalf("piece completion init failed: %v", err)
+		return fmt.Errorf("piece completion init failed: %w", err)
 	}
-	cfg.DefaultStorage = storage.NewFileWithCompletion(dataDir, pc)
+	cfg.DefaultStorage = storage.NewFileWithCompletion(s.dataDir, pc)
 
 	cfg.NoUpload = false
 	cfg.Debug = false
@@ -342,17 +358,56 @@ func NewTorrentStreamer(dataDir string) *TorrentStreamer {
 
 	c, err := torrent.NewClient(cfg)
 	if err != nil {
-		log.Fatalf("error creating torrent client: %s", err)
+		return fmt.Errorf("error creating torrent client: %w", err)
 	}
 
-	return &TorrentStreamer{
-		client:  c,
-		streams: make(map[string]*TorrentStream),
-		dataDir: dataDir,
+	s.client = c
+	s.enabled = true
+	log.Printf("Torrenting enabled")
+	return nil
+}
+
+func (s *TorrentStreamer) Disable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	client := s.client
+	streams := s.streams
+	s.client = nil
+	s.enabled = false
+	s.streams = make(map[string]*TorrentStream)
+
+	for infoHash, torrentStream := range streams {
+		if torrentStream == nil {
+			continue
+		}
+		torrentStream.stop()
+		if torrentStream.t != nil {
+			log.Printf("Dropping torrent %s", infoHash)
+			torrentStream.t.Drop()
+		}
 	}
+	if client != nil {
+		client.Close()
+	}
+	if err := os.RemoveAll(s.dataDir); err != nil {
+		log.Printf("Warning: failed to remove torrent data while disabling: %v", err)
+	}
+	log.Printf("Torrenting disabled")
+}
+
+func (s *TorrentStreamer) IsEnabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.enabled && s.client != nil
 }
 
 func (s *TorrentStreamer) AddTorrent(magnetOrInfoHash string, fileIdx *int) (string, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.enabled || s.client == nil {
+		return "", "", ErrTorrentingDisabled
+	}
+
 	var (
 		t   *torrent.Torrent
 		err error
@@ -371,9 +426,7 @@ func (s *TorrentStreamer) AddTorrent(magnetOrInfoHash string, fileIdx *int) (str
 
 	// Store stream immediately so session creation doesn't block on metadata.
 	stream := newTorrentStream(t, fileIdx)
-	s.mu.Lock()
 	s.streams[infoHash] = stream
-	s.mu.Unlock()
 
 	// Kick off metadata + file selection in the background.
 	go func() {
@@ -386,6 +439,10 @@ func (s *TorrentStreamer) AddTorrent(magnetOrInfoHash string, fileIdx *int) (str
 }
 
 func (s *TorrentStreamer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !s.IsEnabled() {
+		http.Error(w, ErrTorrentingDisabled.Error(), http.StatusForbidden)
+		return
+	}
 	// Path: /torrents/{infohash}
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/torrents/"), "/")
 	if len(parts) == 0 || parts[0] == "" {
@@ -464,5 +521,5 @@ func (s *TorrentStreamer) GetStatus(infoHash string) (TorrentStatus, bool) {
 }
 
 func (s *TorrentStreamer) Close() {
-	s.client.Close()
+	s.Disable()
 }

--- a/services/server/src/stream/torrent.go
+++ b/services/server/src/stream/torrent.go
@@ -177,8 +177,6 @@ func (ts *TorrentStream) prepare() error {
 		// ok
 	case <-ts.stopCh:
 		return errors.New("torrent stream canceled")
-	case <-time.After(90 * time.Second):
-		return fmt.Errorf("timeout waiting for torrent metadata")
 	}
 
 	log.Printf("Got info for torrent %s: %q, length=%d bytes",
@@ -292,10 +290,10 @@ func (ts *TorrentStream) prepare() error {
 		}
 	}(ts.t.InfoHash().HexString())
 
-	// Best-effort short wait for the first piece, but don't block forever
+	// The first media piece is the real readiness signal. Keep waiting while the
+	// torrent is alive instead of advancing because an arbitrary clock expired.
 	log.Printf("Waiting for first piece of torrent %s (piece %d)...",
 		ts.t.InfoHash().HexString(), startPiece)
-	deadline := time.Now().Add(60 * time.Second)
 	for {
 		select {
 		case <-ts.stopCh:
@@ -305,10 +303,6 @@ func (ts *TorrentStream) prepare() error {
 
 		if ts.t.Piece(startPiece).State().Complete {
 			log.Printf("First piece ready, streaming can start")
-			break
-		}
-		if time.Now().After(deadline) {
-			log.Printf("Timeout waiting for first piece, proceeding anyway")
 			break
 		}
 		time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
## Summary

- Add an opt-in “Allow Torrenting” setting that defaults to off.
- Preserve the first-use torrent notice and enable torrenting after explicit acceptance.
- Enforce the setting server-side so disabled torrenting cannot start, index, download, or seed torrents.
- Improve long-running HTTP, debrid, and torrent stream recovery.
- Replace fixed preparation timeouts with producer/error-driven readiness.
- Fix HLS manifest races and invalid FFmpeg timestamp handling.
- Bound FFmpeg processing to a 90-second playback buffer with proper suspend/resume behavior.
- Limit next-episode prefetching to a 12-second startup buffer, then promote it during playback handoff.
- Show an in-player buffering spinner during seeking instead of restarting the full loading flow.
- Reuse buffered HLS slices to make seeking faster.
- Restore reliable next-episode prefetching and immediate prefetched-session handoff.
- Move Next Episode into the top bar and highlight/pin it during outro chapters.
- Match the Back, stream-title, and Next Episode top-bar styling.
- Improve embedded chapter and IntroDB intro/recap/outro detection.
- Surface preparation failures through the Playback Error modal instead of leaving the loading screen active.
- Reduce FFmpeg output noise while retaining actual errors.

## Root causes

Several independent issues were interacting:

- Concurrent playlist requests could read the HLS manifest before its first usable segment existed.
- Fixed timeouts terminated streams that were still actively downloading or transcoding.
- FFmpeg stream-copy timestamp flags could leave the HLS output clock effectively stalled.
- Playlist polling and cached segment requests repeatedly woke capped FFmpeg processes.
- Next-episode prefetch sessions were treated like full playback sessions and generated excessive media.
- Buffer depth was calculated incorrectly for non-zero segment sequences after seeking.
- An outer playback-loader catch logged preparation errors without clearing the loading state or opening the error modal.

## Impact

Streams now start as soon as usable frames are available, remain recoverable during long playback sessions, and avoid unnecessary background processing. Seeking and episode transitions are faster and less disruptive, while torrent activity remains explicitly user-controlled.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `bun run build:desktop`
- `git diff --check`